### PR TITLE
Housing機能拡張、NPCシステム改善、職業収入システム無効化

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -41,7 +41,8 @@ public final class TofuNomics extends JavaPlugin {
     // Phase 3 新機能マネージャー
     private JobToolManager jobToolManager;
     private JobExperienceManager jobExperienceManager;
-    private JobIncomeManager jobIncomeManager;
+    // 収入システムは無効化: JobIncomeManager は削除されました
+    // private JobIncomeManager jobIncomeManager;
     private JobQuestManager jobQuestManager;
     private JobLevelRewardManager jobLevelRewardManager;
     private JobStatsManager jobStatsManager;
@@ -324,12 +325,14 @@ public final class TofuNomics extends JavaPlugin {
                 experienceManager
             );
             
-            // JobIncomeManagerの初期化
+            // 収入システムは無効化: JobIncomeManagerの初期化はコメントアウト
+            /*
             jobIncomeManager = new JobIncomeManager(
-                configManager, 
-                playerDAO, 
+                configManager,
+                playerDAO,
                 jobManager
             );
+            */
             
             // JobQuestManagerの初期化
             jobQuestManager = new JobQuestManager(
@@ -469,7 +472,6 @@ public final class TofuNomics extends JavaPlugin {
                     playerJobDAO,
                     jobManager,
                     jobExperienceManager,
-                    jobIncomeManager,
                     jobQuestManager,
                     jobBlockPermissionManager
                 );
@@ -542,9 +544,9 @@ public final class TofuNomics extends JavaPlugin {
                 getServer().getPluginManager().registerEvents(unifiedEventHandler, this);
                 getLogger().info("Phase 5 統合イベントハンドラーを登録しました");
             } else {
-                // フォールバック：既存の個別リスナーを登録
+                // フォールバック：既存の個別リスナーを登録（収入システムは無効化）
                 getServer().getPluginManager().registerEvents(jobExperienceManager, this);
-                getServer().getPluginManager().registerEvents(jobIncomeManager, this);
+                // getServer().getPluginManager().registerEvents(jobIncomeManager, this);  // 収入システムは無効化
                 getServer().getPluginManager().registerEvents(jobQuestManager, this);
                 getLogger().info("既存の個別イベントリスナーを登録しました");
             }

--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -53,7 +53,7 @@ public class UnifiedEventHandler implements Listener {
     
     // 既存のハンドラ参照
     private final org.tofu.tofunomics.experience.JobExperienceManager experienceManager;
-    private final org.tofu.tofunomics.income.JobIncomeManager incomeManager;
+    // 収入システムは無効化: incomeManager は削除されました
     private final org.tofu.tofunomics.quests.JobQuestManager questManager;
     
     // 職業ブロック制限システム
@@ -63,7 +63,6 @@ public class UnifiedEventHandler implements Listener {
                               PlayerDAO playerDAO, PlayerJobDAO playerJobDAO,
                               JobManager jobManager,
                               org.tofu.tofunomics.experience.JobExperienceManager experienceManager,
-                              org.tofu.tofunomics.income.JobIncomeManager incomeManager,
                               org.tofu.tofunomics.quests.JobQuestManager questManager,
                               org.tofu.tofunomics.jobs.JobBlockPermissionManager blockPermissionManager) {
         this.plugin = plugin;
@@ -73,7 +72,7 @@ public class UnifiedEventHandler implements Listener {
         this.jobManager = jobManager;
         this.logger = plugin.getLogger();
         this.experienceManager = experienceManager;
-        this.incomeManager = incomeManager;
+        // 収入システムは無効化: incomeManager は削除されました
         this.questManager = questManager;
         this.blockPermissionManager = blockPermissionManager;
         
@@ -138,9 +137,8 @@ public class UnifiedEventHandler implements Listener {
             return; // 50ms以内の重複イベントは無視
         }
         
-        // 既存のマネージャーに処理を委譲
+        // 既存のマネージャーに処理を委譲（収入システムは無効化）
         experienceManager.onBlockBreak(event);
-        incomeManager.onBlockBreak(event);
         questManager.onBlockBreak(event);
         
         // キャッシュに記録
@@ -216,9 +214,8 @@ public class UnifiedEventHandler implements Listener {
             return;
         }
         
-        // 既存のマネージャーに処理を委譲
+        // 既存のマネージャーに処理を委譲（収入システムは無効化）
         experienceManager.onCraftItem(event);
-        incomeManager.onCraftItem(event);
         questManager.onCraftItem(event);
         
         // キャッシュに記録
@@ -308,9 +305,8 @@ public class UnifiedEventHandler implements Listener {
             return;
         }
         
-        // 既存のマネージャーに処理を委譲
+        // 既存のマネージャーに処理を委譲（収入システムは無効化）
         experienceManager.onPlayerFish(event);
-        incomeManager.onPlayerFish(event);
         questManager.onPlayerFish(event);
         
         // キャッシュに記録
@@ -405,13 +401,11 @@ public class UnifiedEventHandler implements Listener {
                 experienceManager.giveExperienceManual(player, jobName, finalExperience);
             }
             
-            // 収入付与（既存システムを利用）
-            if (finalIncome > 0) {
-                incomeManager.giveIncomeManual(player, jobName, finalIncome);
-                
-                // プレイヤーに通知
-                player.sendMessage(String.format("§7[%s] §e+%.1f経験値 §a+%.2f金塊", 
-                    configManager.getJobDisplayName(jobName), finalExperience, finalIncome));
+            // 収入システムは無効化：収入付与は削除されました
+            // プレイヤーに経験値獲得通知のみ（金塊は表示しない）
+            if (finalExperience > 0) {
+                player.sendMessage(String.format("§7[%s] §e+%.1f経験値",
+                    configManager.getJobDisplayName(jobName), finalExperience));
             }
         }
     }

--- a/src/main/java/org/tofu/tofunomics/events/handlers/BreedingEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/handlers/BreedingEventHandler.java
@@ -114,10 +114,9 @@ public class BreedingEventHandler {
         finalExperience *= bonusMultiplier;
         finalIncome *= bonusMultiplier;
         
-        // 非同期で報酬を付与
+        // 非同期で経験値を付与（収入システムは無効化）
         String playerUUID = player.getUniqueId().toString();
         asyncUpdater.updateJobExperience(playerUUID, "farmer", finalExperience);
-        asyncUpdater.updatePlayerBalance(playerUUID, finalIncome, "動物繁殖報酬");
         
         // メッセージ表示
         displayBreedingResult(player, reward, finalExperience, finalIncome, bonusMultiplier > 1.0);

--- a/src/main/java/org/tofu/tofunomics/events/handlers/BrewingEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/handlers/BrewingEventHandler.java
@@ -146,9 +146,8 @@ public class BrewingEventHandler {
                              double income, int potionCount) {
         String playerUUID = player.getUniqueId().toString();
         
-        // 非同期で経験値と残高を更新
+        // 非同期で経験値を更新（収入システムは無効化）
         asyncUpdater.updateJobExperience(playerUUID, "alchemist", experience);
-        asyncUpdater.updatePlayerBalance(playerUUID, income, "醸造報酬");
         
         // メッセージ表示
         String message = String.format(

--- a/src/main/java/org/tofu/tofunomics/events/handlers/BuildingEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/handlers/BuildingEventHandler.java
@@ -179,10 +179,9 @@ public class BuildingEventHandler {
         finalExperience *= projectBonus;
         finalIncome *= projectBonus;
         
-        // 非同期で報酬を付与
+        // 非同期で経験値を付与（収入システムは無効化）
         String playerUUID = player.getUniqueId().toString();
         asyncUpdater.updateJobExperience(playerUUID, "builder", finalExperience);
-        asyncUpdater.updatePlayerBalance(playerUUID, finalIncome, "建築報酬");
         
         // 建築スキル発動チェック
         checkBuildingSkills(player, builderJob, material, location);

--- a/src/main/java/org/tofu/tofunomics/events/handlers/EnchantmentEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/handlers/EnchantmentEventHandler.java
@@ -66,7 +66,6 @@ public class EnchantmentEventHandler {
         
         // 基本報酬計算
         double baseExperience = expLevelCost * 2.0; // 消費レベル×2の経験値
-        double baseIncome = expLevelCost * 5.0; // 消費レベル×5の金塊
         
         // エンチャント数によるボーナス
         double enchantBonus = enchantments.size() * 1.5;
@@ -76,15 +75,13 @@ public class EnchantmentEventHandler {
         
         // 最終報酬計算
         double totalExperience = (baseExperience + enchantBonus) * levelMultiplier;
-        double totalIncome = (baseIncome + enchantBonus * 2) * levelMultiplier;
         
-        // 非同期で報酬を付与
+        // 非同期で経験値を付与（収入システムは無効化）
         String playerUUID = player.getUniqueId().toString();
         asyncUpdater.updateJobExperience(playerUUID, "wizard", totalExperience);
-        asyncUpdater.updatePlayerBalance(playerUUID, totalIncome, "エンチャント報酬");
         
         // メッセージ表示
-        displayEnchantmentResult(player, item, enchantments.size(), totalExperience, totalIncome);
+        displayEnchantmentResult(player, item, enchantments.size(), totalExperience);
     }
     
     /**
@@ -197,7 +194,7 @@ public class EnchantmentEventHandler {
      * エンチャント結果を表示
      */
     private void displayEnchantmentResult(Player player, ItemStack item, int enchantCount,
-                                         double experience, double income) {
+                                         double experience) {
         String itemName = item.getType().name().toLowerCase().replace("_", " ");
         
         player.sendMessage(ChatColor.LIGHT_PURPLE + "═══════════════════════════");
@@ -205,7 +202,6 @@ public class EnchantmentEventHandler {
         player.sendMessage(ChatColor.YELLOW + "アイテム: " + ChatColor.WHITE + itemName);
         player.sendMessage(ChatColor.YELLOW + "付与効果数: " + ChatColor.WHITE + enchantCount);
         player.sendMessage(ChatColor.GREEN + "獲得経験値: +" + String.format("%.1f", experience));
-        player.sendMessage(ChatColor.GOLD + "獲得金塊: +" + String.format("%.1f", income));
         player.sendMessage(ChatColor.LIGHT_PURPLE + "═══════════════════════════");
     }
     

--- a/src/main/java/org/tofu/tofunomics/events/handlers/GrowthEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/handlers/GrowthEventHandler.java
@@ -138,26 +138,22 @@ public class GrowthEventHandler {
         double levelMultiplier = 1.0 + (farmerJob.getLevel() * 0.02); // レベル毎に2%ボーナス
         
         double finalExperience = reward.getExperience() * levelMultiplier;
-        double finalIncome = reward.getIncome() * levelMultiplier;
         
         // 環境ボーナスをチェック
         double bonusMultiplier = checkEnvironmentalBonuses(player, location);
         finalExperience *= bonusMultiplier;
-        finalIncome *= bonusMultiplier;
         
-        // 非同期で報酬を付与
+        // 非同期で経験値を付与（収入システムは無効化）
         String playerUUID = player.getUniqueId().toString();
         asyncUpdater.updateJobExperience(playerUUID, "farmer", finalExperience);
-        asyncUpdater.updatePlayerBalance(playerUUID, finalIncome, "作物成長報酬");
         
         // メッセージ表示（頻繁になりすぎないように制限）
         if (Math.random() < 0.3) { // 30%の確率で表示
             String message = String.format(
-                "%s%sが成長しました！ §a+%.1f経験値 §6+%.1f金塊",
+                "%s%sが成長しました！ §a+%.1f経験値",
                 ChatColor.GREEN,
                 reward.getDisplayName(),
-                finalExperience,
-                finalIncome
+                finalExperience
             );
             player.sendMessage(message);
         }
@@ -212,13 +208,16 @@ public class GrowthEventHandler {
             player.sendMessage(ChatColor.GOLD + "✦ 連鎖成長！周囲の作物も成長しました！");
         }
         
-        // レベル35以上：豊作の恵み
+        // レベル35以上：豊作の恵み（収入システムは無効化）
+        // 以下のコードはコメントアウト
+        /*
         if (level >= 35 && Math.random() < 0.1) { // 10%の確率
             // 追加報酬を付与
             asyncUpdater.updatePlayerBalance(player.getUniqueId().toString(), 
                                            reward.getIncome() * 0.5, "豊作ボーナス");
             player.sendMessage(ChatColor.GOLD + "✦ 豊作の恵み！追加収入を獲得しました！");
         }
+        */
         
         // レベル50以上：生命の祝福
         if (level >= 50 && Math.random() < 0.05) { // 5%の確率

--- a/src/main/java/org/tofu/tofunomics/income/JobIncomeManager.java
+++ b/src/main/java/org/tofu/tofunomics/income/JobIncomeManager.java
@@ -121,6 +121,8 @@ public class JobIncomeManager implements Listener {
         jobIncomeMap.put("architect", architectIncome);
     }
     
+    // 収入システム無効化: 以下のイベントハンドラーをコメントアウト
+    /*
     @EventHandler
     public void onBlockBreak(BlockBreakEvent event) {
         org.bukkit.entity.Player player = event.getPlayer();
@@ -131,7 +133,9 @@ public class JobIncomeManager implements Listener {
         checkAndGiveIncome(player, "woodcutter", blockType);
         checkAndGiveIncome(player, "farmer", blockType);
     }
+    */
     
+    /*
     @EventHandler
     public void onPlayerFish(PlayerFishEvent event) {
         if (event.getState() != PlayerFishEvent.State.CAUGHT_FISH) return;
@@ -142,7 +146,9 @@ public class JobIncomeManager implements Listener {
             checkAndGiveIncome(player, "fisherman", caughtItem.getType());
         }
     }
+    */
     
+    /*
     @EventHandler
     public void onCraftItem(CraftItemEvent event) {
         if (!(event.getWhoClicked() instanceof org.bukkit.entity.Player)) return;
@@ -154,6 +160,7 @@ public class JobIncomeManager implements Listener {
         checkAndGiveIncome(player, "blacksmith", craftedType);
         checkAndGiveIncome(player, "alchemist", craftedType);
     }
+    */
     
     /**
      * 職業別収入の計算と付与


### PR DESCRIPTION
## 概要
Housing機能の拡張、NPCシステムの改善、および職業収入システムの無効化を実装しました。

## 主な変更内容

### 1. Housing機能拡張とNPCシステム改善
- Housing機能の拡張実装
- NPCシステムの全体的な改善

### 2. NPC関連のバグ修正
- **NPC重複スポーン問題を修正**: 同じNPCが複数回スポーンする問題を解決
- **コマンド生成NPCのカスタムGUI未表示問題を修正**: カスタムGUIが正しく表示されるように修正
- **既存NPCの再登録機能を追加**: `/npc reload`コマンドで既存NPCを再登録できるように改善

### 3. 職業収入システムの無効化
職業活動時に自動的に金塊が付与されるシステムを完全に無効化しました。
経験値システムは従来通り動作します。

#### 無効化した機能
- 採掘時の自動収入付与
- 釣り時の自動収入付与
- クラフト時の自動収入付与
- 作物成長時の自動収入付与
- 動物繁殖時の自動収入付与
- 醸造時の自動収入付与
- 建築時の自動収入付与
- エンチャント時の自動収入付与

#### 変更ファイル（職業収入システム無効化）
- `JobIncomeManager.java`: 全イベントハンドラーをコメントアウト
- `EnchantmentEventHandler.java`: 収入計算と支払いを削除
- `GrowthEventHandler.java`: 収入計算と支払いを削除
- `BreedingEventHandler.java`: 収入支払いを削除
- `BrewingEventHandler.java`: 収入支払いを削除
- `BuildingEventHandler.java`: 収入支払いを削除
- `UnifiedEventHandler.java`: jobIncomeManager関連コードを削除
- `TofuNomics.java`: jobIncomeManager初期化をコメントアウト

## 影響範囲
- プレイヤーは職業活動から金塊を獲得しなくなる
- 「XXG獲得」などの収入メッセージは表示されなくなる
- 経験値システムは影響を受けず、従来通り動作する
- NPCシステムの安定性が向上

## テスト計画
- [ ] Housing機能の動作確認
- [ ] NPC生成・再登録の動作確認
- [ ] 職業活動時に収入が付与されないことを確認
- [ ] 職業活動時に経験値が正常に付与されることを確認
- [ ] NPCの重複スポーンが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)