### PR TITLE
feat: ワールド制限 + NPC取引アイテム網羅拡充ほか（バンドル）

### DIFF
--- a/scripts/bulk_update_trading_items.py
+++ b/scripts/bulk_update_trading_items.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+trading_posts の items リストを職業別に一括拡充するスクリプト
+
+【目的】
+  server_config.yml（サーバーからdownloadしたconfig.yml）の各取引所NPCの
+  `items` リストに、職業ごとの売却対象アイテムを安全に追加する。
+
+【安全設計】
+  - items の「追加」のみ。既存アイテムは保持（重複は追加しない）。
+  - 以下は一切読み書きしない＝保護される:
+      x / y / z / id / name / description / accepted_jobs / purchase_prices
+  - accepted_jobs が ["all"] の取引所（総合取引所）はスキップ。
+  - items が未指定 / [] の取引所はスキップ（= 全アイテム対応のため変更不要）。
+
+【使い方】
+  1. ./scripts/download_config.sh でサーバーのconfig.ymlを取得
+  2. python3 scripts/bulk_update_trading_items.py src/main/resources/server_config.yml
+  3. yamllint で構文チェック
+  4. git diff src/main/resources/server_config.yml で座標行にゼロ差分を確認
+  5. ./scripts/upload_config.sh でアップロード
+  6. /tofunomics reload
+
+  --dry-run を付けると変更内容のみ表示し、ファイルは書き換えない。
+"""
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAMLが必要です: pip install pyyaml")
+
+
+# 職業ごとに items へ追加するアイテム（item_prices に存在するキーのみ）
+JOB_ITEMS = {
+    "miner": [
+        "coal", "coal_ore", "iron_ore", "iron_ingot", "gold_ore", "gold_ingot",
+        "diamond", "diamond_ore", "emerald", "emerald_ore", "redstone",
+        "lapis_lazuli", "copper_ore", "copper_ingot",
+        "deepslate_coal_ore", "deepslate_iron_ore", "deepslate_gold_ore",
+        "deepslate_diamond_ore", "deepslate_emerald_ore", "deepslate_redstone_ore",
+        "deepslate_lapis_ore", "deepslate_copper_ore", "nether_gold_ore",
+        "nether_quartz_ore", "ancient_debris", "netherite_scrap", "netherite_ingot",
+        "raw_iron", "raw_gold", "raw_copper", "quartz", "amethyst_shard",
+    ],
+    "woodcutter": [
+        "oak_log", "birch_log", "spruce_log", "jungle_log", "acacia_log",
+        "dark_oak_log", "mangrove_log", "cherry_log",
+        "oak_planks", "birch_planks", "spruce_planks", "jungle_planks",
+        "acacia_planks", "dark_oak_planks", "mangrove_planks", "cherry_planks",
+        "crimson_planks", "warped_planks", "bamboo_planks", "bamboo", "stick",
+        "stripped_oak_log", "stripped_birch_log", "stripped_spruce_log",
+        "stripped_jungle_log", "stripped_acacia_log", "stripped_dark_oak_log",
+        "stripped_mangrove_log", "stripped_cherry_log",
+        "oak_sapling", "birch_sapling", "spruce_sapling", "jungle_sapling",
+        "acacia_sapling", "dark_oak_sapling", "cherry_sapling", "mangrove_propagule",
+    ],
+    "farmer": [
+        "wheat", "potato", "carrot", "beetroot", "pumpkin", "melon", "sugar_cane",
+        "cocoa_beans", "nether_wart", "beef", "porkchop", "chicken", "mutton",
+        "leather", "milk_bucket", "egg",
+        "melon_slice", "glow_berries", "apple", "wheat_seeds", "beetroot_seeds",
+        "pumpkin_seeds", "melon_seeds", "bone_meal", "bone", "rabbit", "rabbit_hide",
+        "feather", "hay_block", "honeycomb", "honey_bottle", "brown_mushroom",
+        "red_mushroom", "poppy", "dandelion", "blue_orchid", "allium", "cornflower",
+        "sunflower", "wither_rose",
+    ],
+    "fisherman": [
+        "cod", "salmon", "tropical_fish", "pufferfish", "prismarine_shard",
+        "prismarine_crystals", "nautilus_shell", "heart_of_the_sea",
+        "cooked_cod", "cooked_salmon", "kelp", "dried_kelp", "sea_pickle",
+        "seagrass", "ink_sac", "glow_ink_sac", "sponge", "wet_sponge", "turtle_egg",
+        "turtle_scute", "cod_bucket", "tropical_fish_bucket", "lily_pad",
+        "fishing_rod", "name_tag", "saddle",
+    ],
+    "blacksmith": [
+        "iron_ingot", "gold_ingot", "diamond", "netherite_ingot",
+        "iron_pickaxe", "iron_sword", "iron_axe", "iron_shovel", "iron_hoe",
+        "iron_helmet", "iron_chestplate", "iron_leggings", "iron_boots",
+        "diamond_pickaxe", "diamond_sword", "diamond_axe", "diamond_shovel",
+        "diamond_hoe", "diamond_helmet", "diamond_chestplate", "diamond_leggings",
+        "diamond_boots", "chainmail_helmet", "chainmail_chestplate",
+        "chainmail_leggings", "chainmail_boots", "golden_helmet", "golden_chestplate",
+        "golden_leggings", "golden_boots", "golden_sword", "golden_pickaxe",
+        "golden_axe", "golden_shovel", "golden_hoe", "netherite_helmet",
+        "netherite_chestplate", "netherite_leggings", "netherite_boots",
+        "netherite_sword", "netherite_pickaxe", "netherite_axe", "netherite_shovel",
+        "netherite_hoe", "shield", "bow", "crossbow", "flint_and_steel", "shears",
+        "bucket",
+    ],
+    "alchemist": [
+        "blaze_powder", "glowstone_dust", "fermented_spider_eye",
+        "glistering_melon_slice", "magma_cream", "blaze_rod", "ender_pearl",
+        "ghast_tear", "experience_bottle", "spider_eye", "golden_carrot",
+        "rabbit_foot", "phantom_membrane", "nether_wart_block", "sugar",
+        "glass_bottle", "dragon_breath", "turtle_helmet", "gunpowder", "slime_ball",
+        "ender_eye",
+    ],
+    "enchanter": [
+        "experience_bottle", "enchanted_book", "book", "bookshelf", "paper",
+        "writable_book", "lapis_lazuli", "lapis_block", "amethyst_block",
+        "glowstone", "sea_lantern",
+    ],
+    "architect": [
+        "stone_bricks", "smooth_stone", "quartz_block", "polished_blackstone",
+        "bricks", "stone", "cobblestone", "smooth_stone_slab", "chiseled_stone_bricks",
+        "cracked_stone_bricks", "mossy_stone_bricks", "deepslate", "cobbled_deepslate",
+        "polished_deepslate", "deepslate_bricks", "deepslate_tiles", "tuff", "calcite",
+        "dripstone_block", "sandstone", "smooth_sandstone", "red_sandstone",
+        "prismarine", "prismarine_bricks", "dark_prismarine", "purpur_block",
+        "end_stone", "end_stone_bricks", "nether_bricks", "red_nether_bricks",
+        "blackstone", "polished_blackstone_bricks", "gilded_blackstone", "glass",
+        "glass_pane", "terracotta", "white_concrete", "quartz_pillar", "quartz_bricks",
+        "copper_block", "cut_copper", "oxidized_copper",
+    ],
+}
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    dry_run = "--dry-run" in sys.argv
+    if not args:
+        sys.exit("使い方: python3 bulk_update_trading_items.py <server_config.yml> [--dry-run]")
+    path = args[0]
+
+    with open(path, encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    posts = (cfg.get("npc_system", {}) or {}).get("trading_posts")
+    if not posts:
+        sys.exit("trading_posts が見つかりません（パス: npc_system.trading_posts）")
+
+    total_added = 0
+    changed_posts = 0
+    for post in posts:
+        jobs = post.get("accepted_jobs") or []
+        if jobs == ["all"]:
+            continue  # 総合取引所は変更不要
+        items = post.get("items")
+        if items is None or items == []:
+            continue  # 全アイテム対応のため変更不要
+
+        added_here = []
+        for job in jobs:
+            for item in JOB_ITEMS.get(job, []):
+                if item not in items:
+                    items.append(item)
+                    added_here.append(item)
+        if added_here:
+            changed_posts += 1
+            total_added += len(added_here)
+            label = post.get("id") or post.get("name") or "?"
+            print(f"[{label}] ({','.join(jobs)}) +{len(added_here)}件: {', '.join(added_here)}")
+
+    print(f"\n合計: {changed_posts}取引所 / {total_added}件追加")
+
+    if dry_run:
+        print("--dry-run のためファイルは変更しませんでした。")
+        return
+
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(cfg, f, allow_unicode=True, sort_keys=False, default_flow_style=False)
+    print(f"書き込み完了: {path}")
+    print("次の手順: yamllint → git diff で座標ゼロ差分確認 → ./scripts/upload_config.sh")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/merge_config_to_server.py
+++ b/scripts/merge_config_to_server.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+ローカルconfig.ymlの「値ブロック」をサーバーからdownloadしたserver_config.ymlへ
+安全にマージするスクリプト（NPC座標等のサーバー固有設定を保護）。
+
+【マージ対象（すべて追加・更新のみ。サーバー固有設定は保護）】
+  - npc_system.item_prices            : ローカルの全キーを追加（既存値は上書きしない）
+  - npc_system.food_npc.food_items    : 同上
+  - npc_system.processing_npc.wood_types : ローカルの全エントリを追加
+  - npc_system.processing_npc.planks_per_log : ローカル値を設定（未設定時のみ）
+  - npc_system.food_npc.npc_types.{greengrocer,specialty}.items : ローカルのitemsを和集合
+  - npc_system.trading_posts[].items  : 職業別アイテムを追加（bulkロジック）
+
+【保護（読みのみ／一切変更しない）】
+  - 全NPC座標(x/y/z) / id / name / description / accepted_jobs / purchase_prices
+  - food_npc.locations / bank_npcs / その他サーバー固有設定
+
+使い方:
+  python3 scripts/merge_config_to_server.py \
+      src/main/resources/config.yml src/main/resources/server_config.yml [--dry-run]
+"""
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAMLが必要です: pip install pyyaml")
+
+# bulkスクリプトの職業別アイテム定義を再利用
+from bulk_update_trading_items import JOB_ITEMS
+
+
+def get(d, *keys):
+    for k in keys:
+        if not isinstance(d, dict):
+            return None
+        d = d.get(k)
+    return d
+
+
+def merge_dict_additive(target, source):
+    """source のキーを target に追加（既存キーは上書きしない）。追加件数を返す。"""
+    added = 0
+    for k, v in source.items():
+        if k not in target:
+            target[k] = v
+            added += 1
+    return added
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    dry_run = "--dry-run" in sys.argv
+    if len(args) < 2:
+        sys.exit("使い方: merge_config_to_server.py <local config.yml> <server_config.yml> [--dry-run]")
+    local_path, server_path = args[0], args[1]
+
+    local = yaml.safe_load(open(local_path, encoding="utf-8"))
+    server = yaml.safe_load(open(server_path, encoding="utf-8"))
+
+    sns = server.setdefault("npc_system", {})
+    lns = local.get("npc_system", {})
+
+    # --- item_prices ---
+    sip = sns.setdefault("item_prices", {})
+    n = merge_dict_additive(sip, lns.get("item_prices", {}))
+    print(f"item_prices: +{n}件 (合計{len(sip)})")
+
+    # --- food_items ---
+    sfi = sns.setdefault("food_npc", {}).setdefault("food_items", {})
+    n = merge_dict_additive(sfi, get(lns, "food_npc", "food_items") or {})
+    print(f"food_items: +{n}件 (合計{len(sfi)})")
+
+    # --- wood_types ---
+    swt = sns.setdefault("processing_npc", {}).setdefault("wood_types", {})
+    n = merge_dict_additive(swt, get(lns, "processing_npc", "wood_types") or {})
+    print(f"wood_types: +{n}件 (合計{len(swt)})")
+
+    # --- planks_per_log（未設定時のみ設定）---
+    spn = sns["processing_npc"]
+    if "planks_per_log" not in spn:
+        spn["planks_per_log"] = get(lns, "processing_npc", "planks_per_log") or 4
+        print(f"planks_per_log: 設定 {spn['planks_per_log']}")
+    else:
+        print(f"planks_per_log: 既存維持 {spn['planks_per_log']}")
+
+    # --- npc_types greengrocer / specialty の items 和集合 ---
+    s_types = get(sns, "food_npc", "npc_types") or {}
+    l_types = get(lns, "food_npc", "npc_types") or {}
+    for t in ("greengrocer", "specialty"):
+        s_t = s_types.get(t)
+        l_t = l_types.get(t)
+        if not s_t or not l_t:
+            continue
+        s_items = s_t.setdefault("items", [])
+        added = [it for it in l_t.get("items", []) if it not in s_items]
+        s_items.extend(added)
+        print(f"npc_types.{t}.items: +{len(added)}件 {added}")
+
+    # --- trading_posts items（職業別追加）---
+    posts = sns.get("trading_posts") or []
+    total_added, changed = 0, 0
+    for post in posts:
+        jobs = post.get("accepted_jobs") or []
+        if jobs == ["all"]:
+            continue
+        items = post.get("items")
+        if items is None or items == []:
+            continue
+        added_here = 0
+        for job in jobs:
+            for item in JOB_ITEMS.get(job, []):
+                if item not in items:
+                    items.append(item)
+                    added_here += 1
+        if added_here:
+            changed += 1
+            total_added += added_here
+    print(f"trading_posts: {changed}取引所 / +{total_added}件")
+
+    if dry_run:
+        print("\n--dry-run のためファイルは変更しませんでした。")
+        return
+
+    with open(server_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(server, f, allow_unicode=True, sort_keys=False, default_flow_style=False)
+    print(f"\n書き込み完了: {server_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/merge_config_to_server.py
+++ b/scripts/merge_config_to_server.py
@@ -19,7 +19,11 @@
   python3 scripts/merge_config_to_server.py \
       src/main/resources/config.yml src/main/resources/server_config.yml [--dry-run]
 """
+import os
 import sys
+
+# どのカレントディレクトリから実行してもbulkスクリプトをimportできるようにする
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 try:
     import yaml

--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -1312,6 +1312,10 @@ public final class TofuNomics extends JavaPlugin {
             // 既存のオンラインプレイヤーに対してルール同意チェック
             getServer().getScheduler().runTaskLater(this, () -> {
                 for (org.bukkit.entity.Player player : getServer().getOnlinePlayers()) {
+                    // 対象ワールド外（tofunomics系以外）のプレイヤーはルール同意システムの対象外
+                    if (!configManager.isEconomyEnabledInWorld(player.getWorld().getName())) {
+                        continue;
+                    }
                     boolean hasAgreed = rulesManager.hasAgreedToRules(player.getUniqueId());
                     if (!hasAgreed) {
                         getLogger().info("オンラインプレイヤー " + player.getName() + " はルール未同意です");

--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -83,7 +83,9 @@ public final class TofuNomics extends JavaPlugin {
 
     // スコアボードシステム
     private org.tofu.tofunomics.scoreboard.ScoreboardManager scoreboardManager;
-    
+    // 取引営業時間BossBarシステム
+    private org.tofu.tofunomics.scoreboard.BossBarManager bossBarManager;
+
     // NPCシステム（新機能）
     private org.tofu.tofunomics.npc.NPCManager npcManager;
     private org.tofu.tofunomics.npc.BankNPCManager bankNPCManager;
@@ -207,6 +209,11 @@ public final class TofuNomics extends JavaPlugin {
             scoreboardManager.shutdown();
         }
 
+        // BossBarシステムのクリーンアップ
+        if (bossBarManager != null) {
+            bossBarManager.shutdown();
+        }
+
         // NPCシステムのクリーンアップ
         cleanupNPCSystem();
 
@@ -258,7 +265,6 @@ public final class TofuNomics extends JavaPlugin {
             return true;
         } catch (Exception e) {
             getLogger().severe("データベース初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
             return false;
         }
     }
@@ -309,10 +315,9 @@ public final class TofuNomics extends JavaPlugin {
             getLogger().info("マネージャーを初期化しました");
         } catch (Exception e) {
             getLogger().severe("マネージャー初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
-    
+
     private void initializePhase3Managers() {
         try {
             // JobToolManagerの初期化
@@ -364,7 +369,6 @@ public final class TofuNomics extends JavaPlugin {
             getLogger().info("Phase 3 職業特化機能を初期化しました");
         } catch (Exception e) {
             getLogger().severe("Phase 3 マネージャー初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -400,13 +404,10 @@ public final class TofuNomics extends JavaPlugin {
             getLogger().info("Phase 4 取引システムを初期化しました");
         } catch (Exception e) {
             getLogger().severe("Phase 4 取引システム初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
-        
+
         // Phase 6 クラフト制限システムの初期化
         try {
-            getLogger().info("Phase 6 クラフト制限システム初期化開始");
-            
             // JobCraftPermissionManagerの初期化
             jobCraftPermissionManager = new org.tofu.tofunomics.jobs.JobCraftPermissionManager(
                 this,
@@ -415,7 +416,6 @@ public final class TofuNomics extends JavaPlugin {
             );
             
             // クラフト制限メッセージの強制初期化（緊急対応）
-            getLogger().info("クラフト制限メッセージの強制初期化を実行");
             configManager.ensureCraftRestrictionMessagesExist();
             saveConfig(); // 設定を確実に保存
             configManager.reloadConfig(); // リロードで反映
@@ -426,7 +426,6 @@ public final class TofuNomics extends JavaPlugin {
             getLogger().info("Phase 6 クラフト制限システムを初期化しました");
         } catch (Exception e) {
             getLogger().severe("Phase 6 クラフト制限システム初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -435,10 +434,7 @@ public final class TofuNomics extends JavaPlugin {
      */
     private void initializeAutoConfig() {
         try {
-            getLogger().info("=== 設定自動初期化開始 ===");
-            
             // 新しい自動更新機能（バージョン2.0対応）
-            getLogger().info("設定ファイルの自動更新を実行中...");
             configManager.updateConfigWithDefaults();
             
             // NPC関連設定の自動初期化
@@ -452,12 +448,11 @@ public final class TofuNomics extends JavaPlugin {
             
             // 設定を保存
             saveConfig();
-            
-            getLogger().info("=== 設定自動初期化完了 ===");
-            
+
+            getLogger().info("設定の自動初期化が完了しました");
+
         } catch (Exception e) {
             getLogger().severe("設定自動初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -469,7 +464,6 @@ public final class TofuNomics extends JavaPlugin {
             }
             
             // UnifiedEventHandlerの初期化
-            getLogger().info("UnifiedEventHandler初期化開始");
             try {
                 unifiedEventHandler = new org.tofu.tofunomics.events.UnifiedEventHandler(
                     this,
@@ -481,16 +475,13 @@ public final class TofuNomics extends JavaPlugin {
                     jobQuestManager,
                     jobBlockPermissionManager
                 );
-                getLogger().info("UnifiedEventHandler初期化完了");
             } catch (Exception e) {
                 getLogger().severe("UnifiedEventHandler初期化エラー: " + e.getMessage());
-                e.printStackTrace();
             }
-            
+
             getLogger().info("Phase 5 統合イベントシステムを初期化しました");
         } catch (Exception e) {
             getLogger().severe("Phase 5 統合イベントシステム初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -508,7 +499,6 @@ public final class TofuNomics extends JavaPlugin {
                 this,
                 configManager,
                 playerDAO,
-                scoreboardManager,
                 inventoryManager,
                 rulesManager
             );
@@ -516,7 +506,6 @@ public final class TofuNomics extends JavaPlugin {
             getLogger().info("プレイヤー参加時処理を初期化しました");
         } catch (Exception e) {
             getLogger().severe("プレイヤー参加時処理の初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -537,9 +526,17 @@ public final class TofuNomics extends JavaPlugin {
             );
             
             getLogger().info("スコアボードシステムを初期化しました");
+
+            // 職業レベルのバニラ経験値バー反映を即時化するため、JobExperienceManagerに注入
+            if (jobExperienceManager != null) {
+                jobExperienceManager.setScoreboardManager(scoreboardManager);
+            }
+
+            // 取引営業時間BossBarシステムの初期化
+            bossBarManager = new org.tofu.tofunomics.scoreboard.BossBarManager(this, configManager);
+            getLogger().info("取引営業時間BossBarシステムを初期化しました");
         } catch (Exception e) {
             getLogger().severe("スコアボードシステムの初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -580,6 +577,12 @@ public final class TofuNomics extends JavaPlugin {
                 getServer().getPluginManager().registerEvents(scoreboardManager, this);
                 getLogger().info("スコアボードシステムリスナーを登録しました");
             }
+
+            // BossBarマネージャーリスナーの登録
+            if (bossBarManager != null) {
+                getServer().getPluginManager().registerEvents(bossBarManager, this);
+                getLogger().info("BossBarシステムリスナーを登録しました");
+            }
             
             // NPCシステムリスナーの登録
             registerNPCEventListeners();
@@ -605,15 +608,14 @@ public final class TofuNomics extends JavaPlugin {
             // ルール確認システムリスナーの登録
             if (rulesManager != null) {
                 getServer().getPluginManager().registerEvents(rulesManager, this);
-                // RulesGUIは廃止（外部サイトURL方式に変更）
-                // getServer().getPluginManager().registerEvents(rulesManager.getRulesGUI(), this);
+                // ルールGUIのクリック・クローズイベントを登録（同意ボタン等を機能させる）
+                getServer().getPluginManager().registerEvents(rulesManager.getRulesGUI(), this);
                 getLogger().info("ルール確認システムリスナーを登録しました");
             }
 
             getLogger().info("全てのイベントリスナーを登録しました");
         } catch (Exception e) {
             getLogger().severe("イベントリスナー登録中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -697,7 +699,6 @@ public final class TofuNomics extends JavaPlugin {
             getLogger().info("コマンドハンドラーを登録しました");
         } catch (Exception e) {
             getLogger().severe("コマンド登録中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -762,50 +763,39 @@ public final class TofuNomics extends JavaPlugin {
                 return;
             }
             
-            getLogger().info("=== NPCシステム初期化開始 ===");
-            
             // NPCマネージャーの初期化
-            getLogger().info("NPCマネージャー初期化中...");
             npcManager = new org.tofu.tofunomics.npc.NPCManager(this, configManager);
-            getLogger().info("NPCマネージャー初期化完了: " + (npcManager != null ? "成功" : "失敗"));
-            
+
             // GUIの初期化（NPCマネージャーより先に）
-            getLogger().info("BankGUIインスタンス作成開始...");
             bankGUI = new org.tofu.tofunomics.npc.gui.BankGUI(
-                this, 
-                configManager, 
-                currencyConverter, 
+                this,
+                configManager,
+                currencyConverter,
                 itemManager
             );
-            getLogger().info("BankGUIインスタンス作成完了: " + (bankGUI != null ? "成功" : "失敗"));
-            
+
             // 銀行NPCマネージャーの初期化
-            getLogger().info("BankNPCマネージャー初期化中...");
             bankNPCManager = new org.tofu.tofunomics.npc.BankNPCManager(
-                this, 
-                configManager, 
-                npcManager, 
-                bankLocationManager, 
+                this,
+                configManager,
+                npcManager,
+                bankLocationManager,
                 currencyConverter,
                 bankGUI
             );
-            getLogger().info("BankNPCマネージャー初期化完了: " + (bankNPCManager != null ? "成功" : "失敗"));
-            
+
             // 取引NPCマネージャーの初期化
-            getLogger().info("TradingNPCマネージャー初期化中...");
             tradingNPCManager = new org.tofu.tofunomics.npc.TradingNPCManager(
-                this, 
-                configManager, 
-                npcManager, 
-                currencyConverter, 
-                jobManager, 
-                tradePriceManager, 
+                this,
+                configManager,
+                npcManager,
+                currencyConverter,
+                jobManager,
+                tradePriceManager,
                 playerDAO
             );
-            getLogger().info("TradingNPCマネージャー初期化完了: " + (tradingNPCManager != null ? "成功" : "失敗"));
-            
+
             // 食料NPCマネージャーの初期化
-            getLogger().info("FoodNPCマネージャー初期化中...");
             foodNPCManager = new org.tofu.tofunomics.npc.FoodNPCManager(
                 this,
                 configManager,
@@ -813,10 +803,8 @@ public final class TofuNomics extends JavaPlugin {
                 currencyConverter,
                 playerDAO
             );
-            getLogger().info("FoodNPCマネージャー初期化完了: " + (foodNPCManager != null ? "成功" : "失敗"));
-            
+
             // 加工NPCマネージャーの初期化
-            getLogger().info("ProcessingNPCマネージャー初期化中...");
             processingNPCManager = new org.tofu.tofunomics.npc.ProcessingNPCManager(
                 this,
                 configManager,
@@ -824,142 +812,99 @@ public final class TofuNomics extends JavaPlugin {
                 currencyConverter,
                 jobManager
             );
-            getLogger().info("ProcessingNPCマネージャー初期化完了: " + (processingNPCManager != null ? "成功" : "失敗"));
-            
+
             // NPCリスナーの初期化
-            getLogger().info("NPCリスナー初期化中...");
             npcListener = new org.tofu.tofunomics.npc.NPCListener(
-                this, 
-                configManager, 
-                npcManager, 
-                bankNPCManager, 
+                this,
+                configManager,
+                npcManager,
+                bankNPCManager,
                 tradingNPCManager,
                 foodNPCManager,
                 processingNPCManager
             );
-            getLogger().info("NPCリスナー初期化完了: " + (npcListener != null ? "成功" : "失敗"));
-            
-            // ===== 重要: TradingGUIの初期化 =====
-            getLogger().info("=== TradingGUI初期化開始 ===");
-            getLogger().info("依存コンポーネント確認:");
-            getLogger().info("  - ConfigManager: " + (configManager != null ? "OK" : "NULL"));
-            getLogger().info("  - CurrencyConverter: " + (currencyConverter != null ? "OK" : "NULL"));
-            getLogger().info("  - JobManager: " + (jobManager != null ? "OK" : "NULL"));
-            getLogger().info("  - TradingNPCManager: " + (tradingNPCManager != null ? "OK" : "NULL"));
-            getLogger().info("  - TradePriceManager: " + (tradePriceManager != null ? "OK" : "NULL"));
-            
+
+            // TradingGUIの初期化
             try {
                 tradingGUI = new org.tofu.tofunomics.npc.gui.TradingGUI(
-                    this, 
-                    configManager, 
-                    currencyConverter, 
-                    jobManager, 
-                    tradingNPCManager, 
+                    this,
+                    configManager,
+                    currencyConverter,
+                    jobManager,
+                    tradingNPCManager,
                     tradePriceManager
                 );
-                
-                if (tradingGUI != null) {
-                    getLogger().info("✓ TradingGUIインスタンス作成成功！");
-                } else {
-                    getLogger().severe("✗ TradingGUIインスタンスがnullです！");
-                }
             } catch (Exception e) {
-                getLogger().severe("✗ TradingGUI初期化中に例外が発生しました:");
-                getLogger().severe("  エラーメッセージ: " + e.getMessage());
-                getLogger().severe("  エラークラス: " + e.getClass().getName());
-                e.printStackTrace();
+                getLogger().severe("TradingGUIの初期化中にエラーが発生しました: " + e.getMessage());
                 tradingGUI = null;
             }
-            getLogger().info("=== TradingGUI初期化完了 ===");
-            
+
             // TradingModeSelectionGUIの初期化
-            getLogger().info("TradingModeSelectionGUIインスタンス作成開始...");
             try {
                 tradingModeSelectionGUI = new org.tofu.tofunomics.npc.gui.TradingModeSelectionGUI(
                     this,
                     configManager,
                     tradingGUI
                 );
-                getLogger().info("TradingModeSelectionGUIインスタンス作成完了: " + (tradingModeSelectionGUI != null ? "成功" : "失敗"));
             } catch (Exception e) {
-                getLogger().severe("TradingModeSelectionGUI初期化エラー: " + e.getMessage());
-                e.printStackTrace();
+                getLogger().severe("TradingModeSelectionGUIの初期化中にエラーが発生しました: " + e.getMessage());
                 tradingModeSelectionGUI = null;
             }
-            
+
             // FoodGUIの初期化
-            getLogger().info("FoodGUIインスタンス作成開始...");
             try {
                 foodGUI = new org.tofu.tofunomics.npc.gui.FoodGUI(
-                    this, 
-                    configManager, 
-                    currencyConverter, 
+                    this,
+                    configManager,
+                    currencyConverter,
                     foodNPCManager
                 );
-                getLogger().info("FoodGUIインスタンス作成完了: " + (foodGUI != null ? "成功" : "失敗"));
             } catch (Exception e) {
-                getLogger().severe("FoodGUI初期化エラー: " + e.getMessage());
-                e.printStackTrace();
+                getLogger().severe("FoodGUIの初期化中にエラーが発生しました: " + e.getMessage());
                 foodGUI = null;
             }
-            
+
             // QuantitySelectorGUIの初期化
-            getLogger().info("QuantitySelectorGUIインスタンス作成開始...");
             try {
                 quantitySelectorGUI = new org.tofu.tofunomics.npc.gui.QuantitySelectorGUI(this);
-                getLogger().info("QuantitySelectorGUIインスタンス作成完了: " + (quantitySelectorGUI != null ? "成功" : "失敗"));
             } catch (Exception e) {
-                getLogger().severe("QuantitySelectorGUI初期化エラー: " + e.getMessage());
-                e.printStackTrace();
+                getLogger().severe("QuantitySelectorGUIの初期化中にエラーが発生しました: " + e.getMessage());
                 quantitySelectorGUI = null;
             }
-            
+
             // ProcessingGUIの初期化
-            getLogger().info("ProcessingGUIインスタンス作成開始...");
             try {
                 processingGUI = new org.tofu.tofunomics.npc.gui.ProcessingGUI(
-                    this, 
-                    configManager, 
-                    currencyConverter, 
+                    this,
+                    configManager,
+                    currencyConverter,
                     processingNPCManager,
                     jobManager,
                     quantitySelectorGUI
                 );
-                getLogger().info("ProcessingGUIインスタンス作成完了: " + (processingGUI != null ? "成功" : "失敗"));
             } catch (Exception e) {
-                getLogger().severe("ProcessingGUI初期化エラー: " + e.getMessage());
-                e.printStackTrace();
+                getLogger().severe("ProcessingGUIの初期化中にエラーが発生しました: " + e.getMessage());
                 processingGUI = null;
             }
-            
+
             // 既存のシステムNPCを削除（重複防止）
-            getLogger().info("既存システムNPCの削除中...");
             npcManager.removeExistingSystemNPCs();
-            
+
             // エンティティ削除が完全に処理されるまで待機（2秒 = 40 ticks）
-            getLogger().info("エンティティ削除処理の完了を待機中（2秒）...");
             getServer().getScheduler().runTaskLater(this, () -> {
                 // NPCの生成（各マネージャーが個別に生成）
-                getLogger().info("各マネージャーによるNPC生成開始...");
                 bankNPCManager.initializeBankNPCs();
                 tradingNPCManager.initializeTradingNPCs();
                 foodNPCManager.initializeFoodNPCs();
                 processingNPCManager.initializeProcessingNPCs();
-                
-                getLogger().info("=== NPCシステム初期化完了（遅延生成） ===");
+
+                getLogger().info("NPCの生成が完了しました");
             }, 40L);  // 40 ticks = 2秒待機
-            
-            getLogger().info("=== GUI初期化完了 ===");
-            getLogger().info("GUI初期化結果サマリー:");
-            getLogger().info("  - NPCManager: " + (npcManager != null ? "✓" : "✗"));
-            getLogger().info("  - BankGUI: " + (bankGUI != null ? "✓" : "✗"));
-            getLogger().info("  - TradingGUI: " + (tradingGUI != null ? "✓" : "✗"));
-            getLogger().info("  - FoodGUI: " + (foodGUI != null ? "✓" : "✗"));
-            getLogger().info("  - ProcessingGUI: " + (processingGUI != null ? "✓" : "✗"));
-            
+
+            getLogger().info("NPCシステムを初期化しました");
+
         } catch (Exception e) {
             getLogger().severe("NPCシステムの初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -1064,7 +1009,6 @@ public final class TofuNomics extends JavaPlugin {
     }
     
     public org.tofu.tofunomics.npc.gui.TradingGUI getTradingGUI() {
-        getLogger().info("TradingGUIインスタンス取得要求: " + (tradingGUI != null ? "存在" : "null"));
         if (tradingGUI == null) {
             getLogger().warning("TradingGUIがnullです。初期化に問題がある可能性があります。");
         }
@@ -1116,7 +1060,6 @@ public final class TofuNomics extends JavaPlugin {
             getLogger().info("エリアシステムを正常に初期化しました（エリア数: " + areaManager.getAreaCount() + "）");
         } catch (Exception e) {
             getLogger().severe("エリアシステムの初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
 
@@ -1153,7 +1096,7 @@ public final class TofuNomics extends JavaPlugin {
             this.testModeManager = new org.tofu.tofunomics.testing.TestModeManager(this);
             
             // WorldGuardテストモードリスナーの初期化（worldGuardIntegrationとtestModeManager両方が準備できてから）
-            this.worldGuardTestModeListener = new org.tofu.tofunomics.testing.WorldGuardTestModeListener(this, testModeManager, worldGuardIntegration);
+            this.worldGuardTestModeListener = new org.tofu.tofunomics.testing.WorldGuardTestModeListener(this, configManager, testModeManager, worldGuardIntegration);
             
             // HousingRentalManager の初期化
             this.housingRentalManager = new org.tofu.tofunomics.housing.HousingRentalManager(
@@ -1184,7 +1127,6 @@ public final class TofuNomics extends JavaPlugin {
             getLogger().info("住居賃貸システムを正常に初期化しました");
         } catch (Exception e) {
             getLogger().severe("住居賃貸システムの初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -1254,7 +1196,6 @@ public final class TofuNomics extends JavaPlugin {
             getLogger().info("時刻放送システムが初期化されました");
         } catch (Exception e) {
             getLogger().severe("時刻放送システムの初期化に失敗しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -1281,7 +1222,6 @@ public final class TofuNomics extends JavaPlugin {
             getLogger().info("時計アイテムシステムが初期化されました");
         } catch (Exception e) {
             getLogger().severe("時計アイテムシステムの初期化に失敗しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -1332,7 +1272,6 @@ public final class TofuNomics extends JavaPlugin {
             
         } catch (Exception e) {
             getLogger().severe("ルール確認システムの初期化に失敗しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     

--- a/src/main/java/org/tofu/tofunomics/announcement/TimeAnnouncementSystem.java
+++ b/src/main/java/org/tofu/tofunomics/announcement/TimeAnnouncementSystem.java
@@ -62,8 +62,11 @@ public class TimeAnnouncementSystem {
      * 時刻をチェックして必要に応じて放送
      */
     private void checkAndAnnounce() {
-        // メインワールドを取得
-        World world = Bukkit.getWorlds().get(0);
+        // 営業時間の判定基準となるワールドを取得
+        // ボスバー/スコアボードはプレイヤーがいる経済対象ワールド(tofuNomics)の時刻で
+        // 営業状態を表示するため、告知も同じ経済対象ワールドの時刻を基準にする。
+        // メインワールドを参照すると時刻がずれて営業状態表示が食い違う。
+        World world = getAnnouncementWorld();
         if (world == null) {
             return;
         }
@@ -102,10 +105,29 @@ public class TimeAnnouncementSystem {
     }
     
     /**
-     * 全プレイヤーにメッセージを放送
+     * 営業時間の判定基準となるワールドを取得する。
+     * 経済対象ワールド(enabled_worlds)のうち実在する最初のワールドを返す。
+     * 見つからない場合はサーバーのメインワールドにフォールバックする。
+     */
+    private World getAnnouncementWorld() {
+        for (String worldName : configManager.getEconomyEnabledWorlds()) {
+            World w = Bukkit.getWorld(worldName);
+            if (w != null) {
+                return w;
+            }
+        }
+        return Bukkit.getWorlds().isEmpty() ? null : Bukkit.getWorlds().get(0);
+    }
+
+    /**
+     * 対象ワールドのプレイヤーにメッセージを放送
+     * 対象外ワールドのプレイヤーには送信しない
      */
     private void broadcastMessage(String message) {
         for (Player player : Bukkit.getOnlinePlayers()) {
+            if (!configManager.isEconomyEnabledInWorld(player.getWorld().getName())) {
+                continue;
+            }
             player.sendMessage(message);
         }
     }

--- a/src/main/java/org/tofu/tofunomics/commands/BalanceCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/BalanceCommand.java
@@ -38,6 +38,10 @@ public class BalanceCommand implements CommandExecutor {
         }
         
         Player player = (Player) sender;
+        if (!configManager.isEconomyEnabledInWorld(player.getWorld().getName())) {
+            player.sendMessage(ChatColor.RED + "このワールドではTofuNomicsの経済機能を利用できません。");
+            return true;
+        }
         double cashBalance = currencyConverter.getCashBalance(player);
         double bankBalance = currencyConverter.getBankBalance(player);
         double totalBalance = cashBalance + bankBalance;

--- a/src/main/java/org/tofu/tofunomics/commands/BalanceTopCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/BalanceTopCommand.java
@@ -57,22 +57,36 @@ public class BalanceTopCommand implements CommandExecutor {
         String currencySymbol = configManager.getCurrencySymbol();
         
         sender.sendMessage(ChatColor.GOLD + "==================== 残高ランキング TOP " + limit + " ====================");
-        
+
+        // Playerかつ演出有効時はホバーで詳細を表示するリッチテキストを使用
+        boolean richDisplay = (sender instanceof org.bukkit.entity.Player)
+            && configManager.isClickableMessagesEnabled();
+
         for (int i = 0; i < topPlayers.size(); i++) {
             org.tofu.tofunomics.models.Player tofuPlayer = topPlayers.get(i);
             int rank = i + 1;
-            
+
             String playerName = getPlayerName(tofuPlayer.getUuid().toString());
             String formattedBalance = currencyConverter.formatCurrency(tofuPlayer.getBalance());
-            
+
             ChatColor rankColor = getRankColor(rank);
-            
+
             String rankText = getRankText(rank);
-            
-            sender.sendMessage(String.format("%s%s %s%s: %s%s %s", 
+
+            String rowText = String.format("%s%s %s%s: %s%s %s",
                 rankColor, rankText,
                 ChatColor.WHITE, playerName,
-                ChatColor.GREEN, formattedBalance, currencySymbol));
+                ChatColor.GREEN, formattedBalance, currencySymbol);
+
+            if (richDisplay) {
+                String hover = String.format("&6%s位&7: &f%s\n&a残高: %s %s",
+                    rank, playerName, formattedBalance, currencySymbol);
+                org.tofu.tofunomics.util.RichMessageBuilder.create()
+                    .hoverText(rowText, hover)
+                    .sendTo((org.bukkit.entity.Player) sender);
+            } else {
+                sender.sendMessage(rowText);
+            }
         }
         
         sender.sendMessage(ChatColor.GOLD + "================================================================");

--- a/src/main/java/org/tofu/tofunomics/commands/CityMapCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/CityMapCommand.java
@@ -67,7 +67,7 @@ public class CityMapCommand implements CommandExecutor {
         } catch (Exception e) {
             player.sendMessage("§c地図の配布に失敗しました。");
             player.sendMessage("§cImageOnMapプラグインが導入されているか確認してください。");
-            e.printStackTrace();
+            Bukkit.getLogger().severe("地図の配布に失敗しました: " + e.getMessage());
             return false;
         }
         

--- a/src/main/java/org/tofu/tofunomics/commands/ClockCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/ClockCommand.java
@@ -104,7 +104,6 @@ public class ClockCommand implements CommandExecutor, TabCompleter {
         } catch (Exception e) {
             player.sendMessage("§c時計の購入中にエラーが発生しました。");
             plugin.getLogger().severe("時計購入エラー: " + e.getMessage());
-            e.printStackTrace();
         }
         
         return true;

--- a/src/main/java/org/tofu/tofunomics/commands/DepositCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/DepositCommand.java
@@ -38,7 +38,13 @@ public class DepositCommand implements CommandExecutor {
         }
         
         Player player = (Player) sender;
-        
+
+        // ワールド制限チェック
+        if (!configManager.isEconomyEnabledInWorld(player.getWorld().getName())) {
+            player.sendMessage(ChatColor.RED + "このワールドではTofuNomicsの経済機能を利用できません。");
+            return true;
+        }
+
         // 場所制限チェック
         if (!bankLocationManager.isPlayerNearBankOrAtm(player)) {
             String deniedMessage = bankLocationManager.getLocationDeniedMessage(player);

--- a/src/main/java/org/tofu/tofunomics/commands/JobsCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/JobsCommand.java
@@ -61,36 +61,63 @@ public class JobsCommand implements CommandExecutor {
     }
 
     private boolean handleJobsList(Player player) {
+        boolean clickable = configManager.isClickableMessagesEnabled();
         player.sendMessage(ChatColor.GOLD + "=== 利用可能な職業 ===");
-        
+
         for (String jobName : jobManager.getJobNames()) {
             String displayName = jobManager.getJobDisplayName(jobName);
             String description = configManager.getJobDescription(jobName);
             int maxLevel = configManager.getJobMaxLevel(jobName);
             double incomeMultiplier = configManager.getJobIncomeMultiplier(jobName);
-            
-            player.sendMessage(ChatColor.YELLOW + "▶ " + displayName + ChatColor.GRAY + " (" + jobName + ")");
-            if (description != null && !description.isEmpty()) {
-                player.sendMessage(ChatColor.WHITE + "  " + description);
-            }
-            player.sendMessage(ChatColor.AQUA + "  最大レベル: " + maxLevel + 
-                             " | 収入倍率: " + String.format("%.1f", incomeMultiplier) + "x");
-            
-            // プレイヤーがこの職業に就いているかチェック
-            if (jobManager.hasJob(player, jobName)) {
-                PlayerJob playerJob = jobManager.getPlayerJob(player, jobName);
-                if (playerJob != null) {
-                    int currentLevel = playerJob.getLevel();
-                    double currentExp = playerJob.getExperience();
-                    int requiredExp = configManager.calculateRequiredExperience(currentLevel + 1);
-                    
-                    player.sendMessage(ChatColor.GREEN + "  ★ 現在就職中 - レベル " + currentLevel + 
-                                     " (経験値: " + (int)currentExp + "/" + requiredExp + ")");
+            boolean employed = jobManager.hasJob(player, jobName);
+
+            if (clickable) {
+                // ホバーで詳細（説明・最大レベル・収入倍率）を表示するツールチップを構築
+                StringBuilder hover = new StringBuilder();
+                hover.append("&e").append(displayName).append(" &7(").append(jobName).append(")\n");
+                if (description != null && !description.isEmpty()) {
+                    hover.append("&f").append(description).append("\n");
                 }
+                hover.append("&b最大レベル: ").append(maxLevel)
+                     .append(" &7| &b収入倍率: ").append(String.format("%.1f", incomeMultiplier)).append("x");
+
+                org.tofu.tofunomics.util.RichMessageBuilder builder =
+                    org.tofu.tofunomics.util.RichMessageBuilder.create()
+                        .hoverText("&e▶ " + displayName + " &7(" + jobName + ")  ", hover.toString());
+
+                if (employed) {
+                    PlayerJob playerJob = jobManager.getPlayerJob(player, jobName);
+                    int currentLevel = playerJob != null ? playerJob.getLevel() : 0;
+                    builder.text("&a[現在就職中 Lv." + currentLevel + "]");
+                } else {
+                    // クリックで就職できるボタン
+                    builder.runButton("&a&l[就職する]", "/jobs join " + jobName,
+                        "&aクリックで " + displayName + " に就職します");
+                }
+                builder.sendTo(player);
+            } else {
+                player.sendMessage(ChatColor.YELLOW + "▶ " + displayName + ChatColor.GRAY + " (" + jobName + ")");
+                if (description != null && !description.isEmpty()) {
+                    player.sendMessage(ChatColor.WHITE + "  " + description);
+                }
+                player.sendMessage(ChatColor.AQUA + "  最大レベル: " + maxLevel +
+                                 " | 収入倍率: " + String.format("%.1f", incomeMultiplier) + "x");
+
+                if (employed) {
+                    PlayerJob playerJob = jobManager.getPlayerJob(player, jobName);
+                    if (playerJob != null) {
+                        int currentLevel = playerJob.getLevel();
+                        double currentExp = playerJob.getExperience();
+                        int requiredExp = configManager.calculateRequiredExperience(currentLevel + 1);
+
+                        player.sendMessage(ChatColor.GREEN + "  ★ 現在就職中 - レベル " + currentLevel +
+                                         " (経験値: " + (int)currentExp + "/" + requiredExp + ")");
+                    }
+                }
+                player.sendMessage("");
             }
-            player.sendMessage("");
         }
-        
+
         player.sendMessage(ChatColor.GOLD + "職業に就くには: " + ChatColor.WHITE + "/jobs join <職業名>");
         return true;
     }

--- a/src/main/java/org/tofu/tofunomics/commands/NPCCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/NPCCommand.java
@@ -306,18 +306,12 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
         }
         
         try {
-            plugin.getLogger().info("=== 食料NPCスポーン処理開始 ===");
-            plugin.getLogger().info("プレイヤー: " + player.getName() + ", NPC名: " + npcName + ", タイプ: " + npcType);
-            
             // 食料NPCを生成
             org.bukkit.entity.Villager foodNPC = npcManager.createNPC(spawnLocation, "food_merchant", npcName);
-            
+
             if (foodNPC != null) {
-                plugin.getLogger().info("NPCManagerでの作成成功: UUID=" + foodNPC.getUniqueId());
-                
                 // FoodNPCManagerに登録
                 if (foodNPCManager != null) {
-                    plugin.getLogger().info("FoodNPCManagerへの登録を開始");
                     foodNPCManager.registerFoodNPC(foodNPC, npcName, npcType);
                     
                     // 食料NPCデータをconfig.ymlに自動追加
@@ -343,8 +337,6 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
                     int endHour = configManager.getFoodNPCEndHour();
                     player.sendMessage(String.format("§e営業時間: %d:00-%d:00", startHour, endHour));
                     player.sendMessage("§e§l右クリックで取引開始");
-                    
-                    plugin.getLogger().info("=== 食料NPCスポーン処理完了 ===");
                 } else {
                     player.sendMessage("§c警告: 食料NPCは生成されましたが、システムへの登録に失敗しました");
                     plugin.getLogger().warning("FoodNPCManagerがnullのため、食料NPCの登録に失敗しました");
@@ -358,7 +350,6 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
         } catch (Exception e) {
             player.sendMessage("§c食料NPC生成中にエラーが発生しました: " + e.getMessage());
             plugin.getLogger().severe("食料NPC生成エラー: " + e.getMessage());
-            e.printStackTrace();
             return true;
         }
     }
@@ -369,15 +360,10 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
             "§6木材加工職人";
             
         try {
-            plugin.getLogger().info("=== 加工NPCスポーン処理開始 ===");
-            plugin.getLogger().info("プレイヤー: " + player.getName() + ", NPC名: " + npcName);
-            
             // 加工NPCを生成
             Villager processingNPC = npcManager.createNPC(spawnLocation, "processing", npcName);
-            
+
             if (processingNPC != null) {
-                plugin.getLogger().info("NPCManagerでの作成成功: UUID=" + processingNPC.getUniqueId());
-                
                 // 加工NPCデータをconfig.ymlに自動追加
                 try {
                     configManager.addProcessingNPC(npcName, spawnLocation);
@@ -412,8 +398,7 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
                     player.sendMessage("§7場所: " + formatLocation(spawnLocation));
                     player.sendMessage("§7UUID: " + processingNPC.getUniqueId());
                 }
-                
-                plugin.getLogger().info("=== 加工NPCスポーン処理完了 ===");
+
                 return true;
             } else {
                 player.sendMessage("§c加工NPCの生成に失敗しました");
@@ -422,7 +407,6 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
         } catch (Exception e) {
             player.sendMessage("§c加工NPC生成中にエラーが発生しました: " + e.getMessage());
             plugin.getLogger().severe("加工NPC生成エラー: " + e.getMessage());
-            e.printStackTrace();
             return true;
         }
     }
@@ -631,8 +615,6 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
         
         try {
             // 既存NPCを削除せずに、内部データのみリロード
-            plugin.getLogger().info("=== NPCデータリロード開始 ===");
-            
             int reloadedCount = 0;
             
             // 取引NPCデータをリロード
@@ -649,8 +631,8 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
                 sender.sendMessage("§a加工NPCデータをリロードしました");
             }
             
-            plugin.getLogger().info("=== NPCデータリロード完了 (" + reloadedCount + "種類) ===");
-            
+            plugin.getLogger().info("NPCデータをリロードしました (" + reloadedCount + "種類)");
+
             sender.sendMessage("§aNPCデータのリロードが完了しました。");
             sender.sendMessage("§7既存のNPCは保持され、config.ymlの設定と照合されました。");
             sender.sendMessage("§e詳細はサーバーログを確認してください。");
@@ -659,7 +641,6 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
         } catch (Exception e) {
             sender.sendMessage("§cNPCリロード中にエラーが発生しました: " + e.getMessage());
             plugin.getLogger().severe("NPCリロード中にエラーが発生: " + e.getMessage());
-            e.printStackTrace();
         }
         
         return true;

--- a/src/main/java/org/tofu/tofunomics/commands/PayCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/PayCommand.java
@@ -108,9 +108,17 @@ public class PayCommand implements CommandExecutor {
             fromPlayer.sendMessage(ChatColor.translateAlternateColorCodes('&', 
                 configManager.getMessagePrefix() + senderMessage));
             
-            targetPlayer.sendMessage(ChatColor.translateAlternateColorCodes('&', 
+            targetPlayer.sendMessage(ChatColor.translateAlternateColorCodes('&',
                 configManager.getMessagePrefix() + receiverMessage));
-            
+
+            // 受取側へActionBarで通知（チャット欄を汚さず気づける）
+            if (configManager.isPayActionBarEnabled()) {
+                double newBalance = currencyConverter.getBalance(targetPlayer.getUniqueId());
+                new org.tofu.tofunomics.util.NotificationManager().sendActionBar(targetPlayer,
+                    "&a+ " + formattedAmount + " " + currencySymbol +
+                    " &7受取 &f(残高: " + currencyConverter.formatCurrency(newBalance) + " " + currencySymbol + ")");
+            }
+
             if (fee > 0) {
                 fromPlayer.sendMessage(ChatColor.YELLOW + "送金手数料: " + 
                     currencyConverter.formatCurrency(fee) + " " + currencySymbol);

--- a/src/main/java/org/tofu/tofunomics/commands/PayCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/PayCommand.java
@@ -32,6 +32,10 @@ public class PayCommand implements CommandExecutor {
         }
         
         Player fromPlayer = (Player) sender;
+        if (!configManager.isEconomyEnabledInWorld(fromPlayer.getWorld().getName())) {
+            sender.sendMessage(ChatColor.RED + "このワールドではTofuNomicsの経済機能を利用できません。");
+            return true;
+        }
         String targetPlayerName = args[0];
         String amountString = args[1];
         

--- a/src/main/java/org/tofu/tofunomics/commands/ReloadCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/ReloadCommand.java
@@ -90,7 +90,6 @@ public class ReloadCommand implements CommandExecutor, TabCompleter {
         } catch (Exception e) {
             sender.sendMessage(ChatColor.RED + "設定のリロードに失敗しました: " + e.getMessage());
             plugin.getLogger().severe("設定リロード中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -114,7 +113,6 @@ public class ReloadCommand implements CommandExecutor, TabCompleter {
         } catch (Exception e) {
             sender.sendMessage(ChatColor.RED + "設定ファイルのリロードに失敗しました: " + e.getMessage());
             plugin.getLogger().severe("設定ファイルリロード中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -158,7 +156,6 @@ public class ReloadCommand implements CommandExecutor, TabCompleter {
         } catch (Exception e) {
             sender.sendMessage(ChatColor.RED + "設定ファイルの検証に失敗しました: " + e.getMessage());
             plugin.getLogger().severe("設定検証中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -195,7 +192,6 @@ public class ReloadCommand implements CommandExecutor, TabCompleter {
         } catch (Exception e) {
             sender.sendMessage(ChatColor.RED + "設定エラーの自動修正に失敗しました: " + e.getMessage());
             plugin.getLogger().severe("設定自動修正中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -235,7 +231,6 @@ public class ReloadCommand implements CommandExecutor, TabCompleter {
         } catch (Exception e) {
             sender.sendMessage(ChatColor.RED + "完全リロード処理に失敗しました: " + e.getMessage());
             plugin.getLogger().severe("完全リロード中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     

--- a/src/main/java/org/tofu/tofunomics/commands/TradeCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/TradeCommand.java
@@ -45,7 +45,12 @@ public class TradeCommand implements CommandExecutor, TabCompleter {
         }
         
         Player player = (Player) sender;
-        
+
+        if (!configManager.isEconomyEnabledInWorld(player.getWorld().getName())) {
+            player.sendMessage(ChatColor.RED + "このワールドではTofuNomicsの経済機能を利用できません。");
+            return true;
+        }
+
         if (args.length == 0) {
             showTradeHelp(player);
             return true;

--- a/src/main/java/org/tofu/tofunomics/commands/WithdrawCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/WithdrawCommand.java
@@ -35,7 +35,13 @@ public class WithdrawCommand implements CommandExecutor {
         }
         
         Player player = (Player) sender;
-        
+
+        // ワールド制限チェック
+        if (!configManager.isEconomyEnabledInWorld(player.getWorld().getName())) {
+            player.sendMessage(ChatColor.RED + "このワールドではTofuNomicsの経済機能を利用できません。");
+            return true;
+        }
+
         // 場所制限チェック
         if (!bankLocationManager.isPlayerNearBankOrAtm(player)) {
             String deniedMessage = bankLocationManager.getLocationDeniedMessage(player);

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -429,6 +429,25 @@ public class ConfigManager {
     public java.util.List<String> getExcludedWorlds() {
         return config.getStringList("events.excluded_worlds");
     }
+
+    /**
+     * 経済機能を有効にするワールド一覧を取得（ホワイトリスト）
+     */
+    public java.util.List<String> getEconomyEnabledWorlds() {
+        return config.getStringList("economy.enabled_worlds");
+    }
+
+    /**
+     * 指定されたワールドでTofuNomicsの経済機能が有効かどうか
+     * 設定リストが空の場合は全ワールドで有効（後方互換）
+     */
+    public boolean isEconomyEnabledInWorld(String worldName) {
+        java.util.List<String> enabledWorlds = getEconomyEnabledWorlds();
+        if (enabledWorlds == null || enabledWorlds.isEmpty()) {
+            return true;
+        }
+        return enabledWorlds.contains(worldName);
+    }
     
     public java.util.List<String> getExcludedGameModes() {
         return config.getStringList("events.excluded_game_modes");

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -69,7 +69,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("設定ファイルのリロード中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -1525,7 +1524,14 @@ public class ConfigManager {
     public int getScoreboardUpdateInterval() {
         return (Integer) getCachedValue("scoreboard.update_interval", 1);
     }
-    
+
+    /**
+     * 職業レベルをバニラ経験値バーに反映するかどうか
+     */
+    public boolean isVanillaExpBarEnabled() {
+        return (Boolean) getCachedValue("scoreboard.vanilla_exp_bar", true);
+    }
+
     /**
      * スコアボードでプレイヤー名を表示するかどうか
      */
@@ -2009,6 +2015,50 @@ public class ConfigManager {
         return config.getInt("npc_system.trading_npcs.trading_hours.end", 22);
     }
 
+    // ==================== UX/UI演出設定（ux_enhancements） ====================
+
+    /**
+     * クリック/ホバー可能なリッチテキストメッセージを有効にするか
+     */
+    public boolean isClickableMessagesEnabled() {
+        return (Boolean) getCachedValue("ux_enhancements.clickable_messages", true);
+    }
+
+    /**
+     * レベルアップ時のTitle演出を有効にするか
+     */
+    public boolean isLevelUpTitleEnabled() {
+        return (Boolean) getCachedValue("ux_enhancements.levelup_title", true);
+    }
+
+    /**
+     * レベルアップ時のパーティクル演出を有効にするか
+     */
+    public boolean isLevelUpParticleEnabled() {
+        return (Boolean) getCachedValue("ux_enhancements.levelup_particle", true);
+    }
+
+    /**
+     * 送金受取時のActionBar通知を有効にするか
+     */
+    public boolean isPayActionBarEnabled() {
+        return (Boolean) getCachedValue("ux_enhancements.pay_actionbar", true);
+    }
+
+    /**
+     * 取引営業時間のBossBar表示を有効にするか
+     */
+    public boolean isTradingBossBarEnabled() {
+        return (Boolean) getCachedValue("ux_enhancements.trading_bossbar", true);
+    }
+
+    /**
+     * GUIの枠装飾を有効にするか
+     */
+    public boolean isGuiDecorationEnabled() {
+        return (Boolean) getCachedValue("ux_enhancements.gui_decoration", true);
+    }
+
     /**
      * 別職業での購入時の価格倍率を取得
      * @return 価格倍率（デフォルト: 1.5 = 50%増）
@@ -2152,7 +2202,6 @@ public class ConfigManager {
 
         } catch (Exception e) {
             plugin.getLogger().severe("取引所データの追加に失敗しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
 
@@ -2337,7 +2386,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("銀行NPCデータの追加に失敗しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -2415,7 +2463,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("食料NPCデータの追加に失敗しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -2424,8 +2471,6 @@ public class ConfigManager {
      */
     public void ensureNPCMessagesExist() {
         try {
-            plugin.getLogger().info("NPCメッセージ設定を確認・初期化しています...");
-            
             // 基本メッセージを確保
             ensureMessagePath("messages.npc.unknown_type", "&cNPCの種類が不明です。");
             ensureMessagePath("messages.npc.service_error", 
@@ -2465,7 +2510,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("NPCメッセージ初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -2494,8 +2538,6 @@ public class ConfigManager {
      */
     public void ensureCraftRestrictionMessagesExist() {
         try {
-            plugin.getLogger().info("クラフト制限メッセージ設定を確認・初期化しています...");
-            
             // 基本クラフト制限メッセージを確保
             ensureMessagePath("messages.craft.no_job_required", 
                 "&c職業に就いていないため、このアイテムをクラフトできません。");
@@ -2508,7 +2550,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("クラフト制限メッセージ初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -2517,8 +2558,6 @@ public class ConfigManager {
      */
     public void ensurePlayerJoinSettingsExist() {
         try {
-            plugin.getLogger().info("player_join設定を確認・初期化しています...");
-            
             // スポーン座標設定を確保
             ensureConfigPath("player_join.spawn_location.enabled", true);
             ensureConfigPath("player_join.spawn_location.world", "tofuNomics");
@@ -2563,7 +2602,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("player_join設定初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -2621,7 +2659,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("取引所データ削除エラー: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -2676,7 +2713,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("銀行NPCデータ削除エラー: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -2729,7 +2765,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("食料NPCデータ削除エラー: " + e.getMessage());
-            e.printStackTrace();
         }
     }
 
@@ -2744,7 +2779,6 @@ public class ConfigManager {
             plugin.getLogger().info("すべての取引所データを削除しました");
         } catch (Exception e) {
             plugin.getLogger().severe("取引所データ全削除エラー: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -2753,10 +2787,6 @@ public class ConfigManager {
      */
     public void markNPCAsDeleted(String npcName, String npcType) {
         try {
-            plugin.getLogger().info("NPC削除フラグ設定開始: " + npcName + " (" + npcType + ")");
-            
-            plugin.getLogger().info("=== 包括的NPC削除処理開始: " + npcName + " (タイプ: " + npcType + ") ===");
-        
         boolean anyDeletionOccurred = false;
         
         // 1. 指定されたタイプでの物理削除
@@ -2802,7 +2832,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("NPC削除フラグ設定エラー: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -3100,7 +3129,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("設定ファイルの自動更新中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
 
@@ -3131,7 +3159,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("デフォルト設定ファイルの生成中にエラーが発生: " + e.getMessage());
-            e.printStackTrace();
             return false;
         }
     }
@@ -3208,7 +3235,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("設定の自動修正中にエラーが発生: " + e.getMessage());
-            e.printStackTrace();
             return false;
         }
     }
@@ -3424,7 +3450,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("NPCメッセージの再読み込み中にエラーが発生: " + e.getMessage());
-            e.printStackTrace();
             return false;
         }
     }
@@ -3734,6 +3759,29 @@ public class ConfigManager {
     public int getProcessingMaxLogsPerProcess() {
         return config.getInt("npc_system.processing_npc.pricing.max_logs_per_process", 64);
     }
+
+    /**
+     * 加工対応木材マッピングを取得（原木Material名 -> 板材Material名）
+     * config.ymlの npc_system.processing_npc.wood_types を読み込む。
+     * 未定義の場合は空マップを返す（呼び出し側でデフォルトにフォールバック）。
+     */
+    public Map<String, String> getProcessingWoodTypes() {
+        Map<String, String> woodTypes = new LinkedHashMap<>();
+        ConfigurationSection section = config.getConfigurationSection("npc_system.processing_npc.wood_types");
+        if (section != null) {
+            for (String key : section.getKeys(false)) {
+                woodTypes.put(key, section.getString(key));
+            }
+        }
+        return woodTypes;
+    }
+
+    /**
+     * 原木1個あたりの板材産出数を取得（デフォルト4）
+     */
+    public int getProcessingPlanksPerLog() {
+        return config.getInt("npc_system.processing_npc.planks_per_log", 4);
+    }
     
     /**
      * 加工NPCメッセージを取得
@@ -3863,7 +3911,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("加工NPCデータの追加に失敗しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -3946,7 +3993,6 @@ public class ConfigManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("設定ファイルのマイグレーション中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     

--- a/src/main/java/org/tofu/tofunomics/dao/JobChangeDAO.java
+++ b/src/main/java/org/tofu/tofunomics/dao/JobChangeDAO.java
@@ -3,9 +3,12 @@ package org.tofu.tofunomics.dao;
 import org.tofu.tofunomics.models.JobChange;
 
 import java.sql.*;
+import java.util.logging.Logger;
 
 public class JobChangeDAO {
-    
+
+    private static final Logger logger = Logger.getLogger(JobChangeDAO.class.getName());
+
     private final Connection connection;
     
     public JobChangeDAO(Connection connection) {
@@ -29,12 +32,12 @@ public class JobChangeDAO {
                 }
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.severe("職業変更履歴の取得に失敗しました: " + e.getMessage());
         }
-        
+
         return null;
     }
-    
+
     public boolean insertJobChange(JobChange jobChange) {
         String query = "INSERT INTO job_changes (uuid, last_change_date, created_at, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)";
         
@@ -44,11 +47,11 @@ public class JobChangeDAO {
             
             return statement.executeUpdate() > 0;
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.severe("職業変更履歴の登録に失敗しました: " + e.getMessage());
             return false;
         }
     }
-    
+
     public boolean updateJobChange(JobChange jobChange) {
         String query = "UPDATE job_changes SET last_change_date = ?, updated_at = CURRENT_TIMESTAMP WHERE uuid = ?";
         
@@ -58,11 +61,11 @@ public class JobChangeDAO {
             
             return statement.executeUpdate() > 0;
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.severe("職業変更履歴の更新に失敗しました: " + e.getMessage());
             return false;
         }
     }
-    
+
     public boolean upsertJobChange(JobChange jobChange) {
         JobChange existing = getJobChangeByUUID(jobChange.getUuid());
         if (existing != null) {
@@ -89,7 +92,7 @@ public class JobChangeDAO {
             statement.setString(1, uuid);
             return statement.executeUpdate() > 0;
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.severe("職業変更履歴の削除に失敗しました: " + e.getMessage());
             return false;
         }
     }

--- a/src/main/java/org/tofu/tofunomics/dao/JobDAO.java
+++ b/src/main/java/org/tofu/tofunomics/dao/JobDAO.java
@@ -215,18 +215,7 @@ public class JobDAO {
             // TofuNomicsインスタンスの安全な取得
             TofuNomics plugin = TofuNomics.getInstance();
             if (plugin != null) {
-                Logger logger = plugin.getLogger();
-                logger.info("=== JobDAO.getAllJobsSafe() Debug ===");
-                logger.info("Executing getAllJobs() query...");
-                
-                List<Job> jobs = getAllJobs();
-                logger.info("Query executed successfully. Jobs found: " + jobs.size());
-                
-                for (Job job : jobs) {
-                    logger.info("Job: " + job.getName() + " (" + job.getDisplayName() + ") ID: " + job.getId());
-                }
-                
-                return jobs;
+                return getAllJobs();
             } else {
                 // テスト環境などでプラグインインスタンスが存在しない場合
                 // 接続が閉じられている可能性があるため、空のリストを返す
@@ -236,12 +225,9 @@ public class JobDAO {
             // エラーログの安全な出力
             TofuNomics plugin = TofuNomics.getInstance();
             if (plugin != null) {
-                Logger logger = plugin.getLogger();
-                logger.severe("SQLException in getAllJobsSafe(): " + e.getMessage());
-                e.printStackTrace();
+                plugin.getLogger().severe("職業一覧の取得に失敗しました: " + e.getMessage());
             } else {
-                System.err.println("SQLException in getAllJobsSafe(): " + e.getMessage());
-                e.printStackTrace();
+                Logger.getLogger(JobDAO.class.getName()).severe("職業一覧の取得に失敗しました: " + e.getMessage());
             }
             return new ArrayList<>();
         }

--- a/src/main/java/org/tofu/tofunomics/dao/JobHistoryDAO.java
+++ b/src/main/java/org/tofu/tofunomics/dao/JobHistoryDAO.java
@@ -5,13 +5,16 @@ import org.tofu.tofunomics.models.JobHistory;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * 職業履歴データアクセスクラス
  * プレイヤーが退職した職業の情報を管理
  */
 public class JobHistoryDAO {
-    
+
+    private static final Logger logger = Logger.getLogger(JobHistoryDAO.class.getName());
+
     private final Connection connection;
     
     public JobHistoryDAO(Connection connection) {
@@ -34,11 +37,11 @@ public class JobHistoryDAO {
             
             return statement.executeUpdate() > 0;
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.severe("職業履歴の登録に失敗しました: " + e.getMessage());
             return false;
         }
     }
-    
+
     /**
      * プレイヤーの職業履歴を全て取得
      * @param uuid プレイヤーUUID
@@ -63,9 +66,9 @@ public class JobHistoryDAO {
                 }
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.severe("職業履歴一覧の取得に失敗しました: " + e.getMessage());
         }
-        
+
         return histories;
     }
     
@@ -76,19 +79,19 @@ public class JobHistoryDAO {
      */
     public int getMaxLevelAchieved(String uuid) {
         String query = "SELECT MAX(max_level) as highest_level FROM job_history WHERE uuid = ?";
-        
+
         try (PreparedStatement statement = connection.prepareStatement(query)) {
             statement.setString(1, uuid);
-            
+
             try (ResultSet resultSet = statement.executeQuery()) {
                 if (resultSet.next()) {
                     return resultSet.getInt("highest_level");
                 }
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.severe("最高到達レベルの取得に失敗しました: " + e.getMessage());
         }
-        
+
         return 0;
     }
     
@@ -111,9 +114,9 @@ public class JobHistoryDAO {
                 }
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.severe("職業別最高到達レベルの取得に失敗しました: " + e.getMessage());
         }
-        
+
         return 0;
     }
     
@@ -143,9 +146,9 @@ public class JobHistoryDAO {
                 }
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.severe("最新職業履歴の取得に失敗しました: " + e.getMessage());
         }
-        
+
         return null;
     }
     
@@ -170,7 +173,7 @@ public class JobHistoryDAO {
             statement.setString(1, uuid);
             return statement.executeUpdate() >= 0;
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.severe("職業履歴の削除に失敗しました: " + e.getMessage());
             return false;
         }
     }

--- a/src/main/java/org/tofu/tofunomics/dao/PlayerDAO.java
+++ b/src/main/java/org/tofu/tofunomics/dao/PlayerDAO.java
@@ -10,8 +10,11 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.logging.Logger;
 
 public class PlayerDAO {
+    private static final Logger logger = Logger.getLogger(PlayerDAO.class.getName());
+
     private final Connection connection;
 
     public PlayerDAO(Connection connection) {
@@ -297,7 +300,7 @@ public class PlayerDAO {
                 return result.getBoolean("rules_agreed");
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.severe("ルール同意状態の取得に失敗しました: " + e.getMessage());
         }
         return false;
     }
@@ -312,7 +315,7 @@ public class PlayerDAO {
             statement.setString(2, uuid.toString());
             statement.executeUpdate();
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.severe("ルール同意状態の更新に失敗しました: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/org/tofu/tofunomics/database/DatabaseManager.java
+++ b/src/main/java/org/tofu/tofunomics/database/DatabaseManager.java
@@ -342,6 +342,28 @@ public class DatabaseManager {
                 
                 logger.info("players テーブルに last_login カラムを追加しました");
             }
+
+            // housing_rentals テーブルの start_tick カラムが存在するかチェック
+            try {
+                statement.executeQuery("SELECT start_tick FROM housing_rentals LIMIT 1");
+            } catch (SQLException e) {
+                logger.info("housing_rentals テーブルに start_tick カラムを追加しています...");
+                statement.executeUpdate("ALTER TABLE housing_rentals ADD COLUMN start_tick INTEGER DEFAULT 0");
+                logger.info("housing_rentals テーブルに start_tick カラムを追加しました");
+            }
+
+            // housing_rentals テーブルの end_tick カラムが存在するかチェック
+            try {
+                statement.executeQuery("SELECT end_tick FROM housing_rentals LIMIT 1");
+            } catch (SQLException e) {
+                logger.info("housing_rentals テーブルに end_tick カラムを追加しています...");
+                statement.executeUpdate("ALTER TABLE housing_rentals ADD COLUMN end_tick INTEGER DEFAULT 0");
+                logger.info("housing_rentals テーブルに end_tick カラムを追加しました");
+            }
+
+            // 期限切れ検索高速化用インデックス（存在しなければ作成）
+            statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_housing_rentals_end_tick ON housing_rentals(end_tick)");
+            statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_housing_rentals_status_end_tick ON housing_rentals(status, end_tick)");
         } catch (SQLException e) {
             logger.warning("マイグレーション処理に失敗しました: " + e.getMessage());
         }

--- a/src/main/java/org/tofu/tofunomics/events/EventProcessor.java
+++ b/src/main/java/org/tofu/tofunomics/events/EventProcessor.java
@@ -29,6 +29,9 @@ public class EventProcessor {
     
     // 除外ワールドのキャッシュ
     private final Set<String> excludedWorlds;
+
+    // 経済機能を有効にするワールド（ホワイトリスト）のキャッシュ
+    private final Set<String> enabledWorlds;
     
     // 除外ゲームモード
     private final Set<GameMode> excludedGameModes;
@@ -37,8 +40,9 @@ public class EventProcessor {
         this.configManager = configManager;
         this.jobManager = jobManager;
         this.excludedWorlds = new HashSet<>();
+        this.enabledWorlds = new HashSet<>();
         this.excludedGameModes = new HashSet<>();
-        
+
         initializeExclusions();
     }
     
@@ -51,7 +55,13 @@ public class EventProcessor {
         if (worlds != null) {
             excludedWorlds.addAll(worlds);
         }
-        
+
+        // 経済機能を有効にするワールド（ホワイトリスト）の設定
+        List<String> economyWorlds = configManager.getEconomyEnabledWorlds();
+        if (economyWorlds != null) {
+            enabledWorlds.addAll(economyWorlds);
+        }
+
         // 除外ゲームモードの設定
         excludedGameModes.add(GameMode.CREATIVE);
         excludedGameModes.add(GameMode.SPECTATOR);
@@ -168,10 +178,17 @@ public class EventProcessor {
         }
         
         String worldName = world.getName();
+        // 除外ワールドはスキップ
         if (excludedWorlds.contains(worldName)) {
             return false;
         }
-        
+
+        // 経済機能を有効にするワールドのホワイトリストチェック
+        // （リストが空の場合は全ワールドで有効：後方互換）
+        if (!enabledWorlds.isEmpty() && !enabledWorlds.contains(worldName)) {
+            return false;
+        }
+
         return true;
     }
     

--- a/src/main/java/org/tofu/tofunomics/events/EventProcessor.java
+++ b/src/main/java/org/tofu/tofunomics/events/EventProcessor.java
@@ -265,35 +265,24 @@ public class EventProcessor {
      * 有効な職業を持っているかチェック
      */
     private boolean hasValidJob(Player player, Event event) {
-        System.out.println("=== hasValidJob デバッグ開始 ===");
-        System.out.println("プレイヤー: " + player.getName());
-        System.out.println("イベント: " + event.getClass().getSimpleName());
-        
         // 特定のイベントは職業なしでも処理可能
         if (isJobOptionalEvent(event)) {
-            System.out.println("職業不要イベントのため許可");
             return true;
         }
-        
+
         // プレイヤーが少なくとも1つの職業を持っているかチェック
         List<PlayerJob> jobs = jobManager.getPlayerJobs(player);
-        System.out.println("取得した職業リスト: " + (jobs != null ? jobs.size() + "個" : "null"));
-        
         if (jobs == null || jobs.isEmpty()) {
-            System.out.println("判定結果: 職業なしのため拒否");
             return false;
         }
-        
+
         // アクティブな職業があるかチェック
         for (PlayerJob job : jobs) {
-            System.out.println("職業チェック: JobID=" + job.getJobId() + ", レベル=" + job.getLevel() + ", アクティブ: " + job.isActive());
             if (job.isActive()) {
-                System.out.println("判定結果: アクティブな職業があるため許可");
                 return true;
             }
         }
-        
-        System.out.println("判定結果: アクティブな職業がないため拒否");
+
         return false;
     }
     

--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -113,64 +113,45 @@ public class UnifiedEventHandler implements Listener {
     
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onBlockBreak(BlockBreakEvent event) {
-        System.out.println("=== UnifiedEventHandler.onBlockBreak デバッグ開始 ===");
-        System.out.println("イベント: " + event.getClass().getSimpleName());
-        
         // 基本的なイベント処理チェック
         if (!shouldProcessEvent(event)) {
-            System.out.println("shouldProcessEventでfalse、処理をスキップ");
             return;
         }
-        
+
         Player player = event.getPlayer();
         Material blockType = event.getBlock().getType();
-        
-        System.out.println("プレイヤー: " + player.getName());
-        System.out.println("ブロック: " + blockType.name());
-        
-        
-        
+
         // 職業ブロック制限チェック（優先度HIGHで早期チェック）
         if (!blockPermissionManager.canPlayerBreakBlock(player, blockType)) {
-            System.out.println("blockPermissionManagerで拒否されました");
             event.setCancelled(true);
             String message = blockPermissionManager.getDeniedMessage(player, blockType);
             player.sendMessage(message);
             return;
         }
-        
-        System.out.println("ブロック破壊許可 - 通常処理を継続");
-        
+
         // プレイヤーが設置したブロックかチェック（メモリ内追跡）
         String blockKey = getBlockLocationKey(event.getBlock().getLocation());
         boolean isPlayerPlaced = playerPlacedBlocks.contains(blockKey);
-        
-        System.out.println("プレイヤー設置ブロック: " + isPlayerPlaced);
-        
+
         // 設置ブロックの場合はセットから削除
         if (isPlayerPlaced) {
             playerPlacedBlocks.remove(blockKey);
         }
-        
+
         // キャッシュチェック
         if (eventCache.isRecentlyProcessed(player, "block_break", 50)) {
-            System.out.println("重複イベントのためスキップ");
             return; // 50ms以内の重複イベントは無視
         }
-        
+
         // 既存のマネージャーに処理を委譲（収入システムは無効化）
         // プレイヤーが設置したブロックの場合は経験値を付与しない
         if (!isPlayerPlaced) {
             experienceManager.onBlockBreak(event);
-        } else {
-            System.out.println("プレイヤー設置ブロックのため経験値なし");
         }
         questManager.onBlockBreak(event);
-        
+
         // キャッシュに記録
         eventCache.markAsProcessed(player, "block_break");
-        
-        System.out.println("=== ブロック破壊イベント処理完了 ===");
     }
     
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
@@ -218,38 +199,28 @@ public class UnifiedEventHandler implements Listener {
     
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onCraftItem(CraftItemEvent event) {
-        plugin.getLogger().info("=== onCraftItem メソッド開始 ===");
         if (!shouldProcessEvent(event)) return;
         if (!(event.getWhoClicked() instanceof Player)) return;
-        
+
         Player player = (Player) event.getWhoClicked();
         Material craftedItem = event.getRecipe().getResult().getType();
-        
+
         // クラフト制限チェック（優先度HIGH で先にチェック）
         TofuNomics tofuPlugin = (TofuNomics) plugin;
-        plugin.getLogger().info("=== CraftItemEvent処理開始 ===");
-        plugin.getLogger().info("プレイヤー: " + player.getName() + ", アイテム: " + craftedItem.name());
-        
         if (tofuPlugin.getJobCraftPermissionManager() != null) {
-            plugin.getLogger().info("JobCraftPermissionManager: 初期化済み");
-            
             if (!tofuPlugin.getJobCraftPermissionManager().canPlayerCraftItem(player, craftedItem)) {
                 // クラフトを禁止
                 event.setCancelled(true);
-                
+
                 // 制限メッセージを送信
                 String message = tofuPlugin.getJobCraftPermissionManager().getCraftDeniedMessage(player, craftedItem);
                 player.sendMessage(message);
-                
-                plugin.getLogger().info("クラフト制限: " + player.getName() + " が " + craftedItem.name() + " のクラフトを禁止されました");
                 return;
-            } else {
-                plugin.getLogger().info("クラフト許可: " + player.getName() + " が " + craftedItem.name() + " のクラフトを許可");
             }
         } else {
             plugin.getLogger().warning("JobCraftPermissionManager: 未初期化のため制限チェックをスキップ");
         }
-        
+
         // キャッシュチェック
         if (eventCache.isRecentlyProcessed(player, "craft_item", 100)) {
             return;
@@ -414,27 +385,13 @@ public class UnifiedEventHandler implements Listener {
      * イベント処理を行うべきかチェック
      */
     private boolean shouldProcessEvent(Event event) {
-        plugin.getLogger().info("=== shouldProcessEvent 診断開始 ===");
-        plugin.getLogger().info("イベントタイプ: " + event.getClass().getSimpleName());
-        
         // 設定でイベントシステムが無効化されている場合
-        boolean isEventSystemEnabled = configManager.isEventSystemEnabled();
-        plugin.getLogger().info("イベントシステム有効: " + isEventSystemEnabled);
-        if (!isEventSystemEnabled) {
-            plugin.getLogger().info("判定結果: イベントシステムが無効のため処理スキップ");
+        if (!configManager.isEventSystemEnabled()) {
             return false;
         }
-        
+
         // イベント処理プロセッサでの判定
-        boolean shouldProcessByProcessor = eventProcessor.shouldProcessEvent(event);
-        plugin.getLogger().info("イベントプロセッサ判定: " + shouldProcessByProcessor);
-        if (!shouldProcessByProcessor) {
-            plugin.getLogger().info("判定結果: イベントプロセッサが処理を拒否");
-            return false;
-        }
-        
-        plugin.getLogger().info("判定結果: イベント処理を実行");
-        return true;
+        return eventProcessor.shouldProcessEvent(event);
     }
     
     /**

--- a/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
+++ b/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
@@ -21,6 +21,7 @@ import org.tofu.tofunomics.jobs.ExperienceManager;
 import org.tofu.tofunomics.models.PlayerJob;
 import org.tofu.tofunomics.models.Job;
 import org.tofu.tofunomics.tools.JobToolManager;
+import org.tofu.tofunomics.util.NotificationManager;
 
 import java.util.HashMap;
 import java.util.List;
@@ -37,7 +38,11 @@ public class JobExperienceManager implements Listener {
     private final JobManager jobManager;
     private final JobToolManager jobToolManager;
     private final ExperienceManager experienceManager;
-    
+    private final NotificationManager notificationManager = new NotificationManager();
+
+    // バニラ経験値バーへの即時反映用（setter注入。null許容）
+    private org.tofu.tofunomics.scoreboard.ScoreboardManager scoreboardManager;
+
     // 経験値テーブル
     private final Map<Material, Double> miningExperience;
     private final Map<Material, Double> loggingExperience;
@@ -69,7 +74,14 @@ public class JobExperienceManager implements Listener {
         
         initializeExperienceTables();
     }
-    
+
+    /**
+     * バニラ経験値バー反映用のScoreboardManagerを注入する
+     */
+    public void setScoreboardManager(org.tofu.tofunomics.scoreboard.ScoreboardManager scoreboardManager) {
+        this.scoreboardManager = scoreboardManager;
+    }
+
     private void initializeExperienceTables() {
         // 採掘経験値テーブル
         miningExperience.put(Material.COAL_ORE, 2.0);
@@ -256,7 +268,12 @@ public class JobExperienceManager implements Listener {
         
         // データベース更新
         playerJobDAO.updatePlayerJobData(playerJob);
-        
+
+        // バニラ経験値バーへ即時反映（経験値獲得・レベルアップを即座に表示）
+        if (scoreboardManager != null) {
+            scoreboardManager.updateExperienceBar(player);
+        }
+
         // 経験値獲得メッセージ（5経験値以上の場合のみ表示）
         if (experience >= 5.0) {
             player.sendMessage(ChatColor.GREEN + String.format("+ %.1f %s経験値", 
@@ -271,19 +288,39 @@ public class JobExperienceManager implements Listener {
         while (canPlayerLevelUp(playerJob)) {
             playerJob.levelUp();
             int newLevel = playerJob.getLevel();
-            
-            // レベルアップメッセージ
-            player.sendMessage(ChatColor.GOLD + "★ レベルアップ！ " + 
-                configManager.getJobDisplayName(jobName) + " レベル " + newLevel + " に到達！");
-            
+            String displayName = configManager.getJobDisplayName(jobName);
+
+            // レベルアップメッセージ（ログとしてチャットにも残す）
+            player.sendMessage(ChatColor.GOLD + "★ レベルアップ！ " +
+                displayName + " レベル " + newLevel + " に到達！");
+
+            // Title演出（画面中央に大きく表示）
+            if (configManager.isLevelUpTitleEnabled()) {
+                notificationManager.sendTitle(player,
+                    "&6&l★ LEVEL UP ★",
+                    "&e" + displayName + " &fLv." + newLevel,
+                    10, 50, 20);
+            }
+
+            // パーティクル演出
+            if (configManager.isLevelUpParticleEnabled()) {
+                notificationManager.playCelebrationEffect(player);
+            }
+
             // 新しいツールの付与チェック
             jobToolManager.checkAndGiveNewTools(player, jobName, newLevel);
-            
+
             // 職業レベル最大値チェック
             Job job = jobDAO.getJobByNameSafe(jobName);
             if (job != null && newLevel >= job.getMaxLevel()) {
-                player.sendMessage(ChatColor.LIGHT_PURPLE + "★ おめでとうございます！ " + 
-                    configManager.getJobDisplayName(jobName) + " の最大レベルに到達しました！");
+                player.sendMessage(ChatColor.LIGHT_PURPLE + "★ おめでとうございます！ " +
+                    displayName + " の最大レベルに到達しました！");
+                if (configManager.isLevelUpTitleEnabled()) {
+                    notificationManager.sendTitle(player,
+                        "&d&l★ MAX LEVEL ★",
+                        "&d" + displayName + " &f最大レベル到達！",
+                        10, 60, 20);
+                }
                 break;
             }
         }

--- a/src/main/java/org/tofu/tofunomics/integration/WorldGuardIntegration.java
+++ b/src/main/java/org/tofu/tofunomics/integration/WorldGuardIntegration.java
@@ -116,7 +116,6 @@ public class WorldGuardIntegration {
                 logger.info("WorldGuard領域 " + regionId + " をディスクに保存しました");
             } catch (Exception saveException) {
                 logger.severe("WorldGuard領域の保存に失敗しました: " + saveException.getMessage());
-                saveException.printStackTrace();
                 // 保存失敗時はリージョンを削除してロールバック
                 regionManager.removeRegion(regionId);
                 return false;
@@ -127,7 +126,6 @@ public class WorldGuardIntegration {
 
         } catch (Exception e) {
             logger.severe("WorldGuard領域の作成に失敗しました: " + e.getMessage());
-            e.printStackTrace();
             return false;
         }
     }
@@ -167,7 +165,6 @@ public class WorldGuardIntegration {
                 logger.info("プレイヤー " + playerUuid + " を領域 " + regionId + " のメンバーに追加し、保存しました");
             } catch (Exception saveException) {
                 logger.severe("メンバー追加の保存に失敗しました: " + saveException.getMessage());
-                saveException.printStackTrace();
                 return false;
             }
             
@@ -214,7 +211,6 @@ public class WorldGuardIntegration {
                 logger.info("プレイヤー " + playerUuid + " を領域 " + regionId + " のメンバーから削除し、保存しました");
             } catch (Exception saveException) {
                 logger.severe("メンバー削除の保存に失敗しました: " + saveException.getMessage());
-                saveException.printStackTrace();
                 return false;
             }
             
@@ -252,7 +248,6 @@ public class WorldGuardIntegration {
                     logger.info("領域 " + regionId + " を削除し、保存しました");
                 } catch (Exception saveException) {
                     logger.severe("領域削除の保存に失敗しました: " + saveException.getMessage());
-                    saveException.printStackTrace();
                     return false;
                 }
                 return true;
@@ -299,12 +294,10 @@ public class WorldGuardIntegration {
                     // いずれかの領域のメンバーまたはオーナーかチェック
                     for (ProtectedRegion region : regions) {
                         if (region.isMember(localPlayer) || region.isOwner(localPlayer)) {
-                            logger.fine("プレイヤー " + player.getName() + " は領域 " + region.getId() + " のメンバーです");
                             return true;
                         }
                     }
                     // どの領域のメンバーでもオーナーでもない場合は拒否
-                    logger.fine("プレイヤー " + player.getName() + " は保護領域のメンバーではありません");
                     return false;
                 }
             }
@@ -314,7 +307,6 @@ public class WorldGuardIntegration {
             
         } catch (Exception e) {
             logger.warning("WorldGuard保護チェック中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
             // エラー時は安全側に倒して操作を拒否
             return false;
         }
@@ -328,11 +320,7 @@ public class WorldGuardIntegration {
      * @return 保護領域内の場合true、領域外の場合false
      */
     public boolean isInProtectedRegion(org.bukkit.Location location) {
-        logger.info("WorldGuardIntegration.isInProtectedRegion: チェック開始 - 座標: " + 
-            location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ());
-        
         if (!enabled) {
-            logger.info("WorldGuardIntegration.isInProtectedRegion: WorldGuardが無効");
             // WorldGuardが無効な場合は保護されていないとみなす
             return false;
         }
@@ -340,7 +328,6 @@ public class WorldGuardIntegration {
         try {
             RegionManager regionManager = regionContainer.get(BukkitAdapter.adapt(location.getWorld()));
             if (regionManager == null) {
-                logger.warning("WorldGuardIntegration.isInProtectedRegion: RegionManagerがnull");
                 return false;
             }
 
@@ -350,19 +337,12 @@ public class WorldGuardIntegration {
                 location.getBlockY(),
                 location.getBlockZ()
             );
-            
+
             // 適用される領域のセットを取得
             java.util.Set<ProtectedRegion> regions = regionManager.getApplicableRegions(position).getRegions();
-            
-            logger.info("WorldGuardIntegration.isInProtectedRegion: 検出された領域数: " + regions.size());
-            for (ProtectedRegion region : regions) {
-                logger.info("WorldGuardIntegration.isInProtectedRegion: 領域名: " + region.getId());
-            }
-            
+
             // 領域が1つでも存在すれば保護領域内
-            boolean result = !regions.isEmpty();
-            logger.info("WorldGuardIntegration.isInProtectedRegion: 最終結果: " + (result ? "保護領域内" : "保護領域外"));
-            return result;
+            return !regions.isEmpty();
 
         } catch (Exception e) {
             logger.warning("保護領域チェック中にエラーが発生しました: " + e.getMessage());
@@ -442,7 +422,6 @@ public class WorldGuardIntegration {
                     logger.info("リージョン " + childRegionId + " の親リージョンを " + parentRegionId + " に設定し、保存しました");
                 } catch (Exception saveException) {
                     logger.severe("親リージョン設定の保存に失敗しました: " + saveException.getMessage());
-                    saveException.printStackTrace();
                     // 保存失敗時は親設定をロールバック
                     childRegion.setParent(null);
                     return false;
@@ -456,7 +435,6 @@ public class WorldGuardIntegration {
 
         } catch (Exception e) {
             logger.severe("親リージョンの設定に失敗しました: " + e.getMessage());
-            e.printStackTrace();
             return false;
         }
     }
@@ -551,7 +529,6 @@ public class WorldGuardIntegration {
                 logger.info("リージョン " + regionId + " のフラグ " + flagName + " を " + state + " に設定し、保存しました");
             } catch (Exception saveException) {
                 logger.severe("フラグ設定の保存に失敗しました: " + saveException.getMessage());
-                saveException.printStackTrace();
                 return false;
             }
             
@@ -559,7 +536,6 @@ public class WorldGuardIntegration {
 
         } catch (Exception e) {
             logger.severe("フラグの設定に失敗しました: " + e.getMessage());
-            e.printStackTrace();
             return false;
         }
     }
@@ -656,7 +632,6 @@ public class WorldGuardIntegration {
                 logger.info("リージョン " + regionId + " の設定を保存しました");
             } catch (Exception saveException) {
                 logger.severe("設定の保存に失敗しました: " + saveException.getMessage());
-                saveException.printStackTrace();
                 return false;
             }
 
@@ -664,7 +639,6 @@ public class WorldGuardIntegration {
 
         } catch (Exception e) {
             logger.severe("敵対的モブのスポーン制御設定に失敗しました: " + e.getMessage());
-            e.printStackTrace();
             return false;
         }
     }

--- a/src/main/java/org/tofu/tofunomics/inventory/PlayerInventoryManager.java
+++ b/src/main/java/org/tofu/tofunomics/inventory/PlayerInventoryManager.java
@@ -71,7 +71,6 @@ public class PlayerInventoryManager {
 
         } catch (Exception e) {
             logger.severe("インベントリ保存中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
             return false;
         }
     }
@@ -123,7 +122,6 @@ public class PlayerInventoryManager {
 
         } catch (Exception e) {
             logger.severe("インベントリ復元中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
             return false;
         }
     }
@@ -145,7 +143,6 @@ public class PlayerInventoryManager {
 
         } catch (Exception e) {
             logger.severe("インベントリデータ削除中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
             return false;
         }
     }
@@ -157,7 +154,6 @@ public class PlayerInventoryManager {
         // 5分ごとにオンラインのプレイヤーのインベントリを保存
         autoSaveTask = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, () -> {
             try {
-                logger.info("インベントリ自動保存を実行中...");
                 int savedCount = 0;
 
                 for (Player player : Bukkit.getOnlinePlayers()) {

--- a/src/main/java/org/tofu/tofunomics/items/ClockItemManager.java
+++ b/src/main/java/org/tofu/tofunomics/items/ClockItemManager.java
@@ -56,6 +56,10 @@ public class ClockItemManager implements Listener {
         
         actionBarTask = Bukkit.getScheduler().runTaskTimer(plugin, () -> {
             for (Player player : Bukkit.getOnlinePlayers()) {
+                // 対象外ワールドのプレイヤーには時刻アクションバーを表示しない
+                if (!configManager.isEconomyEnabledInWorld(player.getWorld().getName())) {
+                    continue;
+                }
                 if (hasClockItem(player)) {
                     updateActionBar(player);
                 }

--- a/src/main/java/org/tofu/tofunomics/jobs/JobBlockPermissionManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobBlockPermissionManager.java
@@ -129,48 +129,30 @@ public class JobBlockPermissionManager {
      * @return 採掘可能な場合true
      */
     public boolean canPlayerBreakBlock(Player player, Material blockType) {
-        System.out.println("=== canPlayerBreakBlock デバッグ開始 ===");
-        System.out.println("プレイヤー: " + player.getName());
-        System.out.println("ブロックタイプ: " + blockType.name());
-        
         // 職業制限システムが無効の場合は常に許可
-        boolean isRestrictionEnabled = configManager.isJobBlockRestrictionEnabled();
-        System.out.println("ブロック制限システム有効: " + isRestrictionEnabled);
-        if (!isRestrictionEnabled) {
-            System.out.println("判定結果: ブロック制限システムが無効のため許可");
+        if (!configManager.isJobBlockRestrictionEnabled()) {
             return true;
         }
-        
+
         // 管理者権限を持つ場合は常に許可
-        boolean hasAdminPermission = player.hasPermission("tofunomics.admin.break");
-        System.out.println("管理者権限: " + hasAdminPermission);
-        if (hasAdminPermission) {
-            System.out.println("判定結果: 管理者権限のため許可");
+        if (player.hasPermission("tofunomics.admin.break")) {
             return true;
         }
-        
+
         // 基本ブロックの場合は常に許可
-        boolean isBasicBlock = basicBlocks.contains(blockType);
-        System.out.println("基本ブロック: " + isBasicBlock);
-        if (isBasicBlock) {
-            System.out.println("判定結果: 基本ブロックのため許可");
+        if (basicBlocks.contains(blockType)) {
             return true;
         }
-        
+
         // 制限ブロックかチェック
         String requiredJob = getRequiredJobForBlock(blockType);
-        System.out.println("必要な職業: " + (requiredJob != null ? requiredJob : "なし"));
         if (requiredJob == null) {
             // 制限されていないブロックは誰でも採掘可能
-            System.out.println("判定結果: 制限されていないブロックのため許可");
             return true;
         }
-        
+
         // プレイヤーが必要な職業を持っているかチェック
-        boolean hasRequiredJob = jobManager.hasJob(player, requiredJob);
-        System.out.println("必要職業の保有: " + hasRequiredJob);
-        System.out.println("判定結果: " + (hasRequiredJob ? "必要職業保有のため許可" : "必要職業なしのため拒否"));
-        return hasRequiredJob;
+        return jobManager.hasJob(player, requiredJob);
     }
     
     /**

--- a/src/main/java/org/tofu/tofunomics/jobs/JobManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobManager.java
@@ -236,7 +236,7 @@ public class JobManager {
             return jobDAO.getJobById(jobId);
         } catch (java.sql.SQLException e) {
             // エラーログを出力してnullを返す
-            System.err.println("Failed to get job by id: " + jobId + " - " + e.getMessage());
+            TofuNomics.getInstance().getLogger().severe("職業IDからの取得に失敗しました (jobId=" + jobId + "): " + e.getMessage());
             return null;
         }
     }

--- a/src/main/java/org/tofu/tofunomics/npc/BankNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/BankNPCManager.java
@@ -43,13 +43,10 @@ public class BankNPCManager {
             plugin.getLogger().info("銀行NPCシステムを初期化しました");
         } catch (Exception e) {
             plugin.getLogger().severe("銀行NPCシステムの初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
-    
+
     private void spawnBankNPCs() {
-        plugin.getLogger().info("銀行NPCをスポーンしています...");
-        
         // 既にスポーンした座標を記録するSet（重複防止用）
         java.util.Set<String> spawnedLocations = new java.util.HashSet<>();
         
@@ -57,8 +54,6 @@ public class BankNPCManager {
         java.util.List<java.util.Map<?, ?>> bankNPCLocations = configManager.getBankNPCLocations();
         
         if (!bankNPCLocations.isEmpty()) {
-            plugin.getLogger().info("config.ymlから" + bankNPCLocations.size() + "個の銀行NPC設定を読み込みました");
-            
             for (java.util.Map<?, ?> npcData : bankNPCLocations) {
                 try {
                     String worldName = (String) npcData.get("world");
@@ -104,7 +99,6 @@ public class BankNPCManager {
                     }
                 } catch (Exception e) {
                     plugin.getLogger().severe("銀行NPCのスポーン中にエラー: " + e.getMessage());
-                    e.printStackTrace();
                 }
             }
         } else {
@@ -227,8 +221,6 @@ public class BankNPCManager {
     }
     
     public void removeBankNPCs() {
-        plugin.getLogger().info("全ての銀行NPCを削除しています...");
-        
         Collection<NPCManager.NPCData> allNPCs = npcManager.getAllNPCs();
         int removedCount = 0;
         
@@ -243,7 +235,6 @@ public class BankNPCManager {
     }
     
     public void reloadBankNPCs() {
-        plugin.getLogger().info("銀行NPCをリロードしています...");
         removeBankNPCs();
         spawnBankNPCs();
         plugin.getLogger().info("銀行NPCのリロードが完了しました");

--- a/src/main/java/org/tofu/tofunomics/npc/FoodNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/FoodNPCManager.java
@@ -99,23 +99,18 @@ public class FoodNPCManager {
             plugin.getLogger().info("食料NPCシステムを初期化しました");
         } catch (Exception e) {
             plugin.getLogger().severe("食料NPCシステムの初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
-    
+
     /**
      * 食料NPCをスポーンする
      */
     private void spawnFoodNPCs() {
-        plugin.getLogger().info("=== 食料NPC生成開始 ===");
-        
         // 既存の食料店データをクリア
         foodStores.clear();
-        plugin.getLogger().info("既存の食料店データをクリアしました");
-        
+
         List<Map<?, ?>> foodNPCConfigs = configManager.getFoodNPCConfigs();
-        plugin.getLogger().info("設定から " + foodNPCConfigs.size() + " 個の食料NPCを読み込み");
-        
+
         for (Map<?, ?> config : foodNPCConfigs) {
             try {
                 String name = (String) config.get("name");
@@ -142,23 +137,19 @@ public class FoodNPCManager {
                 }
                 
                 Location location = new Location(plugin.getServer().getWorld(world), x + 0.5, y, z + 0.5, yaw, pitch);
-                plugin.getLogger().info("食料NPCを生成中: " + name + " at [" + x + ", " + y + ", " + z + "] (world: " + world + ")");
-                
+
                 Villager foodNPC = npcManager.createNPC(location, "food_merchant", name);
-                
+
                 if (foodNPC != null) {
                     setupFoodNPC(foodNPC);
-                    
+
                     // config.ymlからnpc_typeを読み込む（存在しない場合はデフォルト）
                     String npcType = "general_store"; // デフォルトタイプ
                     if (config.containsKey("npc_type")) {
                         Object npcTypeObj = config.get("npc_type");
                         if (npcTypeObj instanceof String) {
                             npcType = (String) npcTypeObj;
-                            plugin.getLogger().info("config.ymlからNPCタイプを読み込みました: " + npcType);
                         }
-                    } else {
-                        plugin.getLogger().info("config.ymlにnpc_typeがないため、デフォルト値を使用: " + npcType);
                     }
                     Map<Material, Double> prices = buildFoodItemPrices(npcType);
                     FoodStore foodStore = new FoodStore(foodNPC.getUniqueId(), name, location, prices, npcType);
@@ -166,21 +157,14 @@ public class FoodNPCManager {
                     
                     // 在庫を初期化
                     initializeStoreInventory(foodNPC.getUniqueId());
-                    
-                    plugin.getLogger().info("========================================");
-                    plugin.getLogger().info("食料NPC配置成功:");
-                    plugin.getLogger().info("  名前: " + name);
-                    plugin.getLogger().info("  UUID: " + foodNPC.getUniqueId());
-                    plugin.getLogger().info("  座標: [" + x + ", " + y + ", " + z + "]");
-                    plugin.getLogger().info("  ワールド: " + world);
-                    plugin.getLogger().info("========================================");
+
+                    plugin.getLogger().info("食料NPCを配置しました: " + name + " [" + x + ", " + y + ", " + z + "]");
                 } else {
                     plugin.getLogger().severe("食料NPCの生成に失敗しました: " + name + " at [" + x + ", " + y + ", " + z + "]");
                 }
-                
+
             } catch (Exception e) {
                 plugin.getLogger().warning("食料NPC生成中にエラーが発生しました: " + e.getMessage());
-                e.printStackTrace();
             }
         }
     }
@@ -223,7 +207,6 @@ public class FoodNPCManager {
             }
         }
         
-        plugin.getLogger().info("NPCタイプ " + npcType + " の商品価格構築完了: " + filteredPrices.size() + "アイテム (倍率: " + priceMultiplier + ")");
         return filteredPrices;
     }
     
@@ -271,16 +254,11 @@ public class FoodNPCManager {
      * 食料NPC相互作用の処理
      */
     public boolean handleFoodNPCInteraction(Player player, UUID npcId) {
-        plugin.getLogger().info("=== 食料NPC相互作用開始 ===");
-        plugin.getLogger().info("プレイヤー: " + player.getName() + ", NPC ID: " + npcId);
-        
         try {
             // NPCデータ取得
             FoodStore foodStore = foodStores.get(npcId);
             if (foodStore == null) {
                 plugin.getLogger().warning("食料店データが見つかりません: " + npcId);
-                plugin.getLogger().warning("登録済み食料店数: " + foodStores.size());
-                plugin.getLogger().warning("登録済み食料店ID: " + foodStores.keySet());
                 return false;
             }
             
@@ -322,7 +300,6 @@ public class FoodNPCManager {
         } catch (Exception e) {
             plugin.getLogger().severe("食料NPC処理中にエラーが発生しました: " + e.getMessage());
             player.sendMessage("§c処理中にエラーが発生しました。管理者にお知らせください。");
-            e.printStackTrace();
             return true;
         }
     }
@@ -368,19 +345,13 @@ public class FoodNPCManager {
         
         int startHour = configManager.getFoodNPCStartHour();
         int endHour = configManager.getFoodNPCEndHour();
-        
-        plugin.getLogger().info("食料NPC営業時間チェック - worldTime: " + worldTime + ", 現在時刻: " + currentHour + ":00, 営業時間: " + startHour + ":00-" + endHour + ":00");
-        
+
         // 日をまたぐ営業時間の場合（例：22:00-8:00）
         if (startHour > endHour) {
-            boolean result = currentHour >= startHour || currentHour < endHour;
-            plugin.getLogger().info("営業時間判定結果（日またぎ）: " + result);
-            return result;
+            return currentHour >= startHour || currentHour < endHour;
         } else {
             // 通常の営業時間の場合（例：6:00-22:00）
-            boolean result = currentHour >= startHour && currentHour < endHour;
-            plugin.getLogger().info("営業時間判定結果: " + result);
-            return result;
+            return currentHour >= startHour && currentHour < endHour;
         }
     }
     
@@ -546,7 +517,6 @@ public class FoodNPCManager {
      * 食料NPCのリロード
      */
     public void reloadFoodNPCs() {
-        plugin.getLogger().info("食料NPCをリロードしています...");
         removeFoodNPCs();
         initializeFoodNPCs();
         plugin.getLogger().info("食料NPCのリロードが完了しました");
@@ -579,43 +549,34 @@ public class FoodNPCManager {
     public void registerFoodNPC(Villager villager, String name, String npcType) {
         UUID npcId = villager.getUniqueId();
         Location location = villager.getLocation();
-        
-        plugin.getLogger().info("=== 食料NPC登録開始 ===");
-        plugin.getLogger().info("手動スポーンされた食料NPCを登録中: " + name + " (ID: " + npcId + ")");
-        plugin.getLogger().info("Location: " + location.toString());
-        
+
         try {
             // Villagerの設定
             setupFoodNPC(villager);
-            plugin.getLogger().info("VillagerのセットアップOK");
-            
+
             // NPCタイプの検証
             if (npcType == null || npcType.isEmpty()) {
                 npcType = "general_store"; // デフォルト
             }
-            
+
             // 有効なNPCタイプかチェック
             if (!configManager.getFoodNPCTypes().contains(npcType)) {
                 plugin.getLogger().warning("無効なNPCタイプ: " + npcType + "。general_storeを使用します。");
                 npcType = "general_store";
             }
-            
+
             // FoodStoreデータを作成
             Map<Material, Double> prices = buildFoodItemPrices(npcType);
-            plugin.getLogger().info("価格データ作成OK: " + prices.size() + "アイテム");
-            
+
             FoodStore foodStore = new FoodStore(npcId, name, location, prices, npcType);
             foodStores.put(npcId, foodStore);
-            plugin.getLogger().info("FoodStoreデータ登録OK - 現在の登録数: " + foodStores.size());
-            
+
             // 在庫を初期化
             initializeStoreInventory(npcId);
-            plugin.getLogger().info("在庫初期化OK");
-            
-            plugin.getLogger().info("=== 食料NPCの登録が完了しました: " + name + " ===");
+
+            plugin.getLogger().info("食料NPCを登録しました: " + name);
         } catch (Exception e) {
             plugin.getLogger().severe("食料NPC登録中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     

--- a/src/main/java/org/tofu/tofunomics/npc/NPCListener.java
+++ b/src/main/java/org/tofu/tofunomics/npc/NPCListener.java
@@ -78,12 +78,9 @@ public class NPCListener implements Listener {
         
         // システムのNPCかチェック
         if (!npcManager.isNPCEntity(npcId)) {
-            plugin.getLogger().info("非NPCエンティティがクリックされました: " + npcId);
             return;
         }
-        
-        plugin.getLogger().info("NPCがクリックされました: " + npcId + " by プレイヤー: " + player.getName());
-        
+
         event.setCancelled(true); // デフォルトの村人取引を無効化
 
         // ワールド制限チェック（経済機能が無効なワールドではNPC機能を提供しない）
@@ -97,9 +94,7 @@ public class NPCListener implements Listener {
                 plugin.getLogger().warning("NPCデータが見つかりません: " + npcId);
                 return;
             }
-            
-            plugin.getLogger().info("NPCタイプを確認: " + npcData.getNpcType() + " (名前: " + npcData.getName() + ")");
-            
+
             // プレイヤーの方を向く機能（設定で有効な場合）
             if (configManager.isLookAtPlayerEnabled()) {
                 makeNPCLookAtPlayer(villager, player);
@@ -107,25 +102,21 @@ public class NPCListener implements Listener {
             
             switch (npcData.getNpcType()) {
                 case "banker":
-                    plugin.getLogger().info("銀行NPCとの相互作用を開始: " + npcData.getName());
                     handleBankNPCInteraction(player, npcId);
                     break;
-                    
+
                 case "trader":
-                    plugin.getLogger().info("取引NPCとの相互作用を開始: " + npcData.getName());
                     handleTradingNPCInteraction(player, npcId);
                     break;
-                    
+
                 case "food_merchant":
-                    plugin.getLogger().info("食料NPCとの相互作用を開始: " + npcData.getName());
                     handleFoodNPCInteraction(player, npcId);
                     break;
-                    
+
                 case "processing":
-                    plugin.getLogger().info("加工NPCとの相互作用を開始: " + npcData.getName());
                     handleProcessingNPCInteraction(player, npcId);
                     break;
-                    
+
                 default:
                     plugin.getLogger().warning("不明なNPCタイプ: " + npcData.getNpcType());
                     player.sendMessage(configManager.getMessage("npc.unknown_type"));
@@ -135,7 +126,6 @@ public class NPCListener implements Listener {
         } catch (Exception e) {
             plugin.getLogger().severe("NPC取引処理中にエラーが発生しました: " + e.getMessage());
             player.sendMessage(configManager.getMessage("npc.service_error"));
-            e.printStackTrace();
         }
     }
     
@@ -193,8 +183,6 @@ public class NPCListener implements Listener {
         }
         
         try {
-            plugin.getLogger().info("加工NPC相互作用処理開始: " + player.getName() + ", NPC ID: " + npcId);
-            
             if (processingNPCManager != null) {
                 boolean handled = processingNPCManager.handleProcessingNPCInteraction(player, npcId);
                 if (handled) {
@@ -212,7 +200,6 @@ public class NPCListener implements Listener {
         } catch (Exception e) {
             plugin.getLogger().severe("加工NPC相互作用処理中に例外が発生しました: " + e.getMessage());
             player.sendMessage("§c処理中にエラーが発生しました。管理者にお知らせください。");
-            e.printStackTrace();
         }
     }
     
@@ -227,8 +214,6 @@ public class NPCListener implements Listener {
         }
         
         try {
-            plugin.getLogger().info("食料NPC相互作用処理開始: " + player.getName() + ", NPC ID: " + npcId);
-            
             if (foodNPCManager != null) {
                 boolean handled = foodNPCManager.handleFoodNPCInteraction(player, npcId);
                 if (handled) {
@@ -248,7 +233,6 @@ public class NPCListener implements Listener {
         } catch (Exception e) {
             plugin.getLogger().severe("食料NPC相互作用処理中に例外が発生しました: " + e.getMessage());
             player.sendMessage("§c処理中にエラーが発生しました。管理者にお知らせください。");
-            e.printStackTrace();
         }
     }
     
@@ -417,18 +401,71 @@ public class NPCListener implements Listener {
      */
     @EventHandler(priority = EventPriority.MONITOR)
     public void onChunkLoad(ChunkLoadEvent event) {
-        // チャンク内の全エンティティをチェック
+        // チャンク内のシステムNPCを「タイプ+整数座標」でグルーピング
+        // （サーバー再起動でNBT復元された旧NPCと新規NPCが重複するため、ここで排除する）
+        Map<String, List<Villager>> npcsByLocation = new HashMap<>();
         for (org.bukkit.entity.Entity entity : event.getChunk().getEntities()) {
             if (entity instanceof Villager) {
                 Villager villager = (Villager) entity;
-                
-                // システムNPCかチェック（PDCベース）
                 if (npcManager.isSystemNPC(villager)) {
-                    // NPC設定を再適用
-                    npcManager.reapplyNPCSettings(villager);
+                    String key = getNPCLocationKey(villager);
+                    npcsByLocation.computeIfAbsent(key, k -> new ArrayList<>()).add(villager);
                 }
             }
         }
+
+        // 同一キーに複数体ある場合は1体だけ残して残りを削除
+        for (Map.Entry<String, List<Villager>> entry : npcsByLocation.entrySet()) {
+            List<Villager> duplicates = entry.getValue();
+            Villager keep = selectNPCToKeep(duplicates);
+
+            for (Villager villager : duplicates) {
+                if (villager == keep) {
+                    continue;
+                }
+                plugin.getLogger().info("重複NPCを削除: " + villager.getCustomName() +
+                    " at " + entry.getKey());
+                villager.remove();
+            }
+
+            // 残った1体にのみ設定を再適用
+            if (keep != null) {
+                npcManager.reapplyNPCSettings(keep);
+            }
+        }
+    }
+
+    /**
+     * NPCの重複判定用キーを生成（タイプ + 整数化したブロック座標）
+     */
+    private String getNPCLocationKey(Villager villager) {
+        Location loc = villager.getLocation();
+        String npcType = "unknown";
+        org.bukkit.persistence.PersistentDataContainer pdc = villager.getPersistentDataContainer();
+        org.bukkit.NamespacedKey typeKey = new org.bukkit.NamespacedKey(plugin, "npc_type");
+        if (pdc.has(typeKey, org.bukkit.persistence.PersistentDataType.STRING)) {
+            String type = pdc.get(typeKey, org.bukkit.persistence.PersistentDataType.STRING);
+            if (type != null) {
+                npcType = type;
+            }
+        } else if (villager.hasMetadata("tofunomics_npc_type")) {
+            npcType = villager.getMetadata("tofunomics_npc_type").get(0).asString();
+        }
+        return npcType + ":" + loc.getBlockX() + "," + loc.getBlockY() + "," + loc.getBlockZ();
+    }
+
+    /**
+     * 重複NPC群から残す1体を選定する
+     * 内部マップ（npcs）に登録済み=今回の起動で正規生成された個体を最優先で残す
+     */
+    private Villager selectNPCToKeep(List<Villager> duplicates) {
+        for (Villager villager : duplicates) {
+            if (npcManager.getNPCData(villager.getUniqueId()) != null) {
+                return villager;
+            }
+        }
+        // 正規個体が見つからなければ最初の1体を残す
+        return duplicates.isEmpty() ? null : duplicates.get(0);
     }
 
     /**

--- a/src/main/java/org/tofu/tofunomics/npc/NPCListener.java
+++ b/src/main/java/org/tofu/tofunomics/npc/NPCListener.java
@@ -85,7 +85,12 @@ public class NPCListener implements Listener {
         plugin.getLogger().info("NPCがクリックされました: " + npcId + " by プレイヤー: " + player.getName());
         
         event.setCancelled(true); // デフォルトの村人取引を無効化
-        
+
+        // ワールド制限チェック（経済機能が無効なワールドではNPC機能を提供しない）
+        if (!configManager.isEconomyEnabledInWorld(player.getWorld().getName())) {
+            return;
+        }
+
         try {
             NPCManager.NPCData npcData = npcManager.getNPCData(npcId);
             if (npcData == null) {

--- a/src/main/java/org/tofu/tofunomics/npc/NPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/NPCManager.java
@@ -84,7 +84,11 @@ public class NPCManager {
             villager.setSilent(true);
             villager.setInvulnerable(true);
             villager.setRemoveWhenFarAway(false);
-            
+            // エンティティ衝突による押し出しを無効化し、その場に固定する
+            villager.setCollidable(false);
+            villager.setGravity(false);
+            villager.setVelocity(new org.bukkit.util.Vector(0, 0, 0));
+
             // NPCの向きを設定（Locationからyaw/pitchを取得）
             Location npcLocation = villager.getLocation();
             npcLocation.setYaw(location.getYaw());
@@ -108,15 +112,12 @@ public class NPCManager {
             // NPCデータを保存
             NPCData npcData = new NPCData(villager.getUniqueId(), npcType, name, location, villager);
             npcs.put(villager.getUniqueId(), npcData);
-            
-            plugin.getLogger().info("NPCを生成しました: " + name + " (" + npcType + ") at " + 
-                location.getX() + ", " + location.getY() + ", " + location.getZ() + 
-                " (yaw: " + location.getYaw() + ", pitch: " + location.getPitch() + ")");
-            
+
+            plugin.getLogger().info("NPCを生成しました: " + name + " (" + npcType + ")");
+
             return villager;
         } catch (Exception e) {
             plugin.getLogger().severe("NPC生成中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
             return null;
         }
     }
@@ -153,6 +154,10 @@ public class NPCManager {
         villager.setInvulnerable(true);
         villager.setRemoveWhenFarAway(false);
         villager.setCustomNameVisible(true);
+        // エンティティ衝突による押し出しを無効化し、その場に固定する
+        villager.setCollidable(false);
+        villager.setGravity(false);
+        villager.setVelocity(new org.bukkit.util.Vector(0, 0, 0));
         
         // 取引を無効化
         villager.setRecipes(new ArrayList<>());
@@ -304,7 +309,8 @@ public class NPCManager {
         // 内部データもクリア
         npcs.clear();
         
-        plugin.getLogger().info("既存システムNPCを " + removedCount + " 個削除しました");
+        plugin.getLogger().info("既存システムNPCを " + removedCount + " 個削除しました" +
+            "（未ロードチャンク内のNPCはチャンクロード時に重複排除されます）");
     }
     
     /**
@@ -376,7 +382,6 @@ public class NPCManager {
             plugin.getLogger().info("設定ファイルからNPCを生成しました");
         } catch (Exception e) {
             plugin.getLogger().severe("設定ファイルからのNPC生成中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     

--- a/src/main/java/org/tofu/tofunomics/npc/ProcessingNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/ProcessingNPCManager.java
@@ -30,8 +30,11 @@ public class ProcessingNPCManager {
     
     // 原木→板材のマッピング
     private final Map<Material, Material> logToPlanksMap;
-    
-    public ProcessingNPCManager(TofuNomics plugin, ConfigManager configManager, NPCManager npcManager, 
+
+    // 原木1個あたりの板材産出数（config駆動）
+    private int planksPerLog;
+
+    public ProcessingNPCManager(TofuNomics plugin, ConfigManager configManager, NPCManager npcManager,
                                CurrencyConverter currencyConverter, JobManager jobManager) {
         this.plugin = plugin;
         this.configManager = configManager;
@@ -40,14 +43,46 @@ public class ProcessingNPCManager {
         this.jobManager = jobManager;
         this.processingStations = new HashMap<>();
         this.logToPlanksMap = new HashMap<>();
-        
+
         initializeLogToPlanksMapping();
     }
-    
+
     /**
-     * 原木→板材のマッピングを初期化
+     * 原木→板材のマッピングを初期化（config.ymlのwood_types駆動）
+     * configが空または未定義の場合はデフォルトのハードコードマッピングにフォールバック
      */
     private void initializeLogToPlanksMapping() {
+        logToPlanksMap.clear();
+        this.planksPerLog = configManager.getProcessingPlanksPerLog();
+
+        Map<String, String> woodTypes = configManager.getProcessingWoodTypes();
+        if (woodTypes.isEmpty()) {
+            loadDefaultLogMapping();
+            return;
+        }
+
+        for (Map.Entry<String, String> entry : woodTypes.entrySet()) {
+            try {
+                Material log = Material.valueOf(entry.getKey().toUpperCase());
+                Material planks = Material.valueOf(entry.getValue().toUpperCase());
+                logToPlanksMap.put(log, planks);
+            } catch (IllegalArgumentException ex) {
+                plugin.getLogger().warning(String.format(
+                    "加工設定の無効なMaterial名をスキップしました: %s -> %s",
+                    entry.getKey(), entry.getValue()));
+            }
+        }
+
+        // configが全て無効だった場合もデフォルトにフォールバック
+        if (logToPlanksMap.isEmpty()) {
+            loadDefaultLogMapping();
+        }
+    }
+
+    /**
+     * デフォルトの原木→板材マッピング（後方互換用フォールバック）
+     */
+    private void loadDefaultLogMapping() {
         logToPlanksMap.put(Material.OAK_LOG, Material.OAK_PLANKS);
         logToPlanksMap.put(Material.SPRUCE_LOG, Material.SPRUCE_PLANKS);
         logToPlanksMap.put(Material.BIRCH_LOG, Material.BIRCH_PLANKS);
@@ -56,8 +91,6 @@ public class ProcessingNPCManager {
         logToPlanksMap.put(Material.DARK_OAK_LOG, Material.DARK_OAK_PLANKS);
         logToPlanksMap.put(Material.CRIMSON_STEM, Material.CRIMSON_PLANKS);
         logToPlanksMap.put(Material.WARPED_STEM, Material.WARPED_PLANKS);
-        
-        plugin.getLogger().info("原木→板材マッピング初期化完了: " + logToPlanksMap.size() + "種類");
     }
     
     /**
@@ -97,16 +130,13 @@ public class ProcessingNPCManager {
             plugin.getLogger().info("加工NPCシステムを初期化しました");
         } catch (Exception e) {
             plugin.getLogger().severe("加工NPCシステムの初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
-    
+
     /**
      * 加工NPCを生成
      */
     private void spawnProcessingNPCs() {
-        plugin.getLogger().info("=== 加工NPC生成開始 ===");
-        
         processingStations.clear();
         
         // 現在スポーン中の全NPCを取得（座標ベースでの重複チェック用）
@@ -125,12 +155,9 @@ public class ProcessingNPCManager {
                 existingNPCsNameByLocation.put(locationKey, npc.getName());
             }
         }
-        
-        plugin.getLogger().info("既存の加工NPC数: " + existingNPCsByLocation.size());
-        
+
         List<Map<?, ?>> processingConfigs = configManager.getProcessingNPCConfigs();
-        plugin.getLogger().info("設定から " + processingConfigs.size() + " 個の加工所を読み込み");
-        
+
         // config.ymlに記載されている座標を記録（警告用）
         Set<String> configLocationKeys = new HashSet<>();
         
@@ -177,12 +204,10 @@ public class ProcessingNPCManager {
                     
                     if (existingNPC != null) {
                         processingNPC = existingNPC.getEntity();
-                        plugin.getLogger().info("既存の加工NPCを再利用: " + name + " (UUID: " + npcId + ")");
-                        
+
                         // 名前が変更されている場合は更新
                         if (!name.equals(existingNPC.getName())) {
                             processingNPC.setCustomName(name);
-                            plugin.getLogger().info("  NPC名を更新: " + existingNPC.getName() + " -> " + name);
                         }
                     } else {
                         // NPCDataが見つからない場合は新規作成
@@ -198,9 +223,8 @@ public class ProcessingNPCManager {
                     }
                 } else {
                     // 新規作成
-                    plugin.getLogger().info("加工NPCを新規生成中: " + name + " at [" + x + ", " + y + ", " + z + "]");
                     processingNPC = npcManager.createNPC(location, "processing", name);
-                    
+
                     if (processingNPC != null) {
                         npcId = processingNPC.getUniqueId();
                         setupProcessingNPC(processingNPC);
@@ -209,27 +233,19 @@ public class ProcessingNPCManager {
                         continue;
                     }
                 }
-                
+
                 // 加工所データを登録
                 ProcessingStation station = new ProcessingStation(id, name, location, npcId);
                 processingStations.put(id, station);
-                
-                plugin.getLogger().info("========================================");
-                plugin.getLogger().info("加工所登録成功:");
-                plugin.getLogger().info("  名前: " + name);
-                plugin.getLogger().info("  ID: " + id);
-                plugin.getLogger().info("  UUID: " + npcId);
-                plugin.getLogger().info("  座標: [" + x + ", " + y + ", " + z + "]");
-                plugin.getLogger().info("========================================");
-                
+
+                plugin.getLogger().info("加工所を登録しました: " + name + " [" + x + ", " + y + ", " + z + "]");
+
             } catch (Exception e) {
                 plugin.getLogger().warning("加工NPC処理中にエラーが発生しました: " + e.getMessage());
-                e.printStackTrace();
             }
         }
-        
+
         // config.ymlに記載されていないNPCを検出して警告
-        plugin.getLogger().info("=== config.yml未登録NPCチェック ===");
         int orphanedCount = 0;
         for (Map.Entry<String, UUID> entry : existingNPCsByLocation.entrySet()) {
             String locationKey = entry.getKey();
@@ -244,11 +260,7 @@ public class ProcessingNPCManager {
         
         if (orphanedCount > 0) {
             plugin.getLogger().warning("config.yml未登録の加工NPC: " + orphanedCount + "体");
-        } else {
-            plugin.getLogger().info("全ての加工NPCがconfig.ymlに登録されています");
         }
-        
-        plugin.getLogger().info("=== 加工NPC生成完了 ===");
     }
     
     /**
@@ -264,9 +276,6 @@ public class ProcessingNPCManager {
      * 加工NPCとのインタラクション処理
      */
     public boolean handleProcessingNPCInteraction(Player player, UUID npcId) {
-        plugin.getLogger().info("=== 加工NPC相互作用開始 ===");
-        plugin.getLogger().info("プレイヤー: " + player.getName() + ", NPC ID: " + npcId);
-        
         try {
             // NPC存在チェック
             if (!npcManager.isNPCEntity(npcId)) {
@@ -303,7 +312,6 @@ public class ProcessingNPCManager {
             
         } catch (Exception e) {
             plugin.getLogger().severe("加工NPC処理中に例外発生: " + e.getMessage());
-            e.printStackTrace();
             player.sendMessage("§c処理中にエラーが発生しました。");
             return true;
         }
@@ -391,7 +399,7 @@ public class ProcessingNPCManager {
             
             if (planksType != null) {
                 int logAmount = item.getAmount();
-                int planksAmount = logAmount * 4; // 原木1個→板材4個
+                int planksAmount = logAmount * planksPerLog; // 原木1個→板材planksPerLog個
                 
                 // 原木を削除
                 item.setAmount(0);
@@ -465,7 +473,7 @@ public class ProcessingNPCManager {
         }
         
         // インベントリ空き容量チェック（板材は原木の4倍になる）
-        int requiredSlots = (int) Math.ceil((actualQuantity * 4) / 64.0);
+        int requiredSlots = (int) Math.ceil((actualQuantity * planksPerLog) / 64.0);
         if (!hasEnoughInventorySpace(player, requiredSlots)) {
             return new ProcessingResult(false, configManager.getProcessingNPCMessage("inventory_full"), actualQuantity, 0, totalFee);
         }
@@ -496,7 +504,7 @@ public class ProcessingNPCManager {
                 item.setAmount(itemAmount - toProcess);
                 
                 // 板材を付与
-                int planksAmount = toProcess * 4;
+                int planksAmount = toProcess * planksPerLog;
                 ItemStack planks = new ItemStack(planksType, planksAmount);
                 player.getInventory().addItem(planks);
                 
@@ -540,7 +548,7 @@ public class ProcessingNPCManager {
     private int calculateRequiredSlots(Map<Material, Integer> logsToProcess) {
         int totalPlanks = 0;
         for (int logAmount : logsToProcess.values()) {
-            totalPlanks += logAmount * 4;
+            totalPlanks += logAmount * planksPerLog;
         }
         // 64個（1スタック）で割って切り上げ
         return (int) Math.ceil(totalPlanks / 64.0);
@@ -635,7 +643,6 @@ public class ProcessingNPCManager {
      * 加工NPCをリロード
      */
     public void reloadProcessingNPCs() {
-        plugin.getLogger().info("加工NPCをリロードしています...");
         removeProcessingNPCs();
         spawnProcessingNPCs();
         plugin.getLogger().info("加工NPCのリロードが完了しました");
@@ -648,24 +655,16 @@ public class ProcessingNPCManager {
      */
     public void registerProcessingNPC(UUID npcId, String id, String name, Location location) {
         try {
-            plugin.getLogger().info("=== 加工NPC即座登録開始 ===");
-            plugin.getLogger().info("  NPC UUID: " + npcId);
-            plugin.getLogger().info("  加工所ID: " + id);
-            plugin.getLogger().info("  NPC名: " + name);
-            
             // ProcessingStationオブジェクトを作成
             ProcessingStation station = new ProcessingStation(id, name, location, npcId);
-            
+
             // processingStationsマップに登録
             processingStations.put(id, station);
-            
-            plugin.getLogger().info("加工NPCを即座に登録完了: " + name + " (UUID: " + npcId + ")");
-            plugin.getLogger().info("登録済み加工所数: " + processingStations.size());
-            plugin.getLogger().info("=== 加工NPC即座登録完了 ===");
-            
+
+            plugin.getLogger().info("加工NPCを登録しました: " + name);
+
         } catch (Exception e) {
             plugin.getLogger().severe("加工NPC即座登録中にエラーが発生: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -673,8 +672,6 @@ public class ProcessingNPCManager {
      * 設定変更後に加工所データを再読み込み（NPCスポーン後の即座反映用）
      */
     public void reloadProcessingStations() {
-        plugin.getLogger().info("加工所データを再読み込みしています...");
-        
         // 現在の設定ファイルから加工所一覧を取得
         List<Map<?, ?>> configProcessingStations = configManager.getProcessingNPCConfigs();
         Set<String> configNPCNames = new HashSet<>();
@@ -694,18 +691,17 @@ public class ProcessingNPCManager {
         for (NPCManager.NPCData npcData : allNPCs) {
             if ("processing".equals(npcData.getNpcType()) && !configNPCNames.contains(npcData.getName())) {
                 npcToRemove.add(npcData);
-                plugin.getLogger().info("設定ファイルから削除されたNPCを除去: " + npcData.getName());
             }
         }
-        
+
         // 削除対象のNPCを除去
         for (NPCManager.NPCData npc : npcToRemove) {
             npcManager.removeNPC(npc.getEntityId());
         }
-        
+
         // processingStationsマップを更新（既存NPCは再スポーンしない）
         updateProcessingStationsFromConfig();
-        
+
         plugin.getLogger().info("加工所データの再読み込みが完了しました");
     }
     
@@ -713,26 +709,11 @@ public class ProcessingNPCManager {
      * 設定ファイルからprocessingStationsマップを更新（既存NPCは再スポーンしない）
      */
     private void updateProcessingStationsFromConfig() {
-        plugin.getLogger().info("=== 加工所マップ更新開始 ===");
-        
         // 既存の加工所データをクリア
         processingStations.clear();
-        
-        // デバッグ: 現在スポーンしている全NPCを確認
-        Collection<NPCManager.NPCData> allNPCs = npcManager.getAllNPCs();
-        plugin.getLogger().info("現在スポーン中のNPC総数: " + allNPCs.size());
-        int processingCount = 0;
-        for (NPCManager.NPCData npc : allNPCs) {
-            if ("processing".equals(npc.getNpcType())) {
-                processingCount++;
-                plugin.getLogger().info("  加工NPC: " + npc.getName() + " (UUID: " + npc.getEntityId() + ", タイプ: " + npc.getNpcType() + ")");
-            }
-        }
-        plugin.getLogger().info("加工NPCの数: " + processingCount);
-        
+
         List<Map<?, ?>> processingConfigs = configManager.getProcessingNPCConfigs();
-        plugin.getLogger().info("設定から " + processingConfigs.size() + " 個の加工所を読み込み");
-        
+
         for (Map<?, ?> config : processingConfigs) {
             try {
                 String id = (String) config.get("id");
@@ -760,36 +741,22 @@ public class ProcessingNPCManager {
                 }
                 
                 Location location = new Location(plugin.getServer().getWorld(world), x + 0.5, y, z + 0.5, yaw, pitch);
-                
-                plugin.getLogger().info("--- 加工所設定処理: " + name + " ---");
-                plugin.getLogger().info("  設定ID: " + id);
-                plugin.getLogger().info("  名前（色コード付き）: " + name);
-                plugin.getLogger().info("  名前（色コード除去）: " + org.bukkit.ChatColor.stripColor(name));
-                
+
                 // 既存のスポーン済みNPCを名前で検索
                 UUID npcId = findExistingProcessingNPCIdByName(name);
-                
+
                 if (npcId != null) {
                     // 既存NPCが見つかった場合、データのみ登録
                     ProcessingStation station = new ProcessingStation(id, name, location, npcId);
                     processingStations.put(id, station);
-                    
-                    plugin.getLogger().info("  ✓ 加工所データ登録成功: " + name + " (既存NPC UUID: " + npcId + ")");
                 } else {
-                    plugin.getLogger().warning("  ✗ 加工所 " + name + " に対応するNPCが見つかりません");
-                    plugin.getLogger().warning("  - config.ymlに設定はあるが、スポーン済みNPCが見つからない");
-                    plugin.getLogger().warning("  - NPCを手動削除した、またはワールドがロードされていない可能性");
-                    plugin.getLogger().warning("  - 解決方法1: /npc spawn processing コマンドで再作成");
-                    plugin.getLogger().warning("  - 解決方法2: config.ymlから該当の設定を削除");
+                    plugin.getLogger().warning("加工所 " + name + " に対応するNPCが見つかりません");
                 }
-                
+
             } catch (Exception e) {
                 plugin.getLogger().warning("加工所データ更新中にエラーが発生しました: " + e.getMessage());
-                e.printStackTrace();
             }
         }
-        
-        plugin.getLogger().info("=== 加工所マップ更新完了: " + processingStations.size() + "個 ===");
     }
     
     /**
@@ -799,28 +766,17 @@ public class ProcessingNPCManager {
         Collection<NPCManager.NPCData> allNPCs = npcManager.getAllNPCs();
         // 色コードを除去した検索名
         String searchName = org.bukkit.ChatColor.stripColor(name);
-        
-        plugin.getLogger().info("  加工NPCを検索中: " + name + " → " + searchName);
-        plugin.getLogger().info("  検索対象NPC総数: " + allNPCs.size());
-        
-        int matchAttempts = 0;
+
         for (NPCManager.NPCData npcData : allNPCs) {
             if ("processing".equals(npcData.getNpcType())) {
-                matchAttempts++;
                 // NPCの名前からも色コードを除去して比較
                 String npcName = org.bukkit.ChatColor.stripColor(npcData.getName());
-                plugin.getLogger().info("    比較 #" + matchAttempts + ": [" + npcData.getName() + "] → [" + npcName + "]");
-                
                 if (searchName.equals(npcName)) {
-                    plugin.getLogger().info("    ✓ マッチ成功！UUID: " + npcData.getEntityId());
                     return npcData.getEntityId();
-                } else {
-                    plugin.getLogger().info("    ✗ マッチ失敗: [" + searchName + "] != [" + npcName + "]");
                 }
             }
         }
-        
-        plugin.getLogger().warning("  検索結果: NPCが見つかりませんでした（" + matchAttempts + "個の加工NPCを確認）");
+
         return null;
     }
     

--- a/src/main/java/org/tofu/tofunomics/npc/ProcessingNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/ProcessingNPCManager.java
@@ -643,9 +643,17 @@ public class ProcessingNPCManager {
      * 加工NPCをリロード
      */
     public void reloadProcessingNPCs() {
+        initializeLogToPlanksMapping(); // config再読込でwood_types/planks_per_logを反映
         removeProcessingNPCs();
         spawnProcessingNPCs();
         plugin.getLogger().info("加工NPCのリロードが完了しました");
+    }
+
+    /**
+     * 原木1個あたりの板材産出数を取得（GUI表示用）
+     */
+    public int getPlanksPerLog() {
+        return planksPerLog;
     }
 
     

--- a/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
@@ -192,17 +192,13 @@ public class TradingNPCManager {
             plugin.getLogger().info("取引NPCシステムを初期化しました");
         } catch (Exception e) {
             plugin.getLogger().severe("取引NPCシステムの初期化中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
-    
+
     private void spawnTradingNPCs() {
-        plugin.getLogger().info("=== 取引NPC生成開始 ===");
-        
         // 既存の取引所データをクリア
         tradingPosts.clear();
-        plugin.getLogger().info("既存の取引所データをクリアしました");
-        
+
         // 現在スポーン中の全NPCを取得（座標ベースでの重複チェック用）
         Collection<NPCManager.NPCData> allNPCs = npcManager.getAllNPCs();
         Map<String, UUID> existingNPCsByLocation = new HashMap<>();
@@ -219,12 +215,9 @@ public class TradingNPCManager {
                 existingNPCsNameByLocation.put(locationKey, npc.getName());
             }
         }
-        
-        plugin.getLogger().info("既存の取引NPC数: " + existingNPCsByLocation.size());
-        
+
         List<Map<?, ?>> tradingPostConfigs = configManager.getTradingPostConfigs();
-        plugin.getLogger().info("設定から " + tradingPostConfigs.size() + " 個の取引所を読み込み");
-        
+
         // config.ymlに記載されている座標を記録（警告用）
         Set<String> configLocationKeys = new HashSet<>();
         
@@ -292,12 +285,10 @@ public class TradingNPCManager {
                     
                     if (existingNPC != null) {
                         tradingNPC = existingNPC.getEntity();
-                        plugin.getLogger().info("既存の取引NPCを再利用: " + name + " (UUID: " + npcId + ")");
-                        
+
                         // 名前が変更されている場合は更新
                         if (!name.equals(existingNPC.getName())) {
                             tradingNPC.setCustomName(name);
-                            plugin.getLogger().info("  NPC名を更新: " + existingNPC.getName() + " -> " + name);
                         }
                     } else {
                         // NPCDataが見つからない場合は新規作成
@@ -313,9 +304,8 @@ public class TradingNPCManager {
                     }
                 } else {
                     // 新規作成
-                    plugin.getLogger().info("取引NPCを新規生成中: " + name + " at [" + x + ", " + y + ", " + z + "]");
                     tradingNPC = npcManager.createNPC(location, "trader", name);
-                    
+
                     if (tradingNPC != null) {
                         npcId = tradingNPC.getUniqueId();
                         setupTradingNPC(tradingNPC);
@@ -367,12 +357,6 @@ public class TradingNPCManager {
                         }
                     }
                     
-                    plugin.getLogger().info("  緊急モード設定: " + emergencyMode);
-                    if (emergencyMode) {
-                        plugin.getLogger().info("    価格倍率: " + emergencyPriceMultiplier);
-                        plugin.getLogger().info("    対象アイテム数: " + emergencyItemNames.size());
-                    }
-                    
                     // 緊急アイテムリストをMaterialに変換
                     List<Material> emergencyItems = new ArrayList<>();
                     for (String itemName : emergencyItemNames) {
@@ -383,27 +367,19 @@ public class TradingNPCManager {
                             plugin.getLogger().warning("無効な緊急アイテム名: " + itemName);
                         }
                     }
-                    
+
                     TradingPost tradingPost = new TradingPost(id, name, location, acceptedJobs, items, prices, purchasePrices, npcId,
                         emergencyMode, emergencyPriceMultiplier, emergencyItems);
                 tradingPosts.put(id, tradingPost);
-                
-                plugin.getLogger().info("========================================");
-                plugin.getLogger().info("取引所登録成功:");
-                plugin.getLogger().info("  名前: " + name);
-                plugin.getLogger().info("  ID: " + id);
-                plugin.getLogger().info("  UUID: " + npcId);
-                plugin.getLogger().info("  座標: [" + x + ", " + y + ", " + z + "]");
-                plugin.getLogger().info("========================================");
-                
+
+                plugin.getLogger().info("取引所を登録しました: " + name + " [" + x + ", " + y + ", " + z + "]");
+
             } catch (Exception e) {
                 plugin.getLogger().warning("取引NPC処理中にエラーが発生しました: " + e.getMessage());
-                e.printStackTrace();
             }
         }
-        
+
         // config.ymlに記載されていないNPCを検出して警告
-        plugin.getLogger().info("=== config.yml未登録NPCチェック ===");
         int orphanedCount = 0;
         for (Map.Entry<String, UUID> entry : existingNPCsByLocation.entrySet()) {
             String locationKey = entry.getKey();
@@ -418,11 +394,7 @@ public class TradingNPCManager {
         
         if (orphanedCount > 0) {
             plugin.getLogger().warning("config.yml未登録の取引NPC: " + orphanedCount + "体");
-        } else {
-            plugin.getLogger().info("全ての取引NPCがconfig.ymlに登録されています");
         }
-        
-        plugin.getLogger().info("=== 取引NPC生成完了 ===");
     }
     
     private void setupTradingNPC(Villager npc) {
@@ -432,94 +404,62 @@ public class TradingNPCManager {
     }
     
     private Map<Material, Double> buildItemPrices(List<String> acceptedJobs, List<String> allowedItems) {
-        plugin.getLogger().info("[TradingNPCManager] buildItemPrices() 開始");
-        plugin.getLogger().info("[TradingNPCManager] acceptedJobs: " + acceptedJobs);
-        
         Map<Material, Double> prices = new HashMap<>();
         Map<String, Double> basePrices = configManager.getItemBasePrices();
-        
+
         for (Map.Entry<String, Double> entry : basePrices.entrySet()) {
             String itemName = entry.getKey();
-            
+
             // allowedItemsが指定されている場合は、そのリストに含まれるアイテムのみ処理
             if (allowedItems != null && !allowedItems.isEmpty() && !allowedItems.contains(itemName)) {
                 continue;
             }
-            
+
             try {
                 Material material = Material.valueOf(itemName.toUpperCase());
                 double basePrice = entry.getValue();
-                
+
                 // 基本価格をそのまま保存（職業倍率は売却時に適用）
                 prices.put(material, basePrice);
-                
-                // oak_logの価格を明示的にログ出力
-                if ("oak_log".equals(itemName.toLowerCase())) {
-                    plugin.getLogger().info("[TradingNPCManager] oak_log price set to: " + basePrice);
-                }
             } catch (IllegalArgumentException e) {
                 plugin.getLogger().warning("無効なマテリアル名です: " + itemName);
             }
         }
-        
-        // 最終的なマップの内容を確認
-        plugin.getLogger().info("[TradingNPCManager] buildItemPrices() 完了 - 登録アイテム数: " + prices.size());
-        if (prices.containsKey(Material.OAK_LOG)) {
-            plugin.getLogger().info("[TradingNPCManager] OAK_LOG price in map: " + prices.get(Material.OAK_LOG));
-        }
-        
+
         return prices;
     }
     
     public boolean handleTradingNPCInteraction(Player player, UUID npcId) {
-        plugin.getLogger().info("=== 取引NPC相互作用開始 ===");
-        plugin.getLogger().info("プレイヤー: " + player.getName() + ", NPC ID: " + npcId);
-        
         try {
             // Step 1: NPC存在チェック
             if (!npcManager.isNPCEntity(npcId)) {
                 plugin.getLogger().warning("NPCエンティティが見つかりません: " + npcId);
                 return false;
             }
-            plugin.getLogger().info("Step 1: NPCエンティティチェック - 成功");
-            
+
             // Step 2: NPCデータ取得
             NPCManager.NPCData npcData = npcManager.getNPCData(npcId);
             if (npcData == null || !npcData.getNpcType().equals("trader")) {
                 plugin.getLogger().warning("取引NPCデータが見つかりません: " + npcId);
                 return false;
             }
-            plugin.getLogger().info("Step 2: NPCデータ取得 - 成功 (" + npcData.getName() + ")");
-            
+
             // Step 3: 取引所データ取得
-            plugin.getLogger().info("=== 取引所データ検索開始 ===");
-            plugin.getLogger().info("検索対象NPC UUID: " + npcId);
-            plugin.getLogger().info("登録済み取引所数: " + tradingPosts.size());
-            
-            // デバッグ：登録済み取引所のUUID一覧
-            for (Map.Entry<String, TradingPost> entry : tradingPosts.entrySet()) {
-                plugin.getLogger().info("  取引所[" + entry.getKey() + "]: NPC UUID=" + entry.getValue().getNpcId());
-            }
-            
             TradingPost tradingPost = getTradingPostByNPCId(npcId);
             if (tradingPost == null) {
-                plugin.getLogger().warning("取引所データが見つかりません: " + npcId);
-                plugin.getLogger().warning("NPCの名前: " + npcData.getName());
-                
                 // 位置情報での検索を試みる
                 tradingPost = findTradingPostByLocation(npcData.getLocation());
                 if (tradingPost != null) {
-                    plugin.getLogger().info("位置情報で取引所を発見: " + tradingPost.getName());
                     // UUIDを更新してデータを同期
                     updateTradingPostNPCId(tradingPost, npcId);
                 } else {
                     // 名前での検索を試みる
                     tradingPost = findTradingPostByName(npcData.getName());
                     if (tradingPost != null) {
-                        plugin.getLogger().info("名前で取引所を発見: " + tradingPost.getName());
                         // UUIDを更新してデータを同期
                         updateTradingPostNPCId(tradingPost, npcId);
                     } else {
+                        plugin.getLogger().warning("取引所データが見つかりません: " + npcId + " (" + npcData.getName() + ")");
                         player.sendMessage("§c取引所の情報を読み込めませんでした。");
                         player.sendMessage("§e管理者に以下の情報をお伝えください:");
                         player.sendMessage("§7NPC UUID: " + npcId);
@@ -528,20 +468,15 @@ public class TradingNPCManager {
                     }
                 }
             }
-            plugin.getLogger().info("Step 3: 取引所データ取得 - 成功 (" + tradingPost.getName() + ")");
-            
+
             // Step 3.5: 営業時間チェック（emergency_mode対応）
             if (!isWithinTradingHours(player, tradingPost)) {
                 player.sendMessage(configManager.getMessage("npc.trading.outside_hours"));
                 return true;
             }
-            plugin.getLogger().info("Step 3.5: 営業時間チェック - 営業時間内");
-            
-            // Step 4: 権限チェック（基本的にすべて許可）
-            boolean hasPermission = hasPermissionToUseTradingNPC(player);
-            plugin.getLogger().info("Step 4: 権限チェック - " + (hasPermission ? "許可" : "拒否"));
 
-            if (!hasPermission) {
+            // Step 4: 権限チェック（基本的にすべて許可）
+            if (!hasPermissionToUseTradingNPC(player)) {
                 player.sendMessage("§c取引NPCを利用する権限がありません。");
                 return true;
             }
@@ -551,38 +486,21 @@ public class TradingNPCManager {
             player.sendMessage(greetingMessage);
 
             // 取引サービスGUIを開く
-            boolean guiOpened = openTradingServiceGUI(player, tradingPost, npcData);
-            
-            plugin.getLogger().info("プレイヤー " + player.getName() + " が取引NPC " + tradingPost.getName() + " と取引しました");
+            openTradingServiceGUI(player, tradingPost, npcData);
+
             return true;
-            
+
         } catch (Exception e) {
-            plugin.getLogger().severe("=== 取引NPC処理中に例外発生 ===");
-            plugin.getLogger().severe("プレイヤー: " + player.getName());
-            plugin.getLogger().severe("NPC ID: " + npcId);
-            plugin.getLogger().severe("例外メッセージ: " + e.getMessage());
-            plugin.getLogger().severe("例外クラス: " + e.getClass().getSimpleName());
+            plugin.getLogger().severe("取引NPC処理中に例外発生: " + e.getMessage());
             player.sendMessage("§c処理中にエラーが発生しました。管理者にお知らせください。");
-            e.printStackTrace();
             return true;
         }
     }
-    
+
     private boolean hasPermissionToUseTradingNPC(Player player) {
-        boolean hasNPCUse = player.hasPermission("tofunomics.npc.trading.use");
-        boolean hasTradeBasic = player.hasPermission("tofunomics.trade.basic");
-        
-        plugin.getLogger().info("権限詳細チェック - プレイヤー: " + player.getName());
-        plugin.getLogger().info("  tofunomics.npc.trading.use: " + hasNPCUse);
-        plugin.getLogger().info("  tofunomics.trade.basic: " + hasTradeBasic);
-        plugin.getLogger().info("  OP権限: " + player.isOp());
-        
         // 無職状態でもNPCとの基本相互作用は可能とする（職業チェックメッセージ表示まで）
         // 権限チェックは実際の取引時に行う
-        boolean result = true; // 基本的にすべてのプレイヤーにNPCアクセスを許可
-        plugin.getLogger().info("  最終権限判定: " + result + " (基本アクセス許可)");
-        
-        return result;
+        return true; // 基本的にすべてのプレイヤーにNPCアクセスを許可
     }
     
     /**
@@ -604,38 +522,18 @@ public class TradingNPCManager {
     }
     
     private boolean openTradingServiceGUI(Player player, TradingPost tradingPost, NPCManager.NPCData npcData) {
-        plugin.getLogger().info("Step 5: GUI表示処理開始");
-        plugin.getLogger().info("  プレイヤー: " + player.getName());
-        plugin.getLogger().info("  取引所: " + tradingPost.getName());
-        plugin.getLogger().info("  NPC: " + npcData.getName());
-        
         try {
             // まず営業時間チェック（遅延前に実行）
             if (!isWithinTradingHours(player, tradingPost)) {
-                plugin.getLogger().info("営業時間外のため処理中断");
                 int startHour = configManager.getTradingStartHour();
                 int endHour = configManager.getTradingEndHour();
                 player.sendMessage("§c申し訳ありません。営業時間は" + startHour + ":00~" + endHour + ":00です。");
                 return false;
             }
-            plugin.getLogger().info("営業時間チェック: OK");
-            
-            // 職業チェック（ログ出力のみ、制限はしない）
-            String playerJob = jobManager.getPlayerJob(player.getUniqueId());
-            plugin.getLogger().info("職業チェック: " + (playerJob != null ? playerJob : "無職"));
 
-            // 購入は全職業可能、売却時のみ職業制限を適用（TradingGUI側で処理）
-            boolean isMatchingJob = tradingPost.isMatchingJob(playerJob);
-            if (!isMatchingJob) {
-                plugin.getLogger().info("別職業または無職です（購入は可能、売却は制限）");
-            } else {
-                plugin.getLogger().info("対応職業です（購入・売却ともに可能）");
-            }
-            
             // TradingGUIインスタンスの確認
-            plugin.getLogger().info("TradingGUIインスタンス確認中...");
             org.tofu.tofunomics.npc.gui.TradingGUI tradingGUI = plugin.getTradingGUI();
-            
+
             if (tradingGUI == null) {
                 plugin.getLogger().severe("TradingGUIがnullです！初期化に失敗している可能性があります");
                 player.sendMessage("§c取引システムの初期化に失敗しています。");
@@ -644,47 +542,35 @@ public class TradingNPCManager {
                 showTradingMenu(player, tradingPost);
                 return false;
             }
-            plugin.getLogger().info("TradingGUIインスタンス確認: OK");
-            
+
             // 遅延してからTradingGUIを開く
             int delayTicks = configManager.getNPCGUIDelayTicks();
-            plugin.getLogger().info("GUI表示を" + delayTicks + "tick遅延実行します");
-            
+
             plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
-                plugin.getLogger().info("=== 遅延実行開始 ===");
-                
                 // プレイヤーがまだオンラインかチェック
                 if (!player.isOnline()) {
-                    plugin.getLogger().info("プレイヤー " + player.getName() + " がオフラインのため、GUIを開きませんでした");
                     return;
                 }
-                plugin.getLogger().info("プレイヤーオンラインチェック: OK");
-                
+
                 // NPCの近くにいるかチェック
                 if (!isPlayerNearNPC(player, npcData)) {
-                    plugin.getLogger().info("プレイヤー " + player.getName() + " がNPCから離れたため、GUIを開きませんでした");
                     player.sendMessage("§cNPCから離れすぎています。");
                     return;
                 }
-                plugin.getLogger().info("NPC距離チェック: OK");
-                
+
                 // 営業時間内か再チェック（念のため）
                 if (!isWithinTradingHours(player, tradingPost)) {
-                    plugin.getLogger().info("営業時間外のため、GUIを開きませんでした");
                     int startHour = configManager.getTradingStartHour();
                     int endHour = configManager.getTradingEndHour();
                     player.sendMessage("§c申し訳ありません。営業時間は" + startHour + ":00~" + endHour + ":00です。");
                     return;
                 }
-                plugin.getLogger().info("営業時間再チェック: OK");
-                
+
                 // モード選択GUIを開く
-                plugin.getLogger().info("TradingModeSelectionGUI.openModeSelectionGUI()を呼び出します");
                 try {
                     org.tofu.tofunomics.npc.gui.TradingModeSelectionGUI modeSelectionGUI = plugin.getTradingModeSelectionGUI();
                     if (modeSelectionGUI != null) {
                         modeSelectionGUI.openModeSelectionGUI(player, tradingPost);
-                        plugin.getLogger().info("TradingModeSelectionGUI.openModeSelectionGUI()の呼び出し完了");
                     } else {
                         // フォールバック: 直接売却モードで開く
                         plugin.getLogger().warning("TradingModeSelectionGUI が初期化されていません。直接TradingGUIを開きます。");
@@ -694,20 +580,16 @@ public class TradingNPCManager {
                     plugin.getLogger().severe("TradingGUI表示中にエラーが発生: " + e.getMessage());
                     player.sendMessage("§c取引画面の表示中にエラーが発生しました。");
                     player.sendMessage("§e管理者にお知らせください。");
-                    e.printStackTrace();
                 }
             }, delayTicks);
-            
+
             // 遅延実行が開始されたのでtrueを返す
             return true;
-            
+
         } catch (Exception e) {
             plugin.getLogger().severe("取引GUI開起中にエラーが発生しました: " + e.getMessage());
-            plugin.getLogger().severe("エラー発生場所: TradingNPCManager.openTradingServiceGUI");
-            plugin.getLogger().severe("プレイヤー: " + player.getName() + ", 取引所: " + tradingPost.getName());
             player.sendMessage("§c取引画面の表示でエラーが発生しました。");
             player.sendMessage("§e再度お試しいただくか、管理者にお知らせください。");
-            e.printStackTrace();
             return false;
         }
     }
@@ -766,8 +648,6 @@ public class TradingNPCManager {
 
     // スペースチェックスキップオプション付きのアイテム売却処理
     public TradeResult processItemSale(Player player, UUID npcId, List<ItemStack> items, boolean skipSpaceCheck) {
-        plugin.getLogger().info("[TradingNPCManager] processItemSale called with skipSpaceCheck: " + skipSpaceCheck);
-        
         TradingPost tradingPost = getTradingPostByNPCId(npcId);
         if (tradingPost == null) {
             return new TradeResult(false, "取引所が見つかりません", 0.0, new HashMap<>());
@@ -808,8 +688,6 @@ public class TradingNPCManager {
         }
         
         if (totalEarnings > 0) {
-            plugin.getLogger().info("[TradingNPCManager] Calling receiveCash with totalEarnings: " + totalEarnings + ", skipSpaceCheck: " + skipSpaceCheck);
-            
             // インベントリに金塊として支払い（スペースチェックスキップオプション付き）
             if (!currencyConverter.receiveCash(player, totalEarnings, skipSpaceCheck)) {
                 return new TradeResult(false, "インベントリに空きがありません。金塊を受け取るスペースを確保してください", 0.0, new HashMap<>());
@@ -909,22 +787,16 @@ public class TradingNPCManager {
     }
     
     public void reloadTradingNPCs() {
-        plugin.getLogger().info("取引NPCをリロードしています...");
         removeTradingNPCs();
         spawnTradingNPCs();
         plugin.getLogger().info("取引NPCのリロードが完了しました");
     }
-    
+
     /**
      * 取引所のNPC UUIDを更新（リカバリー機能）
      */
     private void updateTradingPostNPCId(TradingPost tradingPost, UUID newNpcId) {
-        UUID oldNpcId = tradingPost.getNpcId();
         tradingPost.setNpcId(newNpcId);
-        plugin.getLogger().info("取引所のNPC UUIDを更新:");
-        plugin.getLogger().info("  取引所: " + tradingPost.getName());
-        plugin.getLogger().info("  旧UUID: " + oldNpcId);
-        plugin.getLogger().info("  新UUID: " + newNpcId);
     }
     
     /**
@@ -951,8 +823,6 @@ public class TradingNPCManager {
      * 設定変更後に取引所データを再読み込み（NPCスポーン後の即座反映用）
      */
     public void reloadTradingPosts() {
-        plugin.getLogger().info("取引所データを再読み込みしています...");
-        
         // 現在の設定ファイルから取引所一覧を取得
         List<Map<?, ?>> configTradingPosts = configManager.getTradingPostConfigs();
         Set<String> configNPCNames = new HashSet<>();
@@ -972,18 +842,17 @@ public class TradingNPCManager {
         for (NPCManager.NPCData npcData : allNPCs) {
             if ("trader".equals(npcData.getNpcType()) && !configNPCNames.contains(npcData.getName())) {
                 npcToRemove.add(npcData);
-                plugin.getLogger().info("設定ファイルから削除されたNPCを除去: " + npcData.getName());
             }
         }
-        
+
         // 削除対象のNPCを除去
         for (NPCManager.NPCData npc : npcToRemove) {
             npcManager.removeNPC(npc.getEntityId());
         }
-        
+
         // tradingPostsマップを更新（既存NPCは再スポーンしない）
         updateTradingPostsFromConfig();
-        
+
         plugin.getLogger().info("取引所データの再読み込みが完了しました");
     }
 
@@ -994,34 +863,25 @@ public class TradingNPCManager {
      */
     public void registerTradingNPC(UUID npcId, String id, String name, Location location, List<String> acceptedJobs) {
         try {
-            plugin.getLogger().info("=== 取引NPC即座登録開始 ===");
-            plugin.getLogger().info("  NPC UUID: " + npcId);
-            plugin.getLogger().info("  取引所ID: " + id);
-            plugin.getLogger().info("  NPC名: " + name);
-            plugin.getLogger().info("  受け入れ職業: " + String.join(", ", acceptedJobs));
-            
             // アイテムリストは空（全アイテム対応）
             List<String> items = new ArrayList<>();
-            
+
             // アイテム価格を構築
             Map<Material, Double> prices = buildItemPrices(acceptedJobs, items);
-            
+
             // 購入価格は空（コマンドで作成時は購入不可）
             Map<Material, Double> purchasePrices = new HashMap<>();
-            
+
             // TradingPostオブジェクトを作成
             TradingPost tradingPost = new TradingPost(id, name, location, acceptedJobs, items, prices, purchasePrices, npcId);
-            
+
             // tradingPostsマップに登録
             tradingPosts.put(id, tradingPost);
-            
-            plugin.getLogger().info("取引NPCを即座に登録完了: " + name + " (UUID: " + npcId + ")");
-            plugin.getLogger().info("登録済み取引所数: " + tradingPosts.size());
-            plugin.getLogger().info("=== 取引NPC即座登録完了 ===");
-            
+
+            plugin.getLogger().info("取引NPCを登録しました: " + name);
+
         } catch (Exception e) {
             plugin.getLogger().severe("取引NPC即座登録中にエラーが発生: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -1029,26 +889,11 @@ public class TradingNPCManager {
      * 設定ファイルからtradingPostsマップを更新（既存NPCは再スポーンしない）
      */
     private void updateTradingPostsFromConfig() {
-        plugin.getLogger().info("=== 取引所マップ更新開始 ===");
-        
         // 既存の取引所データをクリア
         tradingPosts.clear();
-        
-        // デバッグ: 現在スポーンしている全NPCを確認
-        Collection<NPCManager.NPCData> allNPCs = npcManager.getAllNPCs();
-        plugin.getLogger().info("現在スポーン中のNPC総数: " + allNPCs.size());
-        int traderCount = 0;
-        for (NPCManager.NPCData npc : allNPCs) {
-            if ("trader".equals(npc.getNpcType())) {
-                traderCount++;
-                plugin.getLogger().info("  取引NPC: " + npc.getName() + " (UUID: " + npc.getEntityId() + ", タイプ: " + npc.getNpcType() + ")");
-            }
-        }
-        plugin.getLogger().info("取引NPCの数: " + traderCount);
-        
+
         List<Map<?, ?>> tradingPostConfigs = configManager.getTradingPostConfigs();
-        plugin.getLogger().info("設定から " + tradingPostConfigs.size() + " 個の取引所を読み込み");
-        
+
         for (Map<?, ?> config : tradingPostConfigs) {
             try {
                 String id = (String) config.get("id");
@@ -1097,12 +942,7 @@ public class TradingNPCManager {
                 }
                 
                 Location location = new Location(plugin.getServer().getWorld(world), x + 0.5, y, z + 0.5, yaw, pitch);
-                
-                plugin.getLogger().info("--- 取引所設定処理: " + name + " ---");
-                plugin.getLogger().info("  設定ID: " + id);
-                plugin.getLogger().info("  名前（色コード付き）: " + name);
-                plugin.getLogger().info("  名前（色コード除去）: " + org.bukkit.ChatColor.stripColor(name));
-                
+
                 // 既存のスポーン済みNPCを名前で検索
                 UUID npcId = findExistingNPCIdByName(name);
                 
@@ -1151,12 +991,6 @@ public class TradingNPCManager {
                         }
                     }
                     
-                    plugin.getLogger().info("  緊急モード設定: " + emergencyMode);
-                    if (emergencyMode) {
-                        plugin.getLogger().info("    価格倍率: " + emergencyPriceMultiplier);
-                        plugin.getLogger().info("    対象アイテム数: " + emergencyItemNames.size());
-                    }
-                    
                     // 緊急アイテムリストをMaterialに変換
                     List<Material> emergencyItems = new ArrayList<>();
                     for (String itemName : emergencyItemNames) {
@@ -1167,27 +1001,18 @@ public class TradingNPCManager {
                             plugin.getLogger().warning("無効な緊急アイテム名: " + itemName);
                         }
                     }
-                    
+
                     TradingPost tradingPost = new TradingPost(id, name, location, acceptedJobs, items, prices, purchasePrices, npcId,
                         emergencyMode, emergencyPriceMultiplier, emergencyItems);
                     tradingPosts.put(id, tradingPost);
-                    
-                    plugin.getLogger().info("  ✓ 取引所データ登録成功: " + name + " (既存NPC UUID: " + npcId + ")");
                 } else {
-                    plugin.getLogger().warning("  ✗ 取引所 " + name + " に対応するNPCが見つかりません");
-                    plugin.getLogger().warning("  - config.ymlに設定はあるが、スポーン済みNPCが見つからない");
-                    plugin.getLogger().warning("  - NPCを手動削除した、またはワールドがロードされていない可能性");
-                    plugin.getLogger().warning("  - 解決方法1: /npc spawn trader コマンドで再作成");
-                    plugin.getLogger().warning("  - 解決方法2: config.ymlから該当の設定を削除");
+                    plugin.getLogger().warning("取引所 " + name + " に対応するNPCが見つかりません");
                 }
-                
+
             } catch (Exception e) {
                 plugin.getLogger().warning("取引所データ更新中にエラーが発生しました: " + e.getMessage());
-                e.printStackTrace();
             }
         }
-        
-        plugin.getLogger().info("=== 取引所マップ更新完了: " + tradingPosts.size() + "個 ===");
     }
     
     /**
@@ -1197,28 +1022,17 @@ public class TradingNPCManager {
         Collection<NPCManager.NPCData> allNPCs = npcManager.getAllNPCs();
         // 色コードを除去した検索名
         String searchName = org.bukkit.ChatColor.stripColor(name);
-        
-        plugin.getLogger().info("  NPCを検索中: " + name + " → " + searchName);
-        plugin.getLogger().info("  検索対象NPC総数: " + allNPCs.size());
-        
-        int matchAttempts = 0;
+
         for (NPCManager.NPCData npcData : allNPCs) {
             if ("trader".equals(npcData.getNpcType())) {
-                matchAttempts++;
                 // NPCの名前からも色コードを除去して比較
                 String npcName = org.bukkit.ChatColor.stripColor(npcData.getName());
-                plugin.getLogger().info("    比較 #" + matchAttempts + ": [" + npcData.getName() + "] → [" + npcName + "]");
-                
                 if (searchName.equals(npcName)) {
-                    plugin.getLogger().info("    ✓ マッチ成功！UUID: " + npcData.getEntityId());
                     return npcData.getEntityId();
-                } else {
-                    plugin.getLogger().info("    ✗ マッチ失敗: [" + searchName + "] != [" + npcName + "]");
                 }
             }
         }
-        
-        plugin.getLogger().warning("  検索結果: NPCが見つかりませんでした（" + matchAttempts + "個の取引NPCを確認）");
+
         return null;
     }
     
@@ -1231,7 +1045,6 @@ public class TradingNPCManager {
             String playerJob = jobManager.getPlayerJob(player.getUniqueId());
             // 取引可能職業のチェック
             if (!tradingPost.acceptsJob(playerJob)) {
-                plugin.getLogger().info("職業不対応: " + playerJob);
                 String npcType = getNPCTypeFromTradingPost(tradingPost);
                 String acceptedJobsStr = String.join(", ", tradingPost.getAcceptedJobTypes());
                 configManager.sendNPCSpecificMessageList(player, npcType, "job_not_accepted", 
@@ -1259,7 +1072,6 @@ public class TradingNPCManager {
         } catch (Exception e) {
             plugin.getLogger().severe("取引メニュー表示中にエラーが発生しました: " + e.getMessage());
             player.sendMessage("§c取引情報の表示でエラーが発生しました。");
-            e.printStackTrace();
         }
     }
     
@@ -1268,8 +1080,6 @@ public class TradingNPCManager {
      */
     private boolean isPlayerNearNPC(Player player, NPCManager.NPCData npcData) {
         try {
-            plugin.getLogger().info("距離チェック開始: プレイヤー=" + player.getName() + ", NPC=" + npcData.getName());
-            
             // NPCエンティティを取得
             Villager npcEntity = null;
             for (Villager villager : player.getWorld().getEntitiesByClass(Villager.class)) {
@@ -1278,26 +1088,19 @@ public class TradingNPCManager {
                     break;
                 }
             }
-            
+
             if (npcEntity == null) {
-                plugin.getLogger().warning("NPCエンティティが見つかりませんでした: " + npcData.getName());
                 return false; // NPCが見つからない場合
             }
-            
+
             // 距離をチェック（設定可能な範囲内）
             double distance = player.getLocation().distance(npcEntity.getLocation());
             int accessRange = configManager.getNPCAccessRange();
-            
-            plugin.getLogger().info("距離チェック結果: 距離=" + String.format("%.2f", distance) + "ブロック, 許容範囲=" + accessRange + "ブロック");
-            
-            boolean isNear = distance <= accessRange;
-            plugin.getLogger().info("距離チェック判定: " + (isNear ? "範囲内" : "範囲外"));
-            
-            return isNear;
-            
+
+            return distance <= accessRange;
+
         } catch (Exception e) {
             plugin.getLogger().warning("プレイヤーとNPCの距離チェック中にエラーが発生: " + e.getMessage());
-            e.printStackTrace();
             return false; // エラーの場合は安全のためfalseを返す
         }
     }
@@ -1309,33 +1112,26 @@ public class TradingNPCManager {
     private boolean isWithinTradingHours(Player player, TradingPost tradingPost) {
         // 緊急モードの場合は常に営業時間内として扱う
         if (tradingPost != null && tradingPost.isEmergencyMode()) {
-            plugin.getLogger().info("緊急モードNPCのため、営業時間チェックをスキップ");
             return true;
         }
-        
+
         if (!configManager.isTradingHoursEnabled()) {
             return true;
         }
-        
+
         // 現在の時間を取得（プレイヤーがいるワールドのMinecraft時間）
         long worldTime = player.getWorld().getTime();
         // 正しいMinecraft時間計算: 0=朝6:00, 6000=正午12:00, 12000=夕方18:00, 18000=深夜0:00
         int currentHour = (int) (((worldTime + 6000) / 1000) % 24);
-        
+
         int startHour = configManager.getTradingStartHour();
         int endHour = configManager.getTradingEndHour();
-        
-        plugin.getLogger().info("営業時間チェック - worldTime: " + worldTime + ", 現在時刻: " + currentHour + ":00, 営業時間: " + startHour + ":00-" + endHour + ":00");
-        
+
         if (startHour <= endHour) {
-            boolean result = currentHour >= startHour && currentHour < endHour;
-            plugin.getLogger().info("営業時間判定結果: " + result);
-            return result;
+            return currentHour >= startHour && currentHour < endHour;
         } else {
             // 日をまたぐ場合
-            boolean result = currentHour >= startHour || currentHour < endHour;
-            plugin.getLogger().info("営業時間判定結果（日またぎ): " + result);
-            return result;
+            return currentHour >= startHour || currentHour < endHour;
         }
     }
 }

--- a/src/main/java/org/tofu/tofunomics/npc/gui/BankGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/BankGUI.java
@@ -74,13 +74,12 @@ public class BankGUI implements Listener {
             
             activeSessions.put(player.getUniqueId(), session);
             player.openInventory(gui);
-            
+
             plugin.getLogger().info("銀行GUIを開きました: " + player.getName() + " -> " + npcData.getName());
-            
+
         } catch (Exception e) {
             plugin.getLogger().severe("銀行GUI作成中にエラーが発生しました: " + e.getMessage());
             player.sendMessage(configManager.getMessage("npc.bank.gui_error"));
-            e.printStackTrace();
         }
     }
     
@@ -182,11 +181,13 @@ public class BankGUI implements Listener {
         );
         gui.setItem(26, closeItem);
         
-        // 装飾アイテム
-        ItemStack glassPane = createGUIItem(Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
-        int[] decorationSlots = {0, 1, 2, 3, 5, 6, 7, 8, 9, 10, 12, 14, 16, 17, 18, 20, 23, 24, 25};
-        for (int slot : decorationSlots) {
-            gui.setItem(slot, glassPane);
+        // 装飾アイテム（銀行テーマ: 水色ガラス。無効時は装飾なし）
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glassPane = createGUIItem(Material.LIGHT_BLUE_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            int[] decorationSlots = {0, 1, 2, 3, 5, 6, 7, 8, 9, 10, 12, 14, 16, 17, 18, 20, 23, 24, 25};
+            for (int slot : decorationSlots) {
+                gui.setItem(slot, glassPane);
+            }
         }
     }
     
@@ -229,7 +230,6 @@ public class BankGUI implements Listener {
         } catch (Exception e) {
             plugin.getLogger().severe("銀行GUIクリック処理中にエラーが発生しました: " + e.getMessage());
             player.sendMessage(configManager.getMessage("npc.bank.action_error"));
-            e.printStackTrace();
         }
     }
     
@@ -511,10 +511,7 @@ public class BankGUI implements Listener {
         Player player = (Player) event.getPlayer();
         UUID playerId = player.getUniqueId();
         
-        BankGUISession session = activeSessions.remove(playerId);
-        if (session != null) {
-            plugin.getLogger().info("銀行GUIを閉じました: " + player.getName());
-        }
+        activeSessions.remove(playerId);
     }
     
     public void closeAllGUIs() {

--- a/src/main/java/org/tofu/tofunomics/npc/gui/FoodGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/FoodGUI.java
@@ -93,7 +93,6 @@ public class FoodGUI implements Listener {
         } catch (Exception e) {
             plugin.getLogger().severe("食料GUI作成中にエラーが発生しました: " + e.getMessage());
             player.sendMessage("§cGUIの作成に失敗しました。管理者にお知らせください。");
-            e.printStackTrace();
         }
     }
     
@@ -147,8 +146,7 @@ public class FoodGUI implements Listener {
     private void setupFoodItems(Inventory gui, Player player, UUID npcId) {
         // 常に設定ファイルから商品リストを取得
         Map<Material, Double> itemPrices = getCurrentFoodPrices(npcId);
-        plugin.getLogger().info("FoodGUI: 商品データ取得完了 - 商品数: " + itemPrices.size());
-        
+
         Map<Material, Integer> storeInventory = foodNPCManager.getStoreInventory(npcId);
         Map<Material, Integer> playerPurchases = foodNPCManager.getPlayerDailyPurchases(player.getUniqueId());
         int dailyLimit = configManager.getFoodNPCDailyLimitPerItem();
@@ -258,9 +256,7 @@ public class FoodGUI implements Listener {
     private String getNPCType(UUID npcId) {
         FoodNPCManager.FoodStore foodStore = foodNPCManager.getFoodStore(npcId);
         if (foodStore != null) {
-            String npcType = foodStore.getNpcType();
-            plugin.getLogger().info("FoodGUI: NPCタイプ取得 - NPC ID: " + npcId + ", タイプ: " + npcType);
-            return npcType;
+            return foodStore.getNpcType();
         }
         plugin.getLogger().warning("FoodGUI: FoodStoreが見つかりません - NPC ID: " + npcId + ", デフォルトタイプを使用");
         return "general_store"; // フォールバック
@@ -401,7 +397,6 @@ public class FoodGUI implements Listener {
         
         if (session != null && event.getInventory().equals(session.getInventory())) {
             activeSessions.remove(player.getUniqueId());
-            plugin.getLogger().info("食料GUIを閉じました: " + player.getName());
         }
     }
     

--- a/src/main/java/org/tofu/tofunomics/npc/gui/ProcessingGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/ProcessingGUI.java
@@ -271,7 +271,7 @@ public class ProcessingGUI implements Listener {
             buttonMaterial = Material.LIME_DYE;
             buttonName = "§a全ての原木を加工する";
             buttonLore.add("§f加工する原木: §e" + totalLogs + "個");
-            buttonLore.add("§f受け取る板材: §a" + (totalLogs * 4) + "個");
+            buttonLore.add("§f受け取る板材: §a" + (totalLogs * processingNPCManager.getPlanksPerLog()) + "個");
             if (totalFee > 0) {
                 buttonLore.add("§f加工料金: §e" + String.format("%.0f", totalFee) + "G");
             } else {
@@ -311,7 +311,7 @@ public class ProcessingGUI implements Listener {
         
         lore.add("§f所持数: §e" + amount + "個");
         lore.add("§7↓");
-        lore.add("§f板材: §a" + (amount * 4) + "個");
+        lore.add("§f板材: §a" + (amount * processingNPCManager.getPlanksPerLog()) + "個");
         
         boolean isWoodcutter = isWoodcutter(player);
         double feePerLog = isWoodcutter ? 

--- a/src/main/java/org/tofu/tofunomics/npc/gui/ProcessingGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/ProcessingGUI.java
@@ -92,7 +92,6 @@ public class ProcessingGUI implements Listener {
         } catch (Exception e) {
             plugin.getLogger().severe("加工GUI作成中にエラーが発生しました: " + e.getMessage());
             player.sendMessage("§cGUIの作成に失敗しました。管理者にお知らせください。");
-            e.printStackTrace();
         }
     }
     
@@ -481,8 +480,6 @@ public class ProcessingGUI implements Listener {
             additionalInfo,
             // 確定時のコールバック
             (p, selectedQuantity) -> {
-                plugin.getLogger().info("数量選択加工開始: " + p.getName() + " - " + selectedQuantity + "個");
-                
                 // 原木を再収集（GUIを閉じている間に変わっている可能性がある）
                 List<ItemStack> currentLogItems = new ArrayList<>();
                 for (ItemStack item : p.getInventory().getContents()) {
@@ -505,7 +502,6 @@ public class ProcessingGUI implements Listener {
             },
             // キャンセル時のコールバック
             () -> {
-                plugin.getLogger().info("数量選択がキャンセルされました: " + player.getName());
             }
         );
     }
@@ -527,9 +523,7 @@ public class ProcessingGUI implements Listener {
             player.closeInventory();
             return;
         }
-        
-        plugin.getLogger().info("加工処理開始: " + player.getName());
-        
+
         // 加工処理実行
         ProcessingNPCManager.ProcessingResult result = processingNPCManager.processWoodConversion(
             player, session.getNpcId(), logItems
@@ -559,7 +553,6 @@ public class ProcessingGUI implements Listener {
         
         if (session != null && event.getInventory().equals(session.getInventory())) {
             activeSessions.remove(player.getUniqueId());
-            plugin.getLogger().info("加工GUIを閉じました: " + player.getName());
         }
     }
     

--- a/src/main/java/org/tofu/tofunomics/npc/gui/QuantitySelectorGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/QuantitySelectorGUI.java
@@ -122,12 +122,9 @@ public class QuantitySelectorGUI implements Listener {
             activeSessions.put(player.getUniqueId(), session);
             player.openInventory(gui);
 
-            plugin.getLogger().info("数量選択GUIを開きました: " + player.getName());
-
         } catch (Exception e) {
             plugin.getLogger().severe("数量選択GUI作成中にエラーが発生しました: " + e.getMessage());
             player.sendMessage("§cGUIの作成に失敗しました。");
-            e.printStackTrace();
         }
     }
 
@@ -354,7 +351,6 @@ public class QuantitySelectorGUI implements Listener {
 
         if (session != null && event.getInventory().equals(session.getInventory())) {
             activeSessions.remove(player.getUniqueId());
-            plugin.getLogger().info("数量選択GUIを閉じました: " + player.getName());
         }
     }
 

--- a/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
@@ -115,34 +115,22 @@ public class TradingGUI implements Listener {
     }
     
     public void openTradingGUI(Player player, TradingNPCManager.TradingPost tradingPost) {
-        plugin.getLogger().info("TradingGUI.openTradingGUI開始: プレイヤー=" + player.getName() + ", 取引所=" + tradingPost.getName());
-        
         try {
             String playerJob = jobManager.getPlayerJob(player.getUniqueId());
-            plugin.getLogger().info("TradingGUI内での職業確認: " + (playerJob != null ? playerJob : "職業なし"));
-            
+
             // 無職の場合、この取引所が無職を受け入れるかチェック
             if (playerJob == null) {
-                plugin.getLogger().info("TradingGUI: 無職プレイヤーの受け入れ判定中...");
                 boolean acceptsNoJob = tradingPost.acceptsJob(null);
-                plugin.getLogger().info("TradingGUI: 取引所「" + tradingPost.getName() + "」の無職受け入れ: " + (acceptsNoJob ? "可能" : "不可"));
-                
+
                 if (!acceptsNoJob) {
                     // この取引所は無職を受け入れない
-                    plugin.getLogger().info("TradingGUI: 職業なしのため処理中断");
                     String npcType = getNPCTypeFromTradingPostId(tradingPost.getId());
                     configManager.sendNPCSpecificMessageList(player, npcType, "no_job");
                     return;
                 }
-                
-                // この取引所は無職も受け入れる
-                plugin.getLogger().info("TradingGUI: この取引所は無職も受け入れます。GUI作成を続行");
             } else {
                 // 職業がある場合、職業対応チェック
-                plugin.getLogger().info("TradingGUI: 職業対応チェック - プレイヤー職業=" + playerJob + ", 対応職業=" + String.join(", ", tradingPost.getAcceptedJobTypes()));
-                
                 if (!tradingPost.acceptsJob(playerJob)) {
-                    plugin.getLogger().info("TradingGUI: 職業不対応のため処理中断");
                     String npcType = getNPCTypeFromTradingPostId(tradingPost.getId());
                     String acceptedJobsStr = String.join(", ", tradingPost.getAcceptedJobTypes());
                     configManager.sendNPCSpecificMessageList(player, npcType, "job_not_accepted", 
@@ -154,33 +142,27 @@ public class TradingGUI implements Listener {
             }
             
             String title = "§6" + tradingPost.getName() + " - アイテム取引";
-            plugin.getLogger().info("TradingGUI: GUIタイトル設定完了: " + title);
-            
+
             Inventory gui = Bukkit.createInventory(null, 54, title);
-            plugin.getLogger().info("TradingGUI: インベントリ作成完了");
-            
+
             TradingGUISession session = new TradingGUISession(
                 player.getUniqueId(),
                 tradingPost.getId(),
                 gui
             );
-            plugin.getLogger().info("TradingGUI: セッション作成完了");
-            
+
             setupTradingGUIItems(gui, player, tradingPost, session);
-            plugin.getLogger().info("TradingGUI: GUIアイテム設定完了");
-            
+
             activeSessions.put(player.getUniqueId(), session);
             player.openInventory(gui);
-            plugin.getLogger().info("TradingGUI: インベントリ開起完了");
-            
+
             plugin.getLogger().info("取引GUIを開きました: " + player.getName() + " -> " + tradingPost.getName());
-            
+
         } catch (Exception e) {
             plugin.getLogger().severe("取引GUI作成中にエラーが発生しました: " + e.getMessage());
             plugin.getLogger().severe("プレイヤー: " + player.getName() + ", 取引所: " + tradingPost.getName());
             player.sendMessage("§c取引画面の表示中にエラーが発生しました。");
             player.sendMessage("§c管理者にお知らせください。詳細はサーバーログを確認してください。");
-            e.printStackTrace();
         }
     }
     
@@ -191,25 +173,15 @@ public class TradingGUI implements Listener {
      * @param initialMode 初期モード（SELL or BUY）
      */
     public void openTradingGUIWithMode(Player player, TradingNPCManager.TradingPost tradingPost, TradingMode initialMode) {
-        plugin.getLogger().info("TradingGUI.openTradingGUIWithMode開始: プレイヤー=" + player.getName() +
-                               ", 取引所=" + tradingPost.getName() + ", モード=" + initialMode);
-
         try {
             String playerJob = jobManager.getPlayerJob(player.getUniqueId());
-            plugin.getLogger().info("TradingGUI内での職業確認: " + (playerJob != null ? playerJob : "職業なし"));
 
             // 職業チェック（購入と売却で異なる制限）
             boolean isMatchingJob = tradingPost.isMatchingJob(playerJob);
 
             if (!isMatchingJob) {
-                // 別職業または無職の場合
-                plugin.getLogger().info("TradingGUI: 別職業または無職 - プレイヤー職業=" +
-                    (playerJob != null ? playerJob : "無職") + ", 対応職業=" +
-                    String.join(", ", tradingPost.getAcceptedJobTypes()));
-
-                // 売却モードの場合のみ制限
+                // 別職業または無職の場合、売却モードのみ制限
                 if (initialMode == TradingMode.SELL) {
-                    plugin.getLogger().info("TradingGUI: 売却モードのため職業制限を適用");
                     String acceptedJobsStr = String.join("、", tradingPost.getAcceptedJobTypes());
 
                     player.sendMessage("§c売却はこの取引所の対応職業のみ可能です");
@@ -221,44 +193,34 @@ public class TradingGUI implements Listener {
                     }
                     return;
                 }
-
-                // 購入モードの場合は職業に関係なく続行
-                plugin.getLogger().info("TradingGUI: 購入モードのため職業に関係なくGUI開起を続行（割増価格適用）");
-            } else {
-                plugin.getLogger().info("TradingGUI: 対応職業です。購入・売却ともに可能");
+                // 購入モードの場合は職業に関係なく続行（割増価格適用）
             }
-            
+
             String title = "§6" + tradingPost.getName() + " - アイテム取引";
-            plugin.getLogger().info("TradingGUI: GUIタイトル設定完了: " + title);
-            
+
             Inventory gui = Bukkit.createInventory(null, 54, title);
-            plugin.getLogger().info("TradingGUI: インベントリ作成完了");
-            
+
             TradingGUISession session = new TradingGUISession(
                 player.getUniqueId(),
                 tradingPost.getId(),
                 gui
             );
-            
+
             // 初期モードを設定
             session.setTradingMode(initialMode);
-            plugin.getLogger().info("TradingGUI: セッション作成完了（初期モード: " + initialMode + "）");
-            
+
             setupTradingGUIItems(gui, player, tradingPost, session);
-            plugin.getLogger().info("TradingGUI: GUIアイテム設定完了");
-            
+
             activeSessions.put(player.getUniqueId(), session);
             player.openInventory(gui);
-            plugin.getLogger().info("TradingGUI: インベントリ開起完了");
-            
+
             plugin.getLogger().info("取引GUIを開きました: " + player.getName() + " -> " + tradingPost.getName() + " (" + initialMode + "モード)");
-            
+
         } catch (Exception e) {
             plugin.getLogger().severe("取引GUI作成中にエラーが発生しました: " + e.getMessage());
             plugin.getLogger().severe("プレイヤー: " + player.getName() + ", 取引所: " + tradingPost.getName());
             player.sendMessage("§c取引画面の表示中にエラーが発生しました。");
             player.sendMessage("§c管理者にお知らせください。詳細はサーバーログを確認してください。");
-            e.printStackTrace();
         }
     }
     
@@ -316,11 +278,7 @@ public class TradingGUI implements Listener {
 
                 // 木こりが原木を見る場合、GUI表示にも木こりボーナスを適用
                 if ("woodcutter".equals(playerJob) && isLogItem(material)) {
-                    plugin.getLogger().info("[TradingGUI] GUI表示: 木こりボーナス適用前 finalPrice=" + finalPrice + ", material=" + material);
                     finalPrice *= 2.0;
-                    plugin.getLogger().info("[TradingGUI] GUI表示: 木こりボーナス適用後 finalPrice=" + finalPrice);
-                } else {
-                    plugin.getLogger().info("[TradingGUI] GUI表示: playerJob=" + playerJob + ", isLogItem=" + isLogItem(material) + ", finalPrice=" + finalPrice + ", material=" + material);
                 }
 
                 int playerAmount = countPlayerItems(player, material);
@@ -423,13 +381,7 @@ public class TradingGUI implements Listener {
             
             double displayBasePrice = basePrice * displayMultiplier;
             double displayFinalPrice = finalPrice * displayMultiplier;
-            
-            plugin.getLogger().info("[TradingGUI] createTradingItem: material=" + material + 
-                ", basePrice=" + basePrice + 
-                ", finalPrice=" + finalPrice + 
-                ", displayMultiplier=" + displayMultiplier +
-                ", displayFinalPrice=" + displayFinalPrice);
-            
+
             lore.add("§f基本価格: §e" + currencyConverter.formatCurrency(displayBasePrice) + unitSuffix);
             
             if (Math.abs(finalPrice - basePrice) > 0.01) {
@@ -698,8 +650,13 @@ public class TradingGUI implements Listener {
     }
     
     private void fillEmptySlots(Inventory gui) {
-        ItemStack glassPane = createGUIItem(Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
-        
+        // 装飾が無効な場合は枠を付けない
+        if (!configManager.isGuiDecorationEnabled()) {
+            return;
+        }
+        // 取引テーマ: 緑ガラス
+        ItemStack glassPane = createGUIItem(Material.LIME_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+
         // 上段と下段の装飾
         for (int i = 0; i < 9; i++) {
             if (gui.getItem(i) == null) gui.setItem(i, glassPane);
@@ -741,7 +698,6 @@ public class TradingGUI implements Listener {
         } catch (Exception e) {
             plugin.getLogger().severe("取引GUIクリック処理中にエラーが発生しました: " + e.getMessage());
             player.sendMessage(configManager.getMessage("npc.trading.action_error"));
-            e.printStackTrace();
         }
     }
     
@@ -893,49 +849,34 @@ public class TradingGUI implements Listener {
         // 事前にスペースをチェック（売却金額を計算して必要なスロット数を確認）
         double totalEarnings = 0.0;
 
-        plugin.getLogger().info("[TradingGUI] DEBUG ===== 売却処理開始 =====");
-        plugin.getLogger().info("[TradingGUI] DEBUG - itemsToSell.size(): " + itemsToSell.size());
-        plugin.getLogger().info("[TradingGUI] DEBUG - playerJob: " + playerJob);
-        
         // 売却金額の合計を計算（木こりボーナスも考慮）
         for (ItemStack sellItem : itemsToSell) {
             Material mat = sellItem.getType();
             double basePrice = tradingPost.getItemPrice(mat);
-            
-            plugin.getLogger().info("[TradingGUI] DEBUG - Material: " + mat + ", basePrice: " + basePrice + ", playerJob: " + playerJob + ", amount: " + sellItem.getAmount());
-            
+
             if (basePrice > 0) {
                 double finalPrice = tradePriceManager.calculateFinalPrice(mat.toString().toLowerCase(), playerJob, basePrice);
-                
-                plugin.getLogger().info("[TradingGUI] DEBUG - After calculateFinalPrice: " + finalPrice);
-                
+
                 // 木こりが原木を売る場合は価格を2倍に
                 if ("woodcutter".equals(playerJob) && isLogItem(mat)) {
                     finalPrice *= 2.0;
-                    plugin.getLogger().info("[TradingGUI] DEBUG - After woodcutter bonus: " + finalPrice);
                 }
-                
+
                 double itemTotal = finalPrice * sellItem.getAmount();
-                plugin.getLogger().info("[TradingGUI] DEBUG - itemTotal (before floor): " + itemTotal);
-                
+
                 // 個数を掛けた後に切り捨て
                 itemTotal = Math.floor(itemTotal);
-                plugin.getLogger().info("[TradingGUI] DEBUG - itemTotal (after floor): " + itemTotal);
-                
+
                 totalEarnings += itemTotal;
             }
         }
 
         // 必要な金塊数を計算
         int requiredNuggets = currencyConverter.convertBalanceToNuggets(totalEarnings);
-        
-        // デバッグログ
-        plugin.getLogger().info("[TradingGUI] 事前チェック - totalEarnings: " + totalEarnings + ", requiredNuggets: " + requiredNuggets);
-        
+
         // ItemManager.hasInventorySpaceを使用（既存の金塊スタックの空きスペースも考慮される）
         boolean hasSpace = currencyConverter.getItemManager().hasInventorySpace(player, requiredNuggets);
-        plugin.getLogger().info("[TradingGUI] 事前チェック - hasInventorySpace result: " + hasSpace);
-        
+
         if (!hasSpace) {
             player.sendMessage("§cインベントリに空きがありません。金塊を受け取るスペースを確保してください。");
             return;
@@ -1022,7 +963,6 @@ public class TradingGUI implements Listener {
         if (isCrossJob) {
             double multiplier = configManager.getCrossJobPurchaseMultiplier();
             unitPrice *= multiplier;
-            plugin.getLogger().info("別職業購入: " + playerJob + " が " + tradingPost.getName() + " で購入（" + multiplier + "倍）");
         }
 
         // 合計金額を計算
@@ -1088,49 +1028,34 @@ public class TradingGUI implements Listener {
         String playerJob = jobManager.getPlayerJob(player.getUniqueId());
         double totalEarnings = 0.0;
 
-        plugin.getLogger().info("[TradingGUI] DEBUG ===== 全アイテム売却処理開始 =====");
-        plugin.getLogger().info("[TradingGUI] DEBUG - allItems.size(): " + allItems.size());
-        plugin.getLogger().info("[TradingGUI] DEBUG - playerJob: " + playerJob);
-        
         // 売却金額の合計を計算（木こりボーナスも考慮）
         for (ItemStack sellItem : allItems) {
             Material mat = sellItem.getType();
             double basePrice = tradingPost.getItemPrice(mat);
-            
-            plugin.getLogger().info("[TradingGUI] DEBUG - Material: " + mat + ", basePrice: " + basePrice + ", playerJob: " + playerJob + ", amount: " + sellItem.getAmount());
-            
+
             if (basePrice > 0) {
                 double finalPrice = tradePriceManager.calculateFinalPrice(mat.toString().toLowerCase(), playerJob, basePrice);
-                
-                plugin.getLogger().info("[TradingGUI] DEBUG - After calculateFinalPrice: " + finalPrice);
-                
+
                 // 木こりが原木を売る場合は価格を2倍に
                 if ("woodcutter".equals(playerJob) && isLogItem(mat)) {
                     finalPrice *= 2.0;
-                    plugin.getLogger().info("[TradingGUI] DEBUG - After woodcutter bonus: " + finalPrice);
                 }
-                
+
                 double itemTotal = finalPrice * sellItem.getAmount();
-                plugin.getLogger().info("[TradingGUI] DEBUG - itemTotal (before floor): " + itemTotal);
-                
+
                 // 個数を掛けた後に切り捨て
                 itemTotal = Math.floor(itemTotal);
-                plugin.getLogger().info("[TradingGUI] DEBUG - itemTotal (after floor): " + itemTotal);
-                
+
                 totalEarnings += itemTotal;
             }
         }
 
         // 必要な金塊数を計算
         int requiredNuggets = currencyConverter.convertBalanceToNuggets(totalEarnings);
-        
-        // デバッグログ
-        plugin.getLogger().info("[TradingGUI] 事前チェック - totalEarnings: " + totalEarnings + ", requiredNuggets: " + requiredNuggets);
-        
+
         // ItemManager.hasInventorySpaceを使用（既存の金塊スタックの空きスペースも考慮される）
         boolean hasSpace = currencyConverter.getItemManager().hasInventorySpace(player, requiredNuggets);
-        plugin.getLogger().info("[TradingGUI] 事前チェック - hasInventorySpace result: " + hasSpace);
-        
+
         if (!hasSpace) {
             player.sendMessage("§cインベントリに空きがありません。金塊を受け取るスペースを確保してください。");
             return;
@@ -1194,10 +1119,7 @@ public class TradingGUI implements Listener {
         Player player = (Player) event.getPlayer();
         UUID playerId = player.getUniqueId();
         
-        TradingGUISession session = activeSessions.remove(playerId);
-        if (session != null) {
-            plugin.getLogger().info("取引GUIを閉じました: " + player.getName());
-        }
+        activeSessions.remove(playerId);
     }
     
     public void closeAllGUIs() {

--- a/src/main/java/org/tofu/tofunomics/npc/gui/TradingModeSelectionGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/TradingModeSelectionGUI.java
@@ -62,8 +62,6 @@ public class TradingModeSelectionGUI implements Listener {
      * モード選択GUIを開く
      */
     public void openModeSelectionGUI(Player player, TradingNPCManager.TradingPost tradingPost) {
-        plugin.getLogger().info("モード選択GUI開起: プレイヤー=" + player.getName() + ", 取引所=" + tradingPost.getName());
-
         try {
             // GUIタイトル
             String title = "§6" + tradingPost.getName() + " - モード選択";
@@ -87,12 +85,9 @@ public class TradingModeSelectionGUI implements Listener {
             // GUI開起
             player.openInventory(gui);
 
-            plugin.getLogger().info("モード選択GUI開起完了: " + player.getName());
-
         } catch (Exception e) {
             plugin.getLogger().severe("モード選択GUI作成中にエラーが発生しました: " + e.getMessage());
             player.sendMessage("§c画面の表示中にエラーが発生しました。");
-            e.printStackTrace();
         }
     }
 
@@ -203,7 +198,6 @@ public class TradingModeSelectionGUI implements Listener {
         } catch (Exception e) {
             plugin.getLogger().severe("モード選択処理中にエラーが発生しました: " + e.getMessage());
             player.sendMessage("§c処理中にエラーが発生しました。");
-            e.printStackTrace();
         }
     }
 
@@ -216,7 +210,6 @@ public class TradingModeSelectionGUI implements Listener {
         switch (slot) {
             case 11: // 売却モード
                 if (material == Material.EMERALD) {
-                    plugin.getLogger().info("売却モード選択: " + player.getName());
                     player.closeInventory();
                     // 売却モードで取引GUIを開く
                     tradingGUI.openTradingGUIWithMode(player, tradingPost, TradingGUI.TradingMode.SELL);
@@ -225,7 +218,6 @@ public class TradingModeSelectionGUI implements Listener {
 
             case 15: // 購入モード
                 if (material == Material.GOLD_INGOT) {
-                    plugin.getLogger().info("購入モード選択: " + player.getName());
                     player.closeInventory();
                     // 購入モードで取引GUIを開く
                     tradingGUI.openTradingGUIWithMode(player, tradingPost, TradingGUI.TradingMode.BUY);
@@ -234,7 +226,6 @@ public class TradingModeSelectionGUI implements Listener {
 
             case 22: // 閉じる
                 if (material == Material.BARRIER) {
-                    plugin.getLogger().info("モード選択GUI閉じる: " + player.getName());
                     player.closeInventory();
                 }
                 break;
@@ -258,10 +249,7 @@ public class TradingModeSelectionGUI implements Listener {
         UUID playerId = player.getUniqueId();
 
         // セッションを削除
-        ModeSelectionSession session = activeSessions.remove(playerId);
-        if (session != null) {
-            plugin.getLogger().info("モード選択GUI閉じました: " + player.getName());
-        }
+        activeSessions.remove(playerId);
     }
 
     /**

--- a/src/main/java/org/tofu/tofunomics/players/PlayerJoinHandler.java
+++ b/src/main/java/org/tofu/tofunomics/players/PlayerJoinHandler.java
@@ -8,7 +8,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.ItemStack;
@@ -16,106 +15,40 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.tofu.tofunomics.config.ConfigManager;
 import org.tofu.tofunomics.dao.PlayerDAO;
-import org.tofu.tofunomics.scoreboard.ScoreboardManager;
 import org.tofu.tofunomics.inventory.PlayerInventoryManager;
 import org.tofu.tofunomics.rules.RulesManager;
 
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 /**
- * プレイヤー参加時の処理を管理するクラス
- * ワールドに入った時のウェルカムメッセージ、タイトル表示、初回特典などを処理
+ * プレイヤーのtofuNomicsワールド入退場処理を管理するクラス
+ * ワールドに入った時のウェルカムメッセージ・インベントリ復元・プレイヤーデータ初期化、
+ * 退出時のインベントリ保存などを処理する。
+ * ※ 参加時はロビーワールドから始まるため、PlayerJoinEventではなく
+ *   PlayerChangedWorldEvent（tofuNomics入場）を起点とする。
  */
 public class PlayerJoinHandler implements Listener {
-    
+
     private final JavaPlugin plugin;
     private final ConfigManager configManager;
     private final PlayerDAO playerDAO;
-    private final ScoreboardManager scoreboardManager;
     private final PlayerInventoryManager inventoryManager;
     private final RulesManager rulesManager;
     private final Logger logger;
-    
-    // ログイン中フラグを記録するマップ（ログイン直後のワールド変更でインベントリ保存をスキップするため）
-    private final Map<UUID, Boolean> isLoggingIn = new ConcurrentHashMap<>();
 
-    public PlayerJoinHandler(JavaPlugin plugin, ConfigManager configManager, PlayerDAO playerDAO, ScoreboardManager scoreboardManager, PlayerInventoryManager inventoryManager, RulesManager rulesManager) {
+    public PlayerJoinHandler(JavaPlugin plugin, ConfigManager configManager, PlayerDAO playerDAO, PlayerInventoryManager inventoryManager, RulesManager rulesManager) {
         this.plugin = plugin;
         this.configManager = configManager;
         this.playerDAO = playerDAO;
-        this.scoreboardManager = scoreboardManager;
         this.inventoryManager = inventoryManager;
         this.rulesManager = rulesManager;
         this.logger = plugin.getLogger();
     }
     
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void onPlayerJoin(PlayerJoinEvent event) {
-        Player player = event.getPlayer();
-        
-        // ログイン中フラグを設定（ログイン直後のワールド変更でインベントリ保存をスキップするため）
-        isLoggingIn.put(player.getUniqueId(), true);
-        
-        // 5秒後にフラグをクリア
-        Bukkit.getScheduler().runTaskLater(plugin, () -> {
-            isLoggingIn.remove(player.getUniqueId());
-        }, 100L); // 100 ticks = 5秒
-
-        logger.info("プレイヤー参加イベント開始: " + player.getName() + " ワールド: " + player.getWorld().getName());
-
-        // スコアボード処理（同期処理）
-        if (scoreboardManager != null) {
-            scoreboardManager.onPlayerJoin(player);
-        }
-
-        // TofuNomicsワールドに参加した場合、インベントリを復元
-        if (player.getWorld().getName().equals("tofuNomics")) {
-            logger.info("プレイヤー " + player.getName() + " がTofuNomicsワールドに参加 - インベントリを復元します");
-            // 少し遅延してインベントリを復元（TofuHomePluginのナビゲーションアイテム付与の後）
-            Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                // 復元時点でtofuNomicsワールドにいるか再チェック
-                if (inventoryManager != null && player.isOnline() && player.getWorld().getName().equals("tofuNomics")) {
-                    // TofuHomePluginのナビゲーションアイテム（スロット9, 10, 11）を一時保存
-                    ItemStack slot9 = player.getInventory().getItem(9);
-                    ItemStack slot10 = player.getInventory().getItem(10);
-                    ItemStack slot11 = player.getInventory().getItem(11);
-
-                    // インベントリを復元
-                    inventoryManager.loadInventory(player);
-
-                    // ナビゲーションアイテムを復元（TofuHomePluginのアイテムを優先）
-                    if (slot9 != null) {
-                        player.getInventory().setItem(9, slot9);
-                    }
-                    if (slot10 != null) {
-                        player.getInventory().setItem(10, slot10);
-                    }
-                    if (slot11 != null) {
-                        player.getInventory().setItem(11, slot11);
-                    }
-
-                    logger.info("インベントリ復元完了（ナビゲーションアイテム保護済み）: " + player.getName());
-                }
-            }, 40L); // 2秒後に復元（TofuHomePluginの処理完了を待つ）
-
-            // ウェルカム処理
-            logger.info("プレイヤー " + player.getName() + " はtofuNomicsワールドに直接参加しました - ウェルカム処理を開始します");
-            WelcomeDisplayTask welcomeTask = new WelcomeDisplayTask(player);
-            welcomeTask.runTaskLater(plugin, 40L); // 2秒後に実行
-        }
-
-        // 非同期でプレイヤーデータの初期化のみ実行
-        PlayerDataInitializationTask task = new PlayerDataInitializationTask(player);
-        task.runTaskAsynchronously(plugin);
-    }
-    
     /**
      * プレイヤーがワールドを変更した時の処理
-     * TofuNomicsワールドに入った場合、ウェルカムメッセージと職業案内を表示
+     * TofuNomicsワールドに入った場合、プレイヤーデータ初期化・ウェルカムメッセージ・職業案内を表示
      * EventPriority.LOWESTを使用してTofuHomePluginのMONITOR処理の前に実行
      */
     @EventHandler(priority = EventPriority.LOWEST)
@@ -124,14 +57,10 @@ public class PlayerJoinHandler implements Listener {
         String currentWorldName = player.getWorld().getName();
         String previousWorldName = event.getFrom().getName();
 
-        // デバッグログ: ワールド変更を記録
-        logger.info("プレイヤー " + player.getName() + " がワールドを変更しました: " + previousWorldName + " → " + currentWorldName);
-
         // TofuNomicsワールドに入った場合
         if (currentWorldName.equals("tofuNomics")) {
             // TofuNomicsワールドからTofuNomicsワールドへの移動は処理しない
             if (!previousWorldName.equals("tofuNomics")) {
-                logger.info("プレイヤー " + player.getName() + " がTofuNomicsワールドに入りました - インベントリを復元します");
                 // 遅延してインベントリを復元（TofuHomePluginのナビゲーションアイテム付与の後）
                 Bukkit.getScheduler().runTaskLater(plugin, () -> {
                     // 復元時点でtofuNomicsワールドにいるか再チェック
@@ -160,36 +89,57 @@ public class PlayerJoinHandler implements Listener {
                 }, 40L); // 2秒後に復元（TofuHomePluginの処理完了を待つ）
             }
 
-            // 明示的にロビーワールドなどを除外
-            if (currentWorldName.toLowerCase().contains("lobby") ||
-                currentWorldName.toLowerCase().contains("spawn") ||
-                currentWorldName.equals("world") ||
-                currentWorldName.equals("world_nether") ||
-                currentWorldName.equals("world_the_end")) {
-                logger.info("プレイヤー " + player.getName() + " は除外対象のワールド(" + currentWorldName + ")にいるため、処理をスキップします");
-                return;
-            }
-
-            logger.info("プレイヤー " + player.getName() + " がTofuNomicsワールドに入りました - ウェルカムメッセージを表示します");
+            // 非同期でプレイヤーデータを初期化・更新（ワールド非依存のDB登録・更新）
+            // ※ 参加時はロビーから始まるため、JoinEventではなくtofuNomics入場時に実行する
+            PlayerDataInitializationTask dataTask = new PlayerDataInitializationTask(player);
+            dataTask.runTaskAsynchronously(plugin);
 
             // TofuNomicsワールドでのウェルカムメッセージとタイトルを表示
             WelcomeDisplayTask welcomeTask = new WelcomeDisplayTask(player);
             welcomeTask.runTask(plugin);
+
+            // 対象ワールドに入ったタイミングでルール同意チェックを実施
+            checkRulesAgreementOnEnter(player, currentWorldName);
         }
         // TofuNomicsワールドから出た場合、インベントリを保存
         else if (previousWorldName.equals("tofuNomics")) {
-            // ログイン直後（5秒以内）のワールド変更は無視（空のインベントリで上書きされるのを防ぐ）
-            Boolean loggingIn = isLoggingIn.get(player.getUniqueId());
-            if (loggingIn != null && loggingIn) {
-                logger.info("プレイヤー " + player.getName() + " はログイン中のため、インベントリ保存をスキップします");
-                return;
-            }
-            
             logger.info("プレイヤー " + player.getName() + " がTofuNomicsワールドから退出 - インベントリを保存します");
             if (inventoryManager != null) {
                 inventoryManager.saveInventory(player);
             }
         }
+    }
+
+    /**
+     * 対象ワールドに入った際のルール同意チェック
+     * 未同意プレイヤーを制限対象に登録し、ルールGUIを表示する
+     * （onEnableスキャンと同じロジックを参加経路でも適用する）
+     */
+    private void checkRulesAgreementOnEnter(Player player, String worldName) {
+        if (rulesManager == null) {
+            return;
+        }
+
+        // 対象ワールド外（tofunomics系以外）はルール同意システムの対象外
+        if (!configManager.isEconomyEnabledInWorld(worldName)) {
+            return;
+        }
+
+        // 既に同意済みなら何もしない
+        if (rulesManager.hasAgreedToRules(player.getUniqueId())) {
+            return;
+        }
+
+        logger.info("プレイヤー " + player.getName() + " はルール未同意です - ルールGUIを表示します");
+        rulesManager.markAsUnagreed(player.getUniqueId());
+        player.sendMessage(configManager.getMessage("rules.messages.must_agree"));
+
+        // 2秒後にルールGUIを表示（ワールド遷移・他プラグイン処理の完了を待つ）
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (player.isOnline() && configManager.isEconomyEnabledInWorld(player.getWorld().getName())) {
+                rulesManager.getRulesGUI().openRulesGUI(player, 1);
+            }
+        }, 40L);
     }
     
     /**
@@ -199,9 +149,6 @@ public class PlayerJoinHandler implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerQuit(PlayerQuitEvent event) {
         Player player = event.getPlayer();
-        
-        // ログイン中フラグをクリーンアップ（メモリリーク防止）
-        isLoggingIn.remove(player.getUniqueId());
 
         // TofuNomicsワールドにいる場合、インベントリと現金データを保存
         if (player.getWorld().getName().equals("tofuNomics")) {
@@ -232,7 +179,6 @@ public class PlayerJoinHandler implements Listener {
             } catch (Exception e) {
                 logger.severe("プレイヤー退出時のデータ保存中にエラー: " + player.getName());
                 logger.severe("エラー詳細: " + e.getMessage());
-                e.printStackTrace();
             }
         }
     }
@@ -273,10 +219,9 @@ public class PlayerJoinHandler implements Listener {
             }
         } catch (Exception e) {
             logger.severe("プレイヤーデータ処理中にエラー: " + e.getMessage());
-            e.printStackTrace();
         }
     }
-    
+
     /**
      * 新規プレイヤーの作成
      */
@@ -296,7 +241,6 @@ public class PlayerJoinHandler implements Listener {
             
         } catch (Exception e) {
             logger.severe("新規プレイヤー作成中にエラー: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -308,7 +252,6 @@ public class PlayerJoinHandler implements Listener {
             playerDAO.updateLastLogin(player.getUniqueId());
         } catch (Exception e) {
             logger.severe("ログイン時間更新中にエラー: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -320,7 +263,6 @@ public class PlayerJoinHandler implements Listener {
             playerDAO.updatePlayerName(player.getUniqueId(), player.getName());
         } catch (Exception e) {
             logger.severe("プレイヤー名更新中にエラー: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -383,7 +325,6 @@ public class PlayerJoinHandler implements Listener {
             
         } catch (Exception e) {
             logger.warning("ウェルカムメッセージ表示中にエラー: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -417,7 +358,6 @@ public class PlayerJoinHandler implements Listener {
             }
         } catch (Exception e) {
             logger.warning("タイトル表示中にエラー: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -430,51 +370,39 @@ public class PlayerJoinHandler implements Listener {
      */
     private void teleportToSpawn(Player player) {
         try {
-            logger.info("=== テレポート処理開始 ===");
-            logger.info("プレイヤー: " + player.getName());
-            logger.info("現在のワールド: " + player.getWorld().getName());
-            logger.info("現在の座標: " + player.getLocation().getBlockX() + ", " + player.getLocation().getBlockY() + ", " + player.getLocation().getBlockZ());
-            
             // スポーン座標機能が有効でない場合はスキップ
-            boolean isEnabled = configManager.isSpawnLocationEnabled();
-            logger.info("スポーン座標機能の有効状態: " + isEnabled);
-            if (!isEnabled) {
-                logger.info("スポーン座標機能が無効のため、テレポートをスキップします");
+            if (!configManager.isSpawnLocationEnabled()) {
                 return;
             }
-            
+
             // 現在のワールドがtofuNomicsでない場合はスキップ
             if (!player.getWorld().getName().equals("tofuNomics")) {
-                logger.info("プレイヤー " + player.getName() + " は" + player.getWorld().getName() + "にいるため、スポーン座標へのテレポートをスキップします");
                 return;
             }
-            
+
             // 設定からスポーン座標を取得
             String worldName = configManager.getSpawnWorldName();
             int x = configManager.getSpawnX();
             int y = configManager.getSpawnY();
             int z = configManager.getSpawnZ();
             int delay = configManager.getSpawnTeleportDelay();
-            
-            logger.info("スポーン座標設定 - ワールド: " + worldName + ", 座標: (" + x + ", " + y + ", " + z + "), 遅延: " + delay + " tick");
-            
+
             // ワールドを取得
             World world = Bukkit.getWorld(worldName);
             if (world == null) {
                 logger.warning("スポーン座標のワールドが見つかりません: " + worldName);
                 return;
             }
-            
+
             // スポーン座標を作成
             Location spawnLocation = new Location(world, x + 0.5, y, z + 0.5);
-            
+
             // 遅延付きでテレポート実行
             SpawnTeleportTask teleportTask = new SpawnTeleportTask(player, spawnLocation, x, y, z, worldName);
             teleportTask.runTaskLater(plugin, delay);
-            
+
         } catch (Exception e) {
             logger.warning("スポーン座標へのテレポート中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
     
@@ -506,7 +434,6 @@ public class PlayerJoinHandler implements Listener {
                 handlePlayerData(player);
             } catch (Exception e) {
                 logger.warning("プレイヤー参加時データ処理中にエラーが発生しました: " + e.getMessage());
-                e.printStackTrace();
             }
         }
     }
@@ -533,7 +460,6 @@ public class PlayerJoinHandler implements Listener {
                 }
             } catch (Exception e) {
                 logger.warning("TofuNomicsワールド処理中にエラーが発生しました: " + e.getMessage());
-                e.printStackTrace();
             }
         }
     }

--- a/src/main/java/org/tofu/tofunomics/protection/HostileMobRemovalManager.java
+++ b/src/main/java/org/tofu/tofunomics/protection/HostileMobRemovalManager.java
@@ -155,7 +155,6 @@ public class HostileMobRemovalManager {
 
         } catch (Exception e) {
             logger.severe("モブスキャン中にエラーが発生しました: " + e.getMessage());
-            e.printStackTrace();
         }
     }
 

--- a/src/main/java/org/tofu/tofunomics/rules/RulesGUI.java
+++ b/src/main/java/org/tofu/tofunomics/rules/RulesGUI.java
@@ -170,13 +170,10 @@ public class RulesGUI implements Listener {
             
             activeSessions.put(player.getUniqueId(), session);
             player.openInventory(gui);
-            
-            plugin.getLogger().info("ルールGUIを開きました: " + player.getName() + " - ページ " + page);
-            
+
         } catch (Exception e) {
             plugin.getLogger().severe("ルールGUI作成中にエラーが発生しました: " + e.getMessage());
             player.sendMessage("§cルールGUIの表示中にエラーが発生しました");
-            e.printStackTrace();
         }
     }
     

--- a/src/main/java/org/tofu/tofunomics/rules/RulesManager.java
+++ b/src/main/java/org/tofu/tofunomics/rules/RulesManager.java
@@ -272,6 +272,15 @@ public class RulesManager implements Listener {
     public boolean isUnagreed(UUID uuid) {
         return unagreedPlayers.contains(uuid);
     }
+
+    /**
+     * 現在のワールドでルール制限を適用すべきか確認
+     * economy.enabled_worlds（ワールド制限ホワイトリスト）に従い、
+     * 対象ワールド外（tofunomics系以外）ではルール同意システムを動作させない
+     */
+    private boolean isRulesEnabledInWorld(Player player) {
+        return configManager.isEconomyEnabledInWorld(player.getWorld().getName());
+    }
     
     // ========== イベントハンドラ：未同意プレイヤーの行動制限 ==========
     
@@ -281,8 +290,8 @@ public class RulesManager implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerMove(PlayerMoveEvent event) {
         Player player = event.getPlayer();
-        
-        if (isUnagreed(player.getUniqueId())) {
+
+        if (isUnagreed(player.getUniqueId()) && isRulesEnabledInWorld(player)) {
             // 移動先と移動元が異なるブロックの場合のみキャンセル
             if (event.getFrom().getBlockX() != event.getTo().getBlockX() ||
                 event.getFrom().getBlockY() != event.getTo().getBlockY() ||
@@ -300,12 +309,12 @@ public class RulesManager implements Listener {
     public void onBlockBreak(BlockBreakEvent event) {
         Player player = event.getPlayer();
         
-        if (isUnagreed(player.getUniqueId())) {
+        if (isUnagreed(player.getUniqueId()) && isRulesEnabledInWorld(player)) {
             event.setCancelled(true);
             player.sendMessage(configManager.getMessage("rules.action_blocked"));
         }
     }
-    
+
     /**
      * ブロック設置制限
      */
@@ -313,20 +322,20 @@ public class RulesManager implements Listener {
     public void onBlockPlace(BlockPlaceEvent event) {
         Player player = event.getPlayer();
         
-        if (isUnagreed(player.getUniqueId())) {
+        if (isUnagreed(player.getUniqueId()) && isRulesEnabledInWorld(player)) {
             event.setCancelled(true);
             player.sendMessage(configManager.getMessage("rules.action_blocked"));
         }
     }
-    
+
     /**
      * アイテム使用制限
      */
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerInteract(PlayerInteractEvent event) {
         Player player = event.getPlayer();
-        
-        if (isUnagreed(player.getUniqueId())) {
+
+        if (isUnagreed(player.getUniqueId()) && isRulesEnabledInWorld(player)) {
             // ルールブック使用は許可（右クリックでGUI開く）
             ItemStack item = event.getItem();
             if (item != null && item.getType() == Material.WRITTEN_BOOK) {
@@ -355,8 +364,8 @@ public class RulesManager implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerCommand(PlayerCommandPreprocessEvent event) {
         Player player = event.getPlayer();
-        
-        if (isUnagreed(player.getUniqueId())) {
+
+        if (isUnagreed(player.getUniqueId()) && isRulesEnabledInWorld(player)) {
             String command = event.getMessage().toLowerCase();
             
             // /rules コマンドは許可

--- a/src/main/java/org/tofu/tofunomics/rules/RulesManager.java
+++ b/src/main/java/org/tofu/tofunomics/rules/RulesManager.java
@@ -254,7 +254,6 @@ public class RulesManager implements Listener {
             return true;
         } catch (Exception e) {
             plugin.getLogger().severe("ルール同意状態のリセットに失敗しました: " + e.getMessage());
-            e.printStackTrace();
             return false;
         }
     }

--- a/src/main/java/org/tofu/tofunomics/scoreboard/BossBarManager.java
+++ b/src/main/java/org/tofu/tofunomics/scoreboard/BossBarManager.java
@@ -1,0 +1,179 @@
+package org.tofu.tofunomics.scoreboard;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.boss.BossBar;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 取引営業時間をBossBarで常時表示するマネージャー。
+ *
+ * 営業中は緑バーで閉店までの残り時間、閉店中は赤バーで開店までの残り時間を表示する。
+ * 営業時間の判定は {@code ScoreboardManager} と同じ {@code ConfigManager} の
+ * 取引時間設定を再利用する。表示対象ワールドはスコアボードと同じ設定に合わせる。
+ */
+public class BossBarManager implements Listener {
+
+    // 1ゲーム時間 = 1000tick = 50実秒
+    private static final double REAL_SECONDS_PER_GAME_HOUR = 50.0;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+
+    private final Map<UUID, BossBar> playerBars = new HashMap<>();
+    private BukkitTask updateTask;
+
+    public BossBarManager(TofuNomics plugin, ConfigManager configManager) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        startUpdateTask();
+    }
+
+    private void startUpdateTask() {
+        // 1秒ごとに更新（カウントダウンを滑らかに表示）
+        updateTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    if (shouldShow(player)) {
+                        updateBar(player);
+                    } else {
+                        removeBar(player.getUniqueId());
+                    }
+                }
+            }
+        }.runTaskTimer(plugin, 0L, 20L);
+    }
+
+    /**
+     * このプレイヤーにBossBarを表示すべきか判定する。
+     */
+    private boolean shouldShow(Player player) {
+        if (!configManager.isTradingBossBarEnabled()) {
+            return false;
+        }
+        if (!configManager.isTradingHoursEnabled()) {
+            return false;
+        }
+        return configManager.isScoreboardEnabledInWorld(player.getWorld().getName());
+    }
+
+    /**
+     * プレイヤーのBossBarを現在の営業状況に合わせて更新する。
+     */
+    private void updateBar(Player player) {
+        long worldTime = player.getWorld().getTime();
+        double timeOfDay = (((worldTime + 6000) / 1000.0)) % 24.0;
+        int startHour = configManager.getTradingStartHour();
+        int endHour = configManager.getTradingEndHour();
+
+        boolean open;
+        double remainingGameHours;
+        double windowHours;
+
+        if (startHour <= endHour) {
+            open = timeOfDay >= startHour && timeOfDay < endHour;
+            if (open) {
+                remainingGameHours = endHour - timeOfDay;
+                windowHours = endHour - startHour;
+            } else {
+                remainingGameHours = (timeOfDay < startHour)
+                    ? startHour - timeOfDay
+                    : (24 - timeOfDay) + startHour;
+                windowHours = 24 - (endHour - startHour);
+            }
+        } else {
+            // 日をまたぐ営業時間（例: 22時〜翌6時）
+            open = timeOfDay >= startHour || timeOfDay < endHour;
+            if (open) {
+                remainingGameHours = (timeOfDay >= startHour)
+                    ? (24 - timeOfDay) + endHour
+                    : endHour - timeOfDay;
+                windowHours = (24 - startHour) + endHour;
+            } else {
+                remainingGameHours = startHour - timeOfDay;
+                windowHours = startHour - endHour;
+            }
+        }
+
+        long remainingRealSec = (long) (remainingGameHours * REAL_SECONDS_PER_GAME_HOUR);
+        double progress = (windowHours > 0) ? clamp01(remainingGameHours / windowHours) : 1.0;
+
+        BossBar bar = getOrCreate(player);
+        if (open) {
+            bar.setColor(BarColor.GREEN);
+            bar.setTitle(color("&a&l💼 営業中 &f— 閉店まであと " + formatRemain(remainingRealSec)));
+        } else {
+            bar.setColor(BarColor.RED);
+            bar.setTitle(color("&c&l🔒 閉店中 &f— 開店まであと " + formatRemain(remainingRealSec)));
+        }
+        bar.setProgress(progress);
+
+        if (!bar.getPlayers().contains(player)) {
+            bar.addPlayer(player);
+        }
+    }
+
+    private BossBar getOrCreate(Player player) {
+        return playerBars.computeIfAbsent(player.getUniqueId(),
+            uuid -> Bukkit.createBossBar("", BarColor.GREEN, BarStyle.SOLID));
+    }
+
+    private void removeBar(UUID uuid) {
+        BossBar bar = playerBars.remove(uuid);
+        if (bar != null) {
+            bar.removeAll();
+        }
+    }
+
+    private double clamp01(double value) {
+        if (value < 0) return 0;
+        if (value > 1) return 1;
+        return value;
+    }
+
+    private String formatRemain(long seconds) {
+        if (seconds < 0) seconds = 0;
+        long minutes = seconds / 60;
+        long remSec = seconds % 60;
+        if (minutes > 0) {
+            return minutes + "分" + remSec + "秒";
+        }
+        return remSec + "秒";
+    }
+
+    private String color(String legacy) {
+        return ChatColor.translateAlternateColorCodes('&', legacy);
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        removeBar(event.getPlayer().getUniqueId());
+    }
+
+    /**
+     * 終了処理：タスク停止と全BossBarの除去。
+     */
+    public void shutdown() {
+        if (updateTask != null && !updateTask.isCancelled()) {
+            updateTask.cancel();
+        }
+        for (BossBar bar : playerBars.values()) {
+            bar.removeAll();
+        }
+        playerBars.clear();
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/scoreboard/ScoreboardManager.java
+++ b/src/main/java/org/tofu/tofunomics/scoreboard/ScoreboardManager.java
@@ -69,8 +69,20 @@ public class ScoreboardManager implements Listener {
      */
     public void disableScoreboard(Player player) {
         scoreboardEnabled.put(player.getUniqueId(), false);
-        // メインスコアボードに戻す代わりにヒントスコアボードを表示
+        // 対象ワールド外ではTofuNomicsのスコアボードを一切表示しない（ヒントも含めてクリア）
+        if (!isScoreboardEnabledInCurrentWorld(player)) {
+            clearScoreboard(player);
+            return;
+        }
+        // 対象ワールド内でユーザーが手動で非表示にした場合のみヒントスコアボードを表示
         showHintScoreboard(player);
+    }
+
+    /**
+     * プレイヤーのスコアボードをメインスコアボードに戻す（サイドバー表示を消す）
+     */
+    private void clearScoreboard(Player player) {
+        player.setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
     }
 
     /**

--- a/src/main/java/org/tofu/tofunomics/scoreboard/ScoreboardManager.java
+++ b/src/main/java/org/tofu/tofunomics/scoreboard/ScoreboardManager.java
@@ -323,13 +323,64 @@ public class ScoreboardManager implements Listener {
         } catch (Exception e) {
             // スコアボード作成・更新中のエラーをキャッチ
             plugin.getLogger().warning("Failed to update scoreboard for player " + player.getName() + ": " + e.getMessage());
-            // デバッグ用にスタックトレースも出力（必要に応じて）
-            if (plugin.getServer().getPluginManager().getPlugin("TofuNomics").getLogger().isLoggable(java.util.logging.Level.FINE)) {
-                e.printStackTrace();
-            }
         }
     }
     
+    /**
+     * 職業レベルをプレイヤーのバニラ経験値バーに反映する
+     * - 対象ワールド外、または職業なしの場合はバーを0にリセット（職業レベルの残留防止）
+     * - 職業ありの場合はレベル数字＝職業レベル、バー進捗＝次レベルまでの達成率
+     */
+    public void updateExperienceBar(Player player) {
+        if (!configManager.isVanillaExpBarEnabled()) {
+            return;
+        }
+
+        try {
+            // 対象ワールド外では職業レベルを表示しない
+            if (!isScoreboardEnabledInCurrentWorld(player)) {
+                resetExperienceBar(player);
+                return;
+            }
+
+            PlayerJob currentJob = jobManager.getCurrentJob(player.getUniqueId());
+            if (currentJob == null) {
+                resetExperienceBar(player);
+                return;
+            }
+
+            // 進捗率（0.0〜1.0）を計算
+            double currentExp = currentJob.getExperience();
+            double prevLevelExp = PlayerJob.calculateExperienceRequired(currentJob.getLevel());
+            double requiredExp = PlayerJob.calculateExperienceRequired(currentJob.getLevel() + 1);
+
+            float progress;
+            if (currentJob.getLevel() >= configManager.getMaxJobLevel() || requiredExp <= prevLevelExp) {
+                // 最大レベル到達時はバーを満タンにする
+                progress = 1.0f;
+            } else {
+                progress = (float) ((currentExp - prevLevelExp) / (requiredExp - prevLevelExp));
+            }
+
+            // バニラ仕様の範囲（0.0〜1.0）に収める。1.0は次レベル扱いになるため僅かに下げる
+            progress = Math.max(0.0f, Math.min(0.9999f, progress));
+
+            player.setLevel(currentJob.getLevel());
+            player.setExp(progress);
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to update experience bar for player "
+                    + player.getName() + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * バニラ経験値バーを0にリセットする
+     */
+    private void resetExperienceBar(Player player) {
+        player.setLevel(0);
+        player.setExp(0.0f);
+    }
+
     /**
      * 時間をフォーマット（分 -> 時間:分）
      */
@@ -360,6 +411,8 @@ public class ScoreboardManager implements Listener {
             @Override
             public void run() {
                 for (Player player : Bukkit.getOnlinePlayers()) {
+                    // バニラ経験値バーはスコアボード表示のON/OFFと無関係に常時更新する
+                    updateExperienceBar(player);
                     if (isScoreboardEnabled(player)) {
                         updatePlayerScoreboard(player);
                     }
@@ -384,7 +437,10 @@ public class ScoreboardManager implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {
         Player player = event.getPlayer();
-        
+
+        // ワールド移動時に経験値バーを即時反映/リセットする
+        updateExperienceBar(player);
+
         if (isScoreboardEnabledInCurrentWorld(player)) {
             // 対象ワールドに入った場合、スコアボードが有効なら表示する
             if (configManager.isScoreboardDefaultEnabled() || scoreboardEnabled.getOrDefault(player.getUniqueId(), false)) {
@@ -403,6 +459,10 @@ public class ScoreboardManager implements Listener {
      */
     public void onPlayerQuit(Player player) {
         scoreboardEnabled.remove(player.getUniqueId());
+        // 退出時にバニラ経験値バーを0に戻して残留を防ぐ
+        if (configManager.isVanillaExpBarEnabled()) {
+            resetExperienceBar(player);
+        }
     }
     
     /**
@@ -427,6 +487,10 @@ public class ScoreboardManager implements Listener {
         // 全プレイヤーのスコアボードをデフォルトに戻す
         for (Player player : Bukkit.getOnlinePlayers()) {
             player.setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
+            // バニラ経験値バーも0に戻す（職業レベルの残留防止）
+            if (configManager.isVanillaExpBarEnabled()) {
+                resetExperienceBar(player);
+            }
         }
         
         scoreboardEnabled.clear();

--- a/src/main/java/org/tofu/tofunomics/testing/WorldGuardTestModeListener.java
+++ b/src/main/java/org/tofu/tofunomics/testing/WorldGuardTestModeListener.java
@@ -23,6 +23,7 @@ public class WorldGuardTestModeListener implements Listener {
     private final Logger logger;
     private final TestModeManager testModeManager;
     private final org.tofu.tofunomics.integration.WorldGuardIntegration worldGuardIntegration;
+    private final org.tofu.tofunomics.config.ConfigManager configManager;
     
     // テストモード中に操作を制限するブロックタイプ
     private static final Set<Material> PROTECTED_BLOCKS = EnumSet.of(
@@ -104,10 +105,12 @@ public class WorldGuardTestModeListener implements Listener {
         Material.LECTERN
     );
     
-    public WorldGuardTestModeListener(Plugin plugin, TestModeManager testModeManager, 
+    public WorldGuardTestModeListener(Plugin plugin, org.tofu.tofunomics.config.ConfigManager configManager,
+                                      TestModeManager testModeManager,
                                       org.tofu.tofunomics.integration.WorldGuardIntegration worldGuardIntegration) {
         this.plugin = plugin;
         this.logger = plugin.getLogger();
+        this.configManager = configManager;
         this.testModeManager = testModeManager;
         this.worldGuardIntegration = worldGuardIntegration;
     }
@@ -118,47 +121,40 @@ public class WorldGuardTestModeListener implements Listener {
      */
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerInteract(PlayerInteractEvent event) {
-        // テストモード無効時は何もしない
         Player player = event.getPlayer();
-        
-        // デバッグ: イベントハンドラーが呼ばれたことをログ
-        logger.info("WorldGuardTestModeListener: PlayerInteractEvent発生 - プレイヤー: " + player.getName());
-        
-        if (!testModeManager.isInTestMode(player)) {
-            logger.info("WorldGuardTestModeListener: " + player.getName() + " はテストモード中ではありません");
+
+        // ワールド制限: 経済機能が無効なワールドではテストモード判定を行わない
+        if (!configManager.isEconomyEnabledInWorld(player.getWorld().getName())) {
             return;
         }
-        
-        logger.info("WorldGuardTestModeListener: " + player.getName() + " はテストモード中です");
-        
+
+        // テストモード無効時は何もしない
+        if (!testModeManager.isInTestMode(player)) {
+            return;
+        }
+
         // 右クリックまたは左クリックのブロックインタラクションのみチェック
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK && event.getAction() != Action.LEFT_CLICK_BLOCK) {
             return;
         }
-        
+
         Block clickedBlock = event.getClickedBlock();
         if (clickedBlock == null) {
             return;
         }
-        
+
         Material blockType = clickedBlock.getType();
-        
-        logger.info("WorldGuardTestModeListener: クリックされたブロック: " + blockType);
-        
+
         // 保護対象ブロックタイプかチェック
         if (!PROTECTED_BLOCKS.contains(blockType)) {
-            logger.info("WorldGuardTestModeListener: " + blockType + " は保護対象ブロックではありません");
             return;
         }
-        
-        logger.info("WorldGuardTestModeListener: " + blockType + " は保護対象ブロックです");
-        
+
         // テストモード中は、WorldGuardの権限チェックを厳密に実行
         // OP権限を持っていてもWorldGuardの保護をバイパスさせない
         // canInteractメソッドはプレイヤーのメンバー権限も考慮する
         boolean canInteract = worldGuardIntegration.canInteract(player, clickedBlock.getLocation());
-        logger.info("WorldGuardTestModeListener: 操作可否チェック結果: " + (canInteract ? "許可" : "拒否"));
-        
+
         if (!canInteract) {
             // WorldGuardの権限チェックで操作不可の場合は拒否
             event.setCancelled(true);

--- a/src/main/java/org/tofu/tofunomics/trade/TradeChestManager.java
+++ b/src/main/java/org/tofu/tofunomics/trade/TradeChestManager.java
@@ -58,7 +58,7 @@ public class TradeChestManager {
             }
             
         } catch (SQLException e) {
-            System.err.println("取引チェストの読み込みに失敗しました: " + e.getMessage());
+            configManager.getPlugin().getLogger().severe("取引チェストの読み込みに失敗しました: " + e.getMessage());
         }
     }
     
@@ -127,7 +127,7 @@ public class TradeChestManager {
             }
             
         } catch (SQLException e) {
-            System.err.println("取引チェストの保存に失敗しました: " + e.getMessage());
+            configManager.getPlugin().getLogger().severe("取引チェストの保存に失敗しました: " + e.getMessage());
         }
         
         return false;
@@ -158,7 +158,7 @@ public class TradeChestManager {
             }
             
         } catch (SQLException e) {
-            System.err.println("取引チェストの削除に失敗しました: " + e.getMessage());
+            configManager.getPlugin().getLogger().severe("取引チェストの削除に失敗しました: " + e.getMessage());
         }
         
         return false;
@@ -228,7 +228,7 @@ public class TradeChestManager {
             }
             
         } catch (SQLException e) {
-            System.err.println("取引履歴の保存に失敗しました: " + e.getMessage());
+            configManager.getPlugin().getLogger().severe("取引履歴の保存に失敗しました: " + e.getMessage());
         }
         
         return false;
@@ -252,7 +252,7 @@ public class TradeChestManager {
             }
             
         } catch (SQLException e) {
-            System.err.println("取引履歴の取得に失敗しました: " + e.getMessage());
+            configManager.getPlugin().getLogger().severe("取引履歴の取得に失敗しました: " + e.getMessage());
         }
         
         return histories;

--- a/src/main/java/org/tofu/tofunomics/trade/TradePriceManager.java
+++ b/src/main/java/org/tofu/tofunomics/trade/TradePriceManager.java
@@ -384,25 +384,16 @@ public class TradePriceManager {
      * NPCシステム用の最終価格計算メソッド
      */
     public double calculateFinalPrice(String itemName, String jobType, double basePrice) {
-        System.out.println("[TradePriceManager] calculateFinalPrice - itemName: " + itemName + ", jobType: " + jobType + ", basePrice: " + basePrice);
-        
         // 職業倍率を取得（無職の場合は1.0）
         double jobMultiplier = (jobType == null || jobType.isEmpty()) ? 1.0 : configManager.getJobPriceMultiplier(jobType);
-        System.out.println("[TradePriceManager] jobMultiplier: " + jobMultiplier);
-        
+
         double finalPrice = basePrice * jobMultiplier;
-        System.out.println("[TradePriceManager] After job multiplier: " + finalPrice);
-        
+
         // グローバル倍率を適用
         double globalMultiplier = configManager.getTradePriceMultiplier();
-        System.out.println("[TradePriceManager] globalMultiplier: " + globalMultiplier);
-        
         finalPrice *= globalMultiplier;
-        System.out.println("[TradePriceManager] After global multiplier: " + finalPrice);
-        
+
         // 個数を掛ける前の価格を返す（切り捨ては呼び出し側で行う）
-        System.out.println("[TradePriceManager] Returning finalPrice (before floor): " + finalPrice);
-        
         return finalPrice;
     }
 }

--- a/src/main/java/org/tofu/tofunomics/util/NotificationManager.java
+++ b/src/main/java/org/tofu/tofunomics/util/NotificationManager.java
@@ -1,0 +1,51 @@
+package org.tofu.tofunomics.util;
+
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.entity.Player;
+
+/**
+ * Title / ActionBar / パーティクル演出をまとめた通知ヘルパー。
+ *
+ * 既存実装と同じ Bukkit 標準 API + BungeeCord Chat API を使用する:
+ * - ActionBar: {@code items/ClockItemManager.java}
+ * - Title: {@code area/AreaListener.java}
+ * - パーティクル: {@code housing/SelectionManager.java}
+ *
+ * 演出のON/OFF判定は呼び出し側で {@code ConfigManager} を見て行う。
+ * このクラスは純粋な送信ヘルパーに徹する。
+ */
+public class NotificationManager {
+
+    private static String color(String legacy) {
+        return ChatColor.translateAlternateColorCodes('&', legacy);
+    }
+
+    /**
+     * ActionBar（画面下部のホットバー上）にメッセージを表示する。
+     */
+    public void sendActionBar(Player player, String message) {
+        player.spigot().sendMessage(ChatMessageType.ACTION_BAR,
+            TextComponent.fromLegacyText(color(message)));
+    }
+
+    /**
+     * 画面中央に Title / Subtitle を表示する（時間はtick単位）。
+     */
+    public void sendTitle(Player player, String title, String subtitle,
+                          int fadeIn, int stay, int fadeOut) {
+        player.sendTitle(color(title), color(subtitle), fadeIn, stay, fadeOut);
+    }
+
+    /**
+     * レベルアップ等の祝福パーティクルをプレイヤー周囲に表示する。
+     */
+    public void playCelebrationEffect(Player player) {
+        Location loc = player.getLocation().add(0, 1, 0);
+        player.getWorld().spawnParticle(Particle.HAPPY_VILLAGER, loc, 40, 0.5, 1.0, 0.5, 0.1);
+        player.getWorld().spawnParticle(Particle.TOTEM_OF_UNDYING, loc, 20, 0.4, 0.8, 0.4, 0.3);
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/util/RichMessageBuilder.java
+++ b/src/main/java/org/tofu/tofunomics/util/RichMessageBuilder.java
@@ -1,0 +1,85 @@
+package org.tofu.tofunomics.util;
+
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.chat.hover.content.Text;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+
+/**
+ * クリック実行・ホバー説明付きのリッチテキストメッセージを組み立てるヘルパー。
+ *
+ * 既存の {@code commands/RulesCommand.java} と同じ BungeeCord Chat API
+ * （{@code net.md_5.bungee.api.chat.*}）を使用する。
+ * カラーコードは Minecraft 標準の {@code &} 記法で指定する。
+ */
+public class RichMessageBuilder {
+
+    private final TextComponent root = new TextComponent("");
+
+    public static RichMessageBuilder create() {
+        return new RichMessageBuilder();
+    }
+
+    private static String color(String legacy) {
+        return ChatColor.translateAlternateColorCodes('&', legacy);
+    }
+
+    /**
+     * 通常テキストを追加する（{@code &} カラーコード対応）。
+     */
+    public RichMessageBuilder text(String legacy) {
+        for (BaseComponent component : TextComponent.fromLegacyText(color(legacy))) {
+            root.addExtra(component);
+        }
+        return this;
+    }
+
+    /**
+     * クリックでコマンドを実行するボタンを追加する。
+     *
+     * @param label   表示テキスト（{@code &} カラーコード対応）
+     * @param command 実行するコマンド（先頭の {@code /} を含む）
+     * @param hover   ホバー時のツールチップ（null可、{@code &} カラーコード対応）
+     */
+    public RichMessageBuilder runButton(String label, String command, String hover) {
+        TextComponent button = new TextComponent(TextComponent.fromLegacyText(color(label)));
+        button.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, command));
+        if (hover != null) {
+            button.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                new Text(TextComponent.fromLegacyText(color(hover)))));
+        }
+        root.addExtra(button);
+        return this;
+    }
+
+    /**
+     * ホバー時に詳細を表示するテキストを追加する（クリック動作なし）。
+     *
+     * @param label 表示テキスト（{@code &} カラーコード対応）
+     * @param hover ホバー時のツールチップ（{@code &} カラーコード対応）
+     */
+    public RichMessageBuilder hoverText(String label, String hover) {
+        TextComponent component = new TextComponent(TextComponent.fromLegacyText(color(label)));
+        component.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+            new Text(TextComponent.fromLegacyText(color(hover)))));
+        root.addExtra(component);
+        return this;
+    }
+
+    /**
+     * 組み立てたコンポーネントを返す。
+     */
+    public TextComponent build() {
+        return root;
+    }
+
+    /**
+     * 組み立てたメッセージをプレイヤーへ送信する。
+     */
+    public void sendTo(Player player) {
+        player.spigot().sendMessage(root);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,6 +31,14 @@ economy:
   # 初期残高（新規プレイヤーの開始残高）
   starting_balance: 100
 
+  # 経済機能を有効にするワールド（ホワイトリスト方式）
+  # ここに記載したワールドでのみ、経験値・報酬・コマンド・NPC等のTofuNomics機能が動作する
+  # 空リストの場合は全ワールドで有効（後方互換）
+  enabled_worlds:
+    - "tofuNomics"
+    - "tofuNomics_nether"
+    - "tofuNomics_the_end"
+
   # 送金設定
   pay:
     # 最低送金額
@@ -239,6 +247,139 @@ jobs:
       exp_multiplier: 10.0
       # 売却ボーナス（レベル1での基本ボーナス）
       base_sell_bonus: 0.05
+      # 職業ガイドブック設定
+      guide_book:
+        enabled: true
+        title: "&6&l鉱夫ガイドブック"
+        author: "TofuNomics職業組合"
+        pages:
+          - |
+            &0&l【鉱夫の仕事】
+
+            &0鉱夫は鉱物資源と
+            石材の供給を担当
+            する職業です。
+
+            採掘で経験値と
+            報酬を獲得できます。
+          - |
+            &0&l【主な収入源】
+
+            &8採掘した鉱石を
+            &8取引所NPCで売却！
+
+            &0・石炭/鉄が基本
+            &0・金/ダイヤが高額
+            &0・エメラルドも◎
+
+            &eレベルUPで
+            &e売却ボーナス増加！
+          - |
+            &0&l【経験値の上げ方】
+
+            &0対象の鉱石や石を
+            採掘すると職業
+            経験値を獲得！
+
+            &8■自分で掘った
+            　ブロックが対象
+            &8■設置した石は
+            　経験値対象外
+
+            &e掘るほど成長！
+          - |
+            &0&l【経験値一覧①】
+
+            &8採掘1個あたり:
+
+            &8■石炭鉱石 25
+            &8■鉄鉱石 50
+            &8■金鉱石 80
+            &8■レッドストーン 30
+            &8■ラピスラズリ 40
+            &8■石 50
+          - |
+            &0&l【経験値一覧②】
+
+            &8採掘1個あたり:
+
+            &8■ダイヤ鉱石 200
+            &8■エメラルド鉱石 200
+            &8■ネザークォーツ 60
+            &8■古代の残骸 500
+
+            &e希少な鉱石ほど
+            &e経験値も大量！
+          - |
+            &0&l【必要経験値】
+
+            &8レベルUPに必要な
+            &8累計経験値:
+
+            &8■Lv5: 1,393
+            &8■Lv10: 6,502
+            &8■Lv25: 41,918
+            &8■Lv50: 162,694
+            &8■Lv100: 619,023
+
+            &8高Lvほど経験値
+            &8効率が低下します
+          - |
+            &0&l【職業スキル①】
+
+            &6幸運の一撃
+            &8Lv10〜 発動5〜25%
+            &8ドロップ量が1.5倍
+
+            &6鉱脈発見
+            &8Lv25〜 発動8〜30%
+            &8周囲3マスも採掘
+          - |
+            &0&l【職業スキル②】
+
+            &6採掘の極意
+            &8Lv50〜 発動10〜40%
+            &8ツール耐久を
+            &830%節約できる
+
+            &eスキルはレベルUPで
+            &e発動率が上昇！
+          - |
+            &0&l【レベルUP特典】
+
+            &8到達報酬:
+            &8■Lv10: 200金塊
+            &8■Lv25: 500金塊
+            &8　＋ダイヤのツルハシ
+            &8■Lv50: 1000金塊
+            &8■Lv75: 2000金塊
+
+            &8レベルに応じて
+            &8称号も変化！
+
+            &eLv50で転職可能！
+          - |
+            &0&l【稼ぐコツ】
+
+            &8■まず石炭と鉄を
+            　集めて売ろう
+            &8■ツルハシの耐久
+            　に注意
+            &8■ダイヤ/エメラルド
+            　は特に高経験値
+            &8■洞窟や廃坑が
+            　おすすめ
+          - |
+            &0&l【便利なコマンド】
+
+            &0/jobs stats
+            &8→ 職業の統計情報
+
+            &0/jobs info
+            &8→ 職業の詳細
+
+            &0/jobs guide
+            &8→ この本を再取得
       
     woodcutter:
       display_name: "木こり"
@@ -247,6 +388,129 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      # 職業ガイドブック設定
+      guide_book:
+        enabled: true
+        title: "&2&l木こりガイドブック"
+        author: "TofuNomics職業組合"
+        pages:
+          - |
+            &0&l【木こりの仕事】
+
+            &0木こりは木材の
+            供給を担当する
+            職業です。
+
+            伐採で経験値と
+            報酬を獲得できます。
+          - |
+            &0&l【主な収入源】
+
+            &8原木を取引所NPCで
+            &8売却して稼ごう！
+
+            &0・苗木も売れる
+            &0・ダークオークが
+            　 高額
+            &0・レベルUPで
+            　 売却ボーナス増加
+          - |
+            &0&l【経験値の上げ方】
+
+            &0対象の原木を
+            伐採すると職業
+            経験値を獲得！
+
+            &8■原木の種類で
+            　経験値が変化
+            &8■苗木を植えて
+            　持続的に伐採
+
+            &a森を育てよう！
+          - |
+            &0&l【経験値一覧】
+
+            &8伐採1本あたり:
+
+            &8■オーク原木 30
+            &8■白樺原木 30
+            &8■トウヒ原木 30
+            &8■ジャングル原木 40
+            &8■アカシア原木 40
+            &8■ダークオーク原木 40
+            &8■歪んだ幹 50
+            &8■真紅の幹 50
+          - |
+            &0&l【必要経験値】
+
+            &8レベルUPに必要な
+            &8累計経験値:
+
+            &8■Lv5: 1,393
+            &8■Lv10: 6,502
+            &8■Lv25: 41,918
+            &8■Lv50: 162,694
+            &8■Lv100: 619,023
+
+            &8高Lvほど経験値
+            &8効率が低下します
+          - |
+            &0&l【職業スキル①】
+
+            &2一斉伐採
+            &8Lv15〜 発動10〜35%
+            &8木全体を一括伐採
+            &8(最大64ブロック)
+
+            &2苗木の恵み
+            &8Lv30〜 発動15〜50%
+            &8苗木が追加ドロップ
+          - |
+            &0&l【職業スキル②】
+
+            &2森の番人
+            &8Lv45〜 発動5〜20%
+            &8木材の品質が
+            &81.8倍に向上
+
+            &aスキルはレベルUPで
+            &a発動率が上昇！
+          - |
+            &0&l【レベルUP特典】
+
+            &8到達報酬:
+            &8■Lv10: 200金塊
+            &8■Lv25: 500金塊
+            &8　＋ダイヤの斧
+            &8■Lv50: 1000金塊
+            &8■Lv75: 2000金塊
+
+            &8レベルに応じて
+            &8称号も変化！
+
+            &aLv50で転職可能！
+          - |
+            &0&l【稼ぐコツ】
+
+            &8■オークや白樺は
+            　育てやすい
+            &8■苗木を植えて
+            　持続可能に
+            &8■ダークオークが
+            　高値で売れる
+            &8■斧の耐久に
+            　注意しよう
+          - |
+            &0&l【便利なコマンド】
+
+            &0/jobs stats
+            &8→ 職業の統計情報
+
+            &0/jobs info
+            &8→ 職業の詳細
+
+            &0/jobs guide
+            &8→ この本を再取得
       
     farmer:
       display_name: "農家"
@@ -255,6 +519,138 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      # 職業ガイドブック設定
+      guide_book:
+        enabled: true
+        title: "&a&l農家ガイドブック"
+        author: "TofuNomics職業組合"
+        pages:
+          - |
+            &0&l【農家の仕事】
+
+            &0農家は農作物と
+            畜産物の供給を
+            担当する職業です。
+
+            収穫で経験値と
+            報酬を獲得できます。
+          - |
+            &0&l【主な収入源】
+
+            &8農作物を取引所NPCで
+            &8売却して稼ごう！
+
+            &0・小麦/にんじんが
+            　 基本
+            &0・かぼちゃ/スイカ
+            　 が高額
+            &0・レベルUPで
+            　 売却ボーナス増加
+          - |
+            &0&l【経験値の上げ方】
+
+            &0育てた農作物を
+            収穫すると職業
+            経験値を獲得！
+
+            &8■成熟した作物を
+            　収穫しよう
+            &8■種を撒いて
+            　再び育てよう
+
+            &a畑を広げよう！
+          - |
+            &0&l【経験値一覧①】
+
+            &8収穫1個あたり:
+
+            &8■小麦 30
+            &8■にんじん 25
+            &8■じゃがいも 25
+            &8■ビートルート 30
+            &8■サトウキビ 20
+          - |
+            &0&l【経験値一覧②】
+
+            &8収穫1個あたり:
+
+            &8■かぼちゃ 35
+            &8■スイカ 30
+            &8■カカオ豆 30
+            &8■ネザーウォート 35
+
+            &e作物の種類で
+            &e経験値が変化
+          - |
+            &0&l【必要経験値】
+
+            &8レベルUPに必要な
+            &8累計経験値:
+
+            &8■Lv5: 1,393
+            &8■Lv10: 6,502
+            &8■Lv25: 41,918
+            &8■Lv50: 162,694
+            &8■Lv100: 619,023
+
+            &8高Lvほど経験値
+            &8効率が低下します
+          - |
+            &0&l【職業スキル①】
+
+            &a豊穣の恵み
+            &8Lv10〜 発動12〜40%
+            &8収穫量が50%増加
+
+            &a双子の奇跡
+            &8Lv15〜 発動10〜25%
+            &8繁殖で双子が誕生
+          - |
+            &0&l【職業スキル②】
+
+            &a成長促進
+            &8Lv30〜 発動20〜60%
+            &8作物の成長が
+            &825%加速
+
+            &a品種改良
+            &8Lv50〜 発動5〜15%
+            &8品質が2.0倍に
+          - |
+            &0&l【レベルUP特典】
+
+            &8到達報酬:
+            &8■Lv10: 200金塊
+            &8■Lv25: 500金塊
+            &8■Lv50: 1000金塊
+            &8■Lv75: 2000金塊
+
+            &8レベルに応じて
+            &8称号も変化！
+
+            &aLv50で転職可能！
+          - |
+            &0&l【稼ぐコツ】
+
+            &8■水源の近くに
+            　畑を作ろう
+            &8■かぼちゃ/スイカが
+            　高値で売れる
+            &8■骨粉で成長を
+            　早めよう
+            &8■動物の繁殖でも
+            　収入を得られる
+          - |
+            &0&l【便利なコマンド】
+
+            &0/jobs stats
+            &8→ 職業の統計情報
+
+            &0/jobs info
+            &8→ 職業の詳細
+
+            &0/jobs guide
+            &8→ この本を再取得
       
     fisherman:
       display_name: "釣り人"
@@ -263,6 +659,127 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      # 職業ガイドブック設定
+      guide_book:
+        enabled: true
+        title: "&b&l釣り人ガイドブック"
+        author: "TofuNomics職業組合"
+        pages:
+          - |
+            &0&l【釣り人の仕事】
+
+            &0釣り人は魚と宝の
+            供給を担当する
+            職業です。
+
+            釣りで経験値と
+            報酬を獲得できます。
+          - |
+            &0&l【主な収入源】
+
+            &8釣った魚を取引所
+            &8NPCで売却！
+
+            &0・タラ/サケが基本
+            &0・宝物もドロップ
+            &0・レベルUPで
+            　 売却ボーナス増加
+
+            &bレア魚は高額！
+          - |
+            &0&l【経験値の上げ方】
+
+            &0釣りをすると
+            職業経験値を
+            獲得できます。
+
+            &8■魚や宝物を
+            　釣り上げよう
+            &8■雨や夜は
+            　経験値ボーナス
+
+            &b釣り続けよう！
+          - |
+            &0&l【経験値一覧】
+
+            &8釣り1回あたり:
+
+            &8■魚を釣る 100
+            &8■生物を釣る 150
+            &8■宝物ボーナス +150
+
+            &8天候ボーナス:
+            &8■雨天時 経験値1.2倍
+            &8■夜間 経験値1.15倍
+          - |
+            &0&l【必要経験値】
+
+            &8レベルUPに必要な
+            &8累計経験値:
+
+            &8■Lv5: 1,393
+            &8■Lv10: 6,502
+            &8■Lv25: 41,918
+            &8■Lv50: 162,694
+            &8■Lv100: 619,023
+
+            &8高Lvほど経験値
+            &8効率が低下します
+          - |
+            &0&l【職業スキル①】
+
+            &b大物釣り
+            &8Lv20〜 発動8〜30%
+            &8魚のサイズが1.5倍
+
+            &b宝探し
+            &8Lv35〜 発動5〜20%
+            &8宝物の確率が1.8倍
+          - |
+            &0&l【職業スキル②】
+
+            &b海の加護
+            &8Lv50〜 常時発動
+            &8天候による
+            &8釣果のムラを解消
+
+            &bスキルはレベルUPで
+            &b発動率が上昇！
+          - |
+            &0&l【レベルUP特典】
+
+            &8到達報酬:
+            &8■Lv10: 200金塊
+            &8■Lv25: 500金塊
+            &8■Lv50: 1000金塊
+            &8■Lv75: 2000金塊
+
+            &8レベルに応じて
+            &8称号も変化！
+
+            &bLv50で転職可能！
+          - |
+            &0&l【稼ぐコツ】
+
+            &8■雨の日は
+            　釣り効率UP
+            &8■宝釣りエンチャント
+            　を付けよう
+            &8■開けた水場が
+            　ベスト
+            &8■宝物は高値で
+            　売れる
+          - |
+            &0&l【便利なコマンド】
+
+            &0/jobs stats
+            &8→ 職業の統計情報
+
+            &0/jobs info
+            &8→ 職業の詳細
+
+            &0/jobs guide
+            &8→ この本を再取得
       
     blacksmith:
       display_name: "鍛冶屋"
@@ -271,6 +788,141 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      # 職業ガイドブック設定
+      guide_book:
+        enabled: true
+        title: "&8&l鍛冶屋ガイドブック"
+        author: "TofuNomics職業組合"
+        pages:
+          - |
+            &0&l【鍛冶屋の仕事】
+
+            &0鍛冶屋はツール、
+            武器、防具の生産
+            と修理を担当する
+            職業です。
+
+            作成で経験値と
+            報酬を獲得できます。
+          - |
+            &0&l【主な収入源】
+
+            &8作成した装備を
+            &8取引所NPCで売却！
+
+            &0・鉄装備が基本
+            &0・ダイヤ装備が高額
+            &0・レベルUPで
+            　 売却ボーナス増加
+
+            &7高品質ほど高額！
+          - |
+            &0&l【経験値の上げ方】
+
+            &0作業台で装備や
+            ツールを作成すると
+            職業経験値を獲得！
+
+            &8■高品質な装備
+            　ほど高経験値
+            &8■素材は鉱夫から
+            　仕入れよう
+
+            &7名工を目指せ！
+          - |
+            &0&l【経験値一覧①】
+
+            &8作成1個あたり:
+
+            &8■鉄インゴット 50
+            &8■金インゴット 80
+            &8■鉄の剣 120
+            &8■鉄ツルハシ/斧 150
+            &8■鉄シャベル 90
+            &8■鉄防具 各100
+            &8■盾 80
+          - |
+            &0&l【経験値一覧②】
+
+            &8作成1個あたり:
+
+            &8■ダイヤの剣 300
+            &8■ダイヤツール 350
+            &8■ダイヤ防具 各250
+            &8■ネザライト 750
+            &8■金リンゴ 150
+
+            &e高級品ほど高経験値
+          - |
+            &0&l【必要経験値】
+
+            &8レベルUPに必要な
+            &8累計経験値:
+
+            &8■Lv5: 1,393
+            &8■Lv10: 6,502
+            &8■Lv25: 41,918
+            &8■Lv50: 162,694
+            &8■Lv100: 619,023
+
+            &8高Lvほど経験値
+            &8効率が低下します
+          - |
+            &0&l【職業スキル①】
+
+            &7完璧な修理
+            &8Lv10〜 発動15〜50%
+            &8修理時に耐久を
+            &820%上乗せ
+
+            &7名工の技
+            &8Lv25〜 発動10〜35%
+            &8装備の品質1.5倍
+          - |
+            &0&l【職業スキル②】
+
+            &7神器創造
+            &8Lv60〜 発動2〜8%
+            &8特殊エンチャントが
+            &8付与される
+
+            &7スキルはレベルUPで
+            &7発動率が上昇！
+          - |
+            &0&l【レベルUP特典】
+
+            &8到達報酬:
+            &8■Lv10: 200金塊
+            &8■Lv25: 500金塊
+            &8■Lv50: 1000金塊
+            &8■Lv75: 2000金塊
+
+            &8レベルに応じて
+            &8称号も変化！
+
+            &7Lv50で転職可能！
+          - |
+            &0&l【稼ぐコツ】
+
+            &8■まず鉄装備から
+            　作り始めよう
+            &8■作業台と金床を
+            　用意しよう
+            &8■ダイヤ装備は
+            　高値で売れる
+            &8■鉱夫と協力して
+            　素材を確保
+          - |
+            &0&l【便利なコマンド】
+
+            &0/jobs stats
+            &8→ 職業の統計情報
+
+            &0/jobs info
+            &8→ 職業の詳細
+
+            &0/jobs guide
+            &8→ この本を再取得
       
     alchemist:
       display_name: "ポーション屋"
@@ -279,6 +931,128 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      # 職業ガイドブック設定
+      guide_book:
+        enabled: true
+        title: "&5&lポーション屋ガイドブック"
+        author: "TofuNomics職業組合"
+        pages:
+          - |
+            &0&l【ポーション屋の仕事】
+
+            &0ポーション屋は
+            各種ポーションの
+            生産を担当する
+            職業です。
+
+            醸造で経験値と
+            報酬を獲得できます。
+          - |
+            &0&l【主な収入源】
+
+            &8ポーションを取引所
+            &8NPCで売却！
+
+            &0・基本ポーション
+            　 から始めよう
+            &0・高効果ほど高額
+            &0・レベルUPで
+            　 売却ボーナス増加
+          - |
+            &0&l【経験値の上げ方】
+
+            &0醸造台でポーション
+            を醸造すると職業
+            経験値を獲得！
+
+            &8■醸造が完了する
+            　たびに経験値
+            &8■醸造台の近くに
+            　いる必要あり
+
+            &5醸造を続けよう！
+          - |
+            &0&l【経験値一覧】
+
+            &8醸造1回あたり:
+
+            &8■ポーション醸造 100
+
+            &7※醸造台での醸造が
+            &7完了するたびに
+            &7経験値を獲得
+
+            &eどの種類でも
+            &e経験値は同じです
+          - |
+            &0&l【必要経験値】
+
+            &8レベルUPに必要な
+            &8累計経験値:
+
+            &8■Lv5: 1,393
+            &8■Lv10: 6,502
+            &8■Lv25: 41,918
+            &8■Lv50: 162,694
+            &8■Lv100: 619,023
+
+            &8高Lvほど経験値
+            &8効率が低下します
+          - |
+            &0&l【職業スキル①】
+
+            &5材料節約
+            &8Lv15〜 発動20〜60%
+            &8醸造材料を50%節約
+
+            &5二重醸造
+            &8Lv30〜 発動10〜25%
+            &8ポーションが追加生成
+          - |
+            &0&l【職業スキル②】
+
+            &5錬金の極意
+            &8Lv50〜 発動15〜40%
+            &8ポーションの効果
+            &8時間が1.5倍に
+
+            &5スキルはレベルUPで
+            &5発動率が上昇！
+          - |
+            &0&l【レベルUP特典】
+
+            &8到達報酬:
+            &8■Lv10: 200金塊
+            &8■Lv25: 500金塊
+            &8■Lv50: 1000金塊
+            &8■Lv75: 2000金塊
+
+            &8レベルに応じて
+            &8称号も変化！
+
+            &5Lv50で転職可能！
+          - |
+            &0&l【稼ぐコツ】
+
+            &8■醸造台とブレイズ
+            　パウダーが必須
+            &8■ネザーウォートを
+            　確保しよう
+            &8■高効果ポーション
+            　ほど高値で売れる
+            &8■残留ポーションが
+            　最も高額
+          - |
+            &0&l【便利なコマンド】
+
+            &0/jobs stats
+            &8→ 職業の統計情報
+
+            &0/jobs info
+            &8→ 職業の詳細
+
+            &0/jobs guide
+            &8→ この本を再取得
       
     enchanter:
       display_name: "エンチャンター"
@@ -287,6 +1061,128 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      # 職業ガイドブック設定
+      guide_book:
+        enabled: true
+        title: "&d&lエンチャンターガイドブック"
+        author: "TofuNomics職業組合"
+        pages:
+          - |
+            &0&l【エンチャンターの仕事】
+
+            &0エンチャンターは
+            エンチャントサービス
+            を担当する職業です。
+
+            エンチャントで
+            経験値と報酬を
+            獲得できます。
+          - |
+            &0&l【主な収入源】
+
+            &8エンチャント済み
+            &8アイテムを取引所
+            &8NPCで売却！
+
+            &0・高レベルエンチャ
+            　 ほど高額
+            &0・レベルUPで
+            　 売却ボーナス増加
+          - |
+            &0&l【経験値の上げ方】
+
+            &0エンチャント台で
+            エンチャントすると
+            職業経験値を獲得！
+
+            &8■付与レベルの
+            　合計が高いほど
+            　経験値も多い
+
+            &dラピスを用意！
+          - |
+            &0&l【経験値一覧】
+
+            &8エンチャント1回:
+            &8(付与Lv合計で変化)
+
+            &8■合計Lv1 150
+            &8■合計Lv2 250
+            &8■合計Lv3 400
+            &8■合計Lv4 550
+            &8■合計Lv5 750
+
+            &d高レベルほど高経験値
+          - |
+            &0&l【必要経験値】
+
+            &8レベルUPに必要な
+            &8累計経験値:
+
+            &8■Lv5: 1,393
+            &8■Lv10: 6,502
+            &8■Lv25: 41,918
+            &8■Lv50: 162,694
+            &8■Lv100: 619,023
+
+            &8高Lvほど経験値
+            &8効率が低下します
+          - |
+            &0&l【職業スキル①】
+
+            &d経験値節約
+            &8Lv10〜 発動25〜70%
+            &8エンチャントコスト
+            &8を30%削減
+
+            &dボーナスエンチャント
+            &8Lv25〜 発動8〜25%
+            &8エンチャレベル+1
+          - |
+            &0&l【職業スキル②】
+
+            &d魔術の神秘
+            &8Lv45〜 発動5〜15%
+            &8希少エンチャントの
+            &8確率が2.0倍に
+
+            &dスキルはレベルUPで
+            &d発動率が上昇！
+          - |
+            &0&l【レベルUP特典】
+
+            &8到達報酬:
+            &8■Lv10: 200金塊
+            &8■Lv25: 500金塊
+            &8■Lv50: 1000金塊
+            &8■Lv75: 2000金塊
+
+            &8レベルに応じて
+            &8称号も変化！
+
+            &dLv50で転職可能！
+          - |
+            &0&l【稼ぐコツ】
+
+            &8■本棚15個で
+            　最大レベル解放
+            &8■経験値を貯めて
+            　おこう
+            &8■高レベルエンチャント
+            　は高値で売れる
+            &8■ラピスラズリを
+            　常備しよう
+          - |
+            &0&l【便利なコマンド】
+
+            &0/jobs stats
+            &8→ 職業の統計情報
+
+            &0/jobs info
+            &8→ 職業の詳細
+
+            &0/jobs guide
+            &8→ この本を再取得
       
     architect:
       display_name: "建築家"
@@ -295,6 +1191,138 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      # 職業ガイドブック設定
+      guide_book:
+        enabled: true
+        title: "&e&l建築家ガイドブック"
+        author: "TofuNomics職業組合"
+        pages:
+          - |
+            &0&l【建築家の仕事】
+
+            &0建築家は建築と
+            装飾を担当する
+            職業です。
+
+            建築で経験値と
+            報酬を獲得できます。
+          - |
+            &0&l【主な収入源】
+
+            &8建築ブロックを
+            &8取引所NPCで売却！
+
+            &0・石系ブロックが
+            　 基本
+            &0・装飾ブロックが
+            　 高額
+            &0・レベルUPで
+            　 売却ボーナス増加
+          - |
+            &0&l【経験値の上げ方】
+
+            &0対象ブロックを
+            設置すると職業
+            経験値を獲得！
+
+            &8■設置するブロック
+            　の種類で変化
+            &8■装飾ブロックは
+            　高経験値
+
+            &e建てて稼ごう！
+          - |
+            &0&l【経験値一覧①】
+
+            &8ブロック設置1個:
+
+            &8■石 8
+            &8■丸石 5
+            &8■各種板材 6
+            &8■レンガ 20
+            &8■ガラス 10
+          - |
+            &0&l【経験値一覧②】
+
+            &8ブロック設置1個:
+
+            &8■石レンガ 15
+            &8■クォーツブロック 30
+            &8■プリズマリン 40
+            &8■プルプァブロック 50
+            &8■エンドレンガ 60
+
+            &e装飾系ほど高経験値
+          - |
+            &0&l【必要経験値】
+
+            &8レベルUPに必要な
+            &8累計経験値:
+
+            &8■Lv5: 1,393
+            &8■Lv10: 6,502
+            &8■Lv25: 41,918
+            &8■Lv50: 162,694
+            &8■Lv100: 619,023
+
+            &8高Lvほど経験値
+            &8効率が低下します
+          - |
+            &0&l【職業スキル①】
+
+            &e材料節約
+            &8Lv10〜 発動15〜45%
+            &8建築材料を25%節約
+
+            &e建築の美学
+            &8Lv30〜 発動20〜60%
+            &8美観ボーナスで
+            &8価値が1.5倍
+          - |
+            &0&l【職業スキル②】
+
+            &e巨匠の設計
+            &8Lv50〜 規模で発動
+            &8100ブロック以上の
+            &8建築でボーナス
+
+            &eスキルはレベルUPで
+            &e効果が上昇！
+          - |
+            &0&l【レベルUP特典】
+
+            &8到達報酬:
+            &8■Lv10: 200金塊
+            &8■Lv25: 500金塊
+            &8■Lv50: 1000金塊
+            &8■Lv75: 2000金塊
+
+            &8レベルに応じて
+            &8称号も変化！
+
+            &eLv50で転職可能！
+          - |
+            &0&l【稼ぐコツ】
+
+            &8■石系ブロックが
+            　基本素材
+            &8■装飾ブロックは
+            　高値で売れる
+            &8■大規模建築で
+            　スキル発動
+            &8■染料で彩りを
+            　加えよう
+          - |
+            &0&l【便利なコマンド】
+
+            &0/jobs stats
+            &8→ 職業の統計情報
+
+            &0/jobs info
+            &8→ 職業の詳細
+
+            &0/jobs guide
+            &8→ この本を再取得
 
 # NPCシステム設定
 npc_system:
@@ -411,7 +1439,7 @@ npc_system:
       
       butcher:         # 肉屋（基本価格）
         name: "§c精肉店"
-        items: ["cooked_beef", "cooked_pork", "cooked_chicken", "cooked_mutton", "cooked_rabbit"]
+        items: ["cooked_beef", "cooked_porkchop", "cooked_chicken", "cooked_mutton", "cooked_rabbit"]
         price_multiplier: 1
       
       fishmonger:      # 魚屋（基本価格）
@@ -421,12 +1449,12 @@ npc_system:
       
       greengrocer:     # 八百屋（基本価格）
         name: "§a八百屋"
-        items: ["carrot", "potato", "beetroot", "apple", "sweet_berries", "melon_slice", "baked_potato"]
+        items: ["carrot", "potato", "beetroot", "apple", "sweet_berries", "melon_slice", "baked_potato", "glow_berries", "melon", "golden_carrot"]
         price_multiplier: 1
-      
+
       specialty:       # 特殊食品店（基本価格）
         name: "§d特産品店"
-        items: ["mushroom_stew", "rabbit_stew", "suspicious_stew"]
+        items: ["mushroom_stew", "rabbit_stew", "suspicious_stew", "golden_apple", "enchanted_golden_apple", "honey_bottle", "chorus_fruit", "beetroot_soup"]
         price_multiplier: 1
     
     # 販売アイテムと価格（基本価格 - NPCタイプ別に倍率適用）
@@ -439,7 +1467,7 @@ npc_system:
       
       # 調理済み肉類
       cooked_beef: 6        # 調理済み牛肉
-      cooked_pork: 5        # 調理済み豚肉
+      cooked_porkchop: 5        # 調理済み豚肉
       cooked_chicken: 5     # 調理済み鶏肉
       cooked_mutton: 5      # 調理済み羊肉      # 調理済み羊肉
       
@@ -471,6 +1499,17 @@ npc_system:
       
       # 特殊食品店用商品
       suspicious_stew: 5    # 怪しげなシチュー    # 怪しげなシチュー
+
+      # === 拡充: 高級・特殊食料 ===
+      golden_apple: 50          # 金のリンゴ
+      enchanted_golden_apple: 200  # エンチャントされた金のリンゴ
+      golden_carrot: 4          # 金のニンジン
+      glow_berries: 2           # 光るベリー
+      honey_bottle: 3           # ハチミツ入りの瓶
+      milk_bucket: 4            # 牛乳入りバケツ
+      melon: 4                  # スイカ（ブロック）
+      chorus_fruit: 3           # コーラスフルーツ
+      beetroot_soup: 4          # ビートルートスープ
     
     # メッセージ設定
     messages:
@@ -507,7 +1546,11 @@ npc_system:
     #   yaw: 0.0
     #   pitch: 0.0
     
+    # 原木1個あたりの板材産出数（バニラ準拠: 4）
+    planks_per_log: 4
+
     # 加工対応木材設定（原木→板材の対応）
+    # ここに追記するだけで加工対応木材を増やせる（コード変更不要）
     wood_types:
       oak_log: "oak_planks"
       birch_log: "birch_planks"
@@ -515,8 +1558,23 @@ npc_system:
       jungle_log: "jungle_planks"
       acacia_log: "acacia_planks"
       dark_oak_log: "dark_oak_planks"
+      mangrove_log: "mangrove_planks"
+      cherry_log: "cherry_planks"
       crimson_stem: "crimson_planks"
       warped_stem: "warped_planks"
+      # 竹ブロック→竹板材（バニラ比率は1:2だが、ここでは一律planks_per_logを適用）
+      bamboo_block: "bamboo_planks"
+      # 樹皮を剥いだ原木も加工対応
+      stripped_oak_log: "oak_planks"
+      stripped_birch_log: "birch_planks"
+      stripped_spruce_log: "spruce_planks"
+      stripped_jungle_log: "jungle_planks"
+      stripped_acacia_log: "acacia_planks"
+      stripped_dark_oak_log: "dark_oak_planks"
+      stripped_mangrove_log: "mangrove_planks"
+      stripped_cherry_log: "cherry_planks"
+      stripped_crimson_stem: "crimson_planks"
+      stripped_warped_stem: "warped_planks"
     
     # メッセージ設定
     messages:
@@ -637,67 +1695,284 @@ npc_system:
   #   items: []  # 空リストまたは未指定で全アイテム対応
 # アイテム買取価格設定（基準価格）
   item_prices:
-    # 鉱物系（tofunomicsワールド向け価格調整）
-    coal: 1
-    iron_ingot: 4
-    gold_ingot: 8
-    diamond: 60
-    emerald: 30
+    # 鉱物系（リリース前バランス調整: 高額アイテムを抑制し職業間格差を縮小）
+    coal: 1.5
+    iron_ingot: 6
+    gold_ingot: 10
+    diamond: 35
+    emerald: 20
     redstone: 1
     lapis_lazuli: 2
     copper_ingot: 2
     # 原石系
-    iron_ore: 3
-    gold_ore: 6
-    diamond_ore: 45
-    emerald_ore: 22
-    coal_ore: 0.5
-    copper_ore: 1
-    # 木材系（tofunomicsワールド向け価格調整）
-    oak_log: 0.2
-    birch_log: 0.2
-    spruce_log: 0.2
-    jungle_log: 0.4
-    acacia_log: 0.4
-    dark_oak_log: 0.4
-    mangrove_log: 0.4
-    cherry_log: 0.4
+    iron_ore: 5
+    gold_ore: 8
+    diamond_ore: 28
+    emerald_ore: 16
+    coal_ore: 1
+    copper_ore: 1.5
+    # 木材系（リリース前バランス調整: 採取系の極端な安値を是正）
+    oak_log: 0.5
+    birch_log: 0.5
+    spruce_log: 0.5
+    jungle_log: 0.7
+    acacia_log: 0.7
+    dark_oak_log: 0.7
+    mangrove_log: 0.7
+    cherry_log: 0.7
     # 木材製品
-    oak_planks: 0.1
-    birch_planks: 0.1
-    spruce_planks: 0.1
-    # 農作物系（tofunomicsワールド向け価格調整）
-    wheat: 0.3
-    potato: 0.2
-    carrot: 0.2
-    beetroot: 0.3
-    pumpkin: 1
-    melon: 1
-    sugar_cane: 0.2
-    cocoa_beans: 1
+    oak_planks: 0.12
+    birch_planks: 0.12
+    spruce_planks: 0.12
+    # 農作物系（リリース前バランス調整: 成長待機時間を考慮し増額）
+    wheat: 1.2
+    potato: 0.9
+    carrot: 0.9
+    beetroot: 1.2
+    pumpkin: 2
+    melon: 1.5
+    sugar_cane: 0.8
+    cocoa_beans: 1.5
+    nether_wart: 2
     # 畜産物
     beef: 2
-    pork: 2
-    chicken: 1
-    mutton: 1
+    porkchop: 2
+    chicken: 1.5
+    mutton: 1.5
     leather: 2
     milk_bucket: 2
-    egg: 0.3
-    # 魚類（tofunomicsワールド向け価格調整）
-    cod: 4
-    salmon: 5
-    tropical_fish: 7
-    pufferfish: 10
+    egg: 0.5
+    # 魚類（リリース前バランス調整: 釣りの直接収入減額分を売却単価で補填）
+    cod: 7
+    salmon: 8
+    tropical_fish: 11
+    pufferfish: 14
     # 宝物・レア素材
     prismarine_shard: 8
     prismarine_crystals: 12
-    nautilus_shell: 25
-    heart_of_the_sea: 150
+    nautilus_shell: 30
+    heart_of_the_sea: 120
     # エンチャント材料
     experience_bottle: 15
     blaze_rod: 20
     ender_pearl: 18
     ghast_tear: 35
+    # 鍛冶屋のクラフト品（リリース前バランス調整: 上級職の売却先を整備）
+    iron_pickaxe: 14
+    iron_sword: 10
+    iron_axe: 14
+    iron_shovel: 6
+    iron_hoe: 8
+    iron_helmet: 18
+    iron_chestplate: 30
+    iron_leggings: 26
+    iron_boots: 16
+    diamond_pickaxe: 70
+    diamond_sword: 50
+    diamond_axe: 70
+    shield: 8
+    # 建築家の建材（リリース前バランス調整: 上級職の売却先を整備）
+    stone_bricks: 1
+    smooth_stone: 1
+    quartz_block: 3
+    polished_blackstone: 2
+    bricks: 2
+    # 錬金術師の材料（リリース前バランス調整: 上級職の売却先を整備）
+    blaze_powder: 10
+    glowstone_dust: 3
+    fermented_spider_eye: 6
+    glistering_melon_slice: 5
+    magma_cream: 7
+    # ========================================================================
+    # 拡充アイテム（職業別の売却先を網羅的に追加）
+    # 価格はフラットマップで全職業共通の基準価格。職業別の振り分けは
+    # trading_posts の items リストで行う。同一キーの重複定義は厳禁。
+    # ========================================================================
+    # --- miner: 深層岩鉱石・ネザー鉱石・raw鉱石 ---
+    deepslate_coal_ore: 1.2
+    deepslate_iron_ore: 5.5
+    deepslate_gold_ore: 9
+    deepslate_diamond_ore: 30
+    deepslate_emerald_ore: 18
+    deepslate_redstone_ore: 1.2
+    deepslate_lapis_ore: 2.5
+    deepslate_copper_ore: 1.8
+    nether_gold_ore: 6
+    nether_quartz_ore: 2
+    ancient_debris: 90
+    netherite_scrap: 95
+    netherite_ingot: 320
+    raw_iron: 5
+    raw_gold: 8
+    raw_copper: 1.5
+    quartz: 2
+    amethyst_shard: 4
+    # --- woodcutter: 板材・剥いだ原木・苗木・竹 ---
+    jungle_planks: 0.12
+    acacia_planks: 0.12
+    dark_oak_planks: 0.12
+    mangrove_planks: 0.12
+    cherry_planks: 0.12
+    crimson_planks: 0.18
+    warped_planks: 0.18
+    bamboo_planks: 0.1
+    bamboo: 0.3
+    stick: 0.05
+    stripped_oak_log: 0.5
+    stripped_birch_log: 0.5
+    stripped_spruce_log: 0.5
+    stripped_jungle_log: 0.7
+    stripped_acacia_log: 0.7
+    stripped_dark_oak_log: 0.7
+    stripped_mangrove_log: 0.7
+    stripped_cherry_log: 0.7
+    oak_sapling: 0.5
+    birch_sapling: 0.5
+    spruce_sapling: 0.5
+    jungle_sapling: 0.7
+    acacia_sapling: 0.7
+    dark_oak_sapling: 0.7
+    cherry_sapling: 0.7
+    mangrove_propagule: 0.7
+    # --- farmer: 作物・種・畜産・染料植物 ---
+    melon_slice: 0.3
+    glow_berries: 1.0
+    apple: 1.5
+    wheat_seeds: 0.1
+    beetroot_seeds: 0.1
+    pumpkin_seeds: 0.1
+    melon_seeds: 0.1
+    bone_meal: 0.5
+    bone: 1.0
+    rabbit: 1.5
+    rabbit_hide: 0.8
+    feather: 0.5
+    hay_block: 10
+    honeycomb: 2
+    honey_bottle: 2
+    brown_mushroom: 0.5
+    red_mushroom: 0.5
+    poppy: 0.3
+    dandelion: 0.3
+    blue_orchid: 0.4
+    allium: 0.4
+    cornflower: 0.4
+    sunflower: 0.5
+    wither_rose: 3
+    # --- fisherman: 海洋素材 ---
+    cooked_cod: 8
+    cooked_salmon: 9
+    kelp: 0.3
+    dried_kelp: 0.5
+    sea_pickle: 1.5
+    seagrass: 0.3
+    ink_sac: 1.5
+    glow_ink_sac: 3
+    sponge: 8
+    wet_sponge: 6
+    turtle_egg: 5
+    turtle_scute: 8
+    cod_bucket: 8
+    tropical_fish_bucket: 14
+    lily_pad: 0.5
+    fishing_rod: 3
+    name_tag: 30
+    saddle: 25
+    # --- blacksmith: 装備・道具・netherite ---
+    diamond_shovel: 30
+    diamond_hoe: 35
+    diamond_helmet: 40
+    diamond_chestplate: 64
+    diamond_leggings: 56
+    diamond_boots: 36
+    chainmail_helmet: 10
+    chainmail_chestplate: 18
+    chainmail_leggings: 16
+    chainmail_boots: 9
+    golden_helmet: 12
+    golden_chestplate: 20
+    golden_leggings: 18
+    golden_boots: 11
+    golden_sword: 6
+    golden_pickaxe: 8
+    golden_axe: 8
+    golden_shovel: 5
+    golden_hoe: 5
+    netherite_helmet: 200
+    netherite_chestplate: 280
+    netherite_leggings: 250
+    netherite_boots: 180
+    netherite_sword: 240
+    netherite_pickaxe: 260
+    netherite_axe: 260
+    netherite_shovel: 220
+    netherite_hoe: 230
+    bow: 4
+    crossbow: 6
+    flint_and_steel: 2
+    shears: 2
+    bucket: 4
+    # --- alchemist: 醸造素材 ---
+    spider_eye: 2
+    golden_carrot: 3
+    rabbit_foot: 7
+    phantom_membrane: 10
+    nether_wart_block: 18
+    sugar: 0.3
+    glass_bottle: 0.5
+    dragon_breath: 25
+    turtle_helmet: 25
+    gunpowder: 2
+    slime_ball: 1.5
+    ender_eye: 22
+    # --- enchanter: エンチャント関連 ---
+    enchanted_book: 25
+    book: 2
+    bookshelf: 6
+    paper: 0.3
+    writable_book: 3
+    lapis_block: 18
+    amethyst_block: 16
+    glowstone: 4
+    sea_lantern: 6
+    # --- architect: 建材 ---
+    stone: 0.3
+    cobblestone: 0.1
+    smooth_stone_slab: 0.5
+    chiseled_stone_bricks: 1.2
+    cracked_stone_bricks: 0.9
+    mossy_stone_bricks: 1.2
+    deepslate: 0.3
+    cobbled_deepslate: 0.2
+    polished_deepslate: 0.5
+    deepslate_bricks: 0.8
+    deepslate_tiles: 0.8
+    tuff: 0.2
+    calcite: 0.5
+    dripstone_block: 0.5
+    sandstone: 0.5
+    smooth_sandstone: 0.8
+    red_sandstone: 0.5
+    prismarine: 3
+    prismarine_bricks: 4
+    dark_prismarine: 4
+    purpur_block: 4
+    end_stone: 1
+    end_stone_bricks: 5
+    nether_bricks: 1.5
+    red_nether_bricks: 2
+    blackstone: 1
+    polished_blackstone_bricks: 2.5
+    gilded_blackstone: 6
+    glass: 0.3
+    glass_pane: 0.2
+    terracotta: 0.5
+    white_concrete: 0.6
+    quartz_pillar: 3
+    quartz_bricks: 3
+    copper_block: 18
+    cut_copper: 18
+    oxidized_copper: 18
 
 # 土地保護システム設定
 land_protection:
@@ -716,6 +1991,22 @@ land_protection:
     - "tofuNomics_nether"  
     - "tofuNomics_the_end"
 
+# UX/UI演出設定（Minecraft 1.21対応）
+# 各演出はサーバー側で個別に無効化できます（未設定時はすべて有効）
+ux_enhancements:
+  # /jobs list や /balancetop のクリック/ホバー可能なリッチテキスト
+  clickable_messages: true
+  # 職業レベルアップ時の画面中央Title演出
+  levelup_title: true
+  # 職業レベルアップ時のパーティクル演出
+  levelup_particle: true
+  # 送金受取時のActionBar通知
+  pay_actionbar: true
+  # 取引営業時間のBossBar表示
+  trading_bossbar: true
+  # GUIの枠装飾（カラーガラスペイン）
+  gui_decoration: true
+
 # スコアボード設定
 scoreboard:
   # スコアボード機能の有効化
@@ -729,7 +2020,12 @@ scoreboard:
   
   # 更新間隔（秒）
   update_interval: 1
-  
+
+  # 職業レベルをバニラ経験値バー（画面下のレベル数字・緑バー）に反映する
+  # true: 現在の職業のレベルと次レベルまでの進捗をバニラ経験値バーに表示
+  # 対象ワールド外や職業なしの場合はバーを0にリセットする
+  vanilla_exp_bar: true
+
   # スコアボード表示対象ワールド
   enabled_worlds:
     - "tofuNomics"
@@ -925,9 +2221,6 @@ events:
   excluded_worlds:
     - "creative_world"
     - "test_world"
-    - "world"
-    - "world_nether"
-    - "world_the_end"
   
   # 除外ゲームモード（常に除外: CREATIVE, SPECTATOR）
   excluded_game_modes:
@@ -1031,15 +2324,15 @@ trade_system:
     woodcutter: 1.0  # 木こりは基本価格のみ
     farmer: 1.0      # 農家は基本価格のみ
     
-    # 中級職業（50%ボーナス）
-    miner: 1.5       # 鉱夫は鉱石系アイテムを50%高く買取
-    fisherman: 1.5   # 漁師は魚類を50%高く買取
-    architect: 1.5   # 建築家は建材を50%高く買取
+    # 中級職業（リリース前バランス調整: 格差縮小 1.5→1.2）
+    miner: 1.2       # 鉱夫は鉱石系アイテムを20%高く買取
+    fisherman: 1.2   # 漁師は魚類を20%高く買取
+    architect: 1.2   # 建築家は建材を20%高く買取
     
-    # 上級職業（100%ボーナス）
-    blacksmith: 2.0  # 鍛冶屋は道具・武器を100%高く買取
-    alchemist: 2.0   # 錬金術師はポーション材料を100%高く買取
-    enchanter: 2.0   # エンチャンターはエンチャント関連を100%高く買取 建築家は建材を15%高く買取
+    # 上級職業（リリース前バランス調整: 格差縮小 2.0→1.4）
+    blacksmith: 1.4  # 鍛冶屋は道具・武器を40%高く買取
+    alchemist: 1.4   # 錬金術師はポーション材料を40%高く買取
+    enchanter: 1.4   # エンチャンターはエンチャント関連を40%高く買取
   
   # 取引履歴の保存設定
   history:
@@ -1302,9 +2595,18 @@ job_skills:
 leveling:
   # 経験値計算設定
   experience:
-    # 基本経験値計算式: base_multiplier * (level ^ exponent)
+    # 必要経験値計算式: base_multiplier * ((level - 1) ^ exponent)
     base_multiplier: 100
-    exponent: 2.0
+    # リリース前バランス調整: 旧2.2(ハードコード) → 1.9 に緩和しLv100到達を現実的に
+    exponent: 1.9
+
+    # 高レベル時の経験値獲得ペナルティ（実効 = max(minimum, 1.0 - level * factor)）
+    # リリース前バランス調整: factor 0.01→0.005, minimum 0.1→0.4 に緩和
+    level_penalty:
+      factor: 0.005
+      minimum: 0.4
+
+    # 注意: 下記 level_scaling は現行実装（ExperienceManager）では未使用
     
     # レベル毎の経験値上昇率調整
     level_scaling:
@@ -2053,3 +3355,125 @@ city_map:
     - "§7  - §b🍖 食料店§7: 食料の購入"
     - "§7  - §b🏘️ 商店街§7: プレイヤー間取引"
 
+# ========================================
+# tohu-app API連携設定
+# ========================================
+api:
+  tohu_app:
+    # 機能の有効/無効
+    enabled: false
+
+    # APIベースURL
+    base_url: "http://localhost:3000"
+
+    # 認証トークン（現時点では不要、将来の拡張用）
+    token: ""
+
+    # ワールドID（tohu-appのworld_idに対応）
+    world_id: 1
+
+
+    # リトライ設定
+    retry:
+      # 最大リトライ回数
+      max_attempts: 3
+      # 初回リトライまでの待機時間（秒）
+      initial_delay_seconds: 5
+
+    # デバッグモード（詳細ログ出力）
+    debug: false
+
+# ========================================
+# チュートリアルシステム設定
+# ========================================
+tutorial:
+  # チュートリアルシステムの有効化
+  enabled: true
+
+  # 新規プレイヤーに自動開始
+  auto_start: true
+
+  # チュートリアル開始遅延（秒）- ウェルカムメッセージ後
+  start_delay_seconds: 10
+
+  # ステップ間のメッセージ遅延（tick）
+  step_message_delay: 60
+
+  # 完了報酬
+  completion_rewards:
+    enabled: true
+    money: 50.0
+
+  # メッセージ設定
+  messages:
+    # チュートリアル開始
+    start:
+      - "&e%player%さん、ようこそ！基本を案内します &7(/tutorial skip でスキップ)"
+
+    # ステップ1: 職業選択
+    step1:
+      title: "&6【1/4】&f職業に就こう → &e/jobs join <職業名>"
+      description:
+        - "&7職業: 鉱夫, 木こり, 農家, 釣り人, 鍛冶屋, ポーション屋, エンチャンター, 建築家"
+      complete: "&a✓ 職業に就職しました！"
+
+    # ステップ2: 初収入
+    step2:
+      title: "&6【2/4】&fお金を稼ごう"
+      description:
+        - "&7職業に応じた作業（採掘、伐採、収穫など）をしてみましょう"
+      complete: "&a✓ 初めての収入を獲得！"
+
+    # ステップ3: 銀行NPC
+    step3:
+      title: "&6【3/4】&f銀行NPCに話しかけよう"
+      description:
+        - "&7街にいる銀行員を右クリックして預け入れ・引き出しができます"
+      complete: "&a✓ 銀行を利用しました！"
+
+    # ステップ4: 取引NPC
+    step4:
+      title: "&6【4/4】&f取引NPCでアイテムを売ろう"
+      description:
+        - "&7街にいる商人を右クリックしてアイテムを売買できます"
+      complete: "&a✓ 取引所を利用しました！"
+
+    # チュートリアル完了
+    completed:
+      - "&a🎉 チュートリアル完了！自由に経済活動を楽しんでください"
+    completed_reward: "&6報酬: &f%money%%currency% &6獲得！"
+
+    # スキップ
+    skip_confirm: "&eチュートリアルをスキップしますか？ &f/tutorial skip confirm &eで確定"
+    skip_success: "&aチュートリアルをスキップしました。"
+    skip_note: "&7いつでも &f/tutorial restart &7でやり直せます。"
+
+    # 進捗表示
+    progress:
+      header: "&6▬▬▬▬▬▬▬▬ チュートリアル進捗 ▬▬▬▬▬▬▬▬"
+      current_step: "&e現在のステップ: &f%step%"
+      step_complete: "&a✓ %step_name% - 完了"
+      step_current: "&e→ %step_name% - 進行中"
+      step_pending: "&7○ %step_name% - 未完了"
+
+    # エラー・その他
+    already_completed: "&eチュートリアルは既に完了しています。"
+    not_started: "&cチュートリアルがまだ開始されていません。"
+    restart_success: "&aチュートリアルを最初からやり直します。"
+    admin_reset_success: "&a%player%さんのチュートリアルをリセットしました。"
+
+# ===================================
+# 職業ガイドブック設定
+# ===================================
+guide_book_settings:
+  # ガイドブック機能の有効化
+  enabled: true
+  
+  # 重複配布を防止するか（同じ職業のガイドブックを既に持っている場合はスキップ）
+  prevent_duplicate: true
+  
+  # インベントリが満杯の場合に足元にドロップするか
+  drop_when_full: true
+  
+  # ガイドブック配布時のメッセージ
+  give_message: "&a【職業ガイド】&f%job%のガイドブックを受け取りました！"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,6 +5,7 @@ api-version: '1.21'
 description: tofunomicsワールド専用経済プラグイン
 author: TofuNomics Team
 website: https://github.com/tofu-server/TofuNomics
+depend: [WorldGuard]
 
 commands:
   balance:

--- a/src/main/resources/server_config.yml
+++ b/src/main/resources/server_config.yml
@@ -1,5 +1,3 @@
-# TofuNomics プラグイン設定ファイル
-# Minecraftサーバー「Tofu」独自経済プラグイン
 messages:
   npc:
     unknown_type: '&cNPCの種類が不明です。'
@@ -711,7 +709,7 @@ npc_system:
         name: §c精肉店
         items:
         - cooked_beef
-        - cooked_pork
+        - cooked_porkchop
         - cooked_chicken
         - cooked_mutton
         - cooked_rabbit
@@ -734,6 +732,9 @@ npc_system:
         - sweet_berries
         - melon_slice
         - baked_potato
+        - glow_berries
+        - melon
+        - golden_carrot
         price_multiplier: 1.0
       specialty:
         name: §d特産品店
@@ -741,6 +742,11 @@ npc_system:
         - mushroom_stew
         - rabbit_stew
         - suspicious_stew
+        - golden_apple
+        - enchanted_golden_apple
+        - honey_bottle
+        - chorus_fruit
+        - beetroot_soup
         price_multiplier: 1.0
     food_items:
       bread: 2.5
@@ -748,7 +754,7 @@ npc_system:
       carrot: 1.5
       apple: 2.0
       cooked_beef: 5.2
-      cooked_pork: 4.8
+      cooked_porkchop: 4.8
       cooked_chicken: 4.2
       cooked_mutton: 4.5
       mushroom_stew: 3.5
@@ -766,6 +772,15 @@ npc_system:
       cake: 8.0
       cooked_rabbit: 4.0
       suspicious_stew: 5.0
+      golden_apple: 50
+      enchanted_golden_apple: 200
+      golden_carrot: 4
+      glow_berries: 2
+      honey_bottle: 3
+      milk_bucket: 4
+      melon: 4
+      chorus_fruit: 3
+      beetroot_soup: 4
     messages:
       greeting: §6「夜分にすみません、%player%さん」
       welcome: §e「緊急時の食料でしたら、こちらで調達できますよ」
@@ -775,58 +790,259 @@ npc_system:
       purchase_success: §a%item% x%amount%を %price% で購入しました
       insufficient_funds: '§c残高が不足しています。必要: %required%'
   item_prices:
-    coal: 1
-    iron_ingot: 4
-    gold_ingot: 8
-    diamond: 60.0
-    emerald: 30.0
+    coal: 1.5
+    iron_ingot: 6
+    gold_ingot: 10
+    diamond: 35.0
+    emerald: 20.0
     redstone: 1
     lapis_lazuli: 2
     copper_ingot: 2
-    iron_ore: 3
-    gold_ore: 6
-    diamond_ore: 45.0
-    emerald_ore: 22.0
-    coal_ore: 0.5
-    copper_ore: 1
-    oak_log: 0.2
-    birch_log: 0.2
-    spruce_log: 0.2
-    jungle_log: 0.4
-    acacia_log: 0.4
-    dark_oak_log: 0.4
-    mangrove_log: 0.4
-    cherry_log: 0.4
-    oak_planks: 0.1
-    birch_planks: 0.1
-    spruce_planks: 0.1
-    wheat: 0.3
-    potato: 0.2
-    carrot: 0.2
-    beetroot: 0.3
-    pumpkin: 1
-    melon: 1
-    sugar_cane: 0.2
-    cocoa_beans: 1
+    iron_ore: 5
+    gold_ore: 8
+    diamond_ore: 28.0
+    emerald_ore: 16.0
+    coal_ore: 1
+    copper_ore: 1.5
+    oak_log: 0.5
+    birch_log: 0.5
+    spruce_log: 0.5
+    jungle_log: 0.7
+    acacia_log: 0.7
+    dark_oak_log: 0.7
+    mangrove_log: 0.7
+    cherry_log: 0.7
+    oak_planks: 0.12
+    birch_planks: 0.12
+    spruce_planks: 0.12
+    wheat: 1.2
+    potato: 0.9
+    carrot: 0.9
+    beetroot: 1.2
+    pumpkin: 2
+    melon: 1.5
+    sugar_cane: 0.8
+    cocoa_beans: 1.5
+    nether_wart: 2
     beef: 2
-    pork: 2
-    chicken: 1
-    mutton: 1
+    porkchop: 2
+    chicken: 1.5
+    mutton: 1.5
     leather: 2
     milk_bucket: 2
-    egg: 0.3
-    cod: 3.5
-    salmon: 4.5
-    tropical_fish: 7.0
-    pufferfish: 9.5
+    egg: 0.5
+    cod: 7
+    salmon: 8
+    tropical_fish: 11
+    pufferfish: 14
     prismarine_shard: 8.0
     prismarine_crystals: 12.0
-    nautilus_shell: 25.0
-    heart_of_the_sea: 150.0
+    nautilus_shell: 30.0
+    heart_of_the_sea: 120.0
     experience_bottle: 15.0
     blaze_rod: 20.0
     ender_pearl: 18.0
     ghast_tear: 35.0
+    iron_pickaxe: 14
+    iron_sword: 10
+    iron_axe: 14
+    iron_shovel: 6
+    iron_hoe: 8
+    iron_helmet: 18
+    iron_chestplate: 30
+    iron_leggings: 26
+    iron_boots: 16
+    diamond_pickaxe: 70
+    diamond_sword: 50
+    diamond_axe: 70
+    shield: 8
+    stone_bricks: 1
+    smooth_stone: 1
+    quartz_block: 3
+    polished_blackstone: 2
+    bricks: 2
+    blaze_powder: 10
+    glowstone_dust: 3
+    fermented_spider_eye: 6
+    glistering_melon_slice: 5
+    magma_cream: 7
+    deepslate_coal_ore: 1.2
+    deepslate_iron_ore: 5.5
+    deepslate_gold_ore: 9
+    deepslate_diamond_ore: 30
+    deepslate_emerald_ore: 18
+    deepslate_redstone_ore: 1.2
+    deepslate_lapis_ore: 2.5
+    deepslate_copper_ore: 1.8
+    nether_gold_ore: 6
+    nether_quartz_ore: 2
+    ancient_debris: 90
+    netherite_scrap: 95
+    netherite_ingot: 320
+    raw_iron: 5
+    raw_gold: 8
+    raw_copper: 1.5
+    quartz: 2
+    amethyst_shard: 4
+    jungle_planks: 0.12
+    acacia_planks: 0.12
+    dark_oak_planks: 0.12
+    mangrove_planks: 0.12
+    cherry_planks: 0.12
+    crimson_planks: 0.18
+    warped_planks: 0.18
+    bamboo_planks: 0.1
+    bamboo: 0.3
+    stick: 0.05
+    stripped_oak_log: 0.5
+    stripped_birch_log: 0.5
+    stripped_spruce_log: 0.5
+    stripped_jungle_log: 0.7
+    stripped_acacia_log: 0.7
+    stripped_dark_oak_log: 0.7
+    stripped_mangrove_log: 0.7
+    stripped_cherry_log: 0.7
+    oak_sapling: 0.5
+    birch_sapling: 0.5
+    spruce_sapling: 0.5
+    jungle_sapling: 0.7
+    acacia_sapling: 0.7
+    dark_oak_sapling: 0.7
+    cherry_sapling: 0.7
+    mangrove_propagule: 0.7
+    melon_slice: 0.3
+    glow_berries: 1.0
+    apple: 1.5
+    wheat_seeds: 0.1
+    beetroot_seeds: 0.1
+    pumpkin_seeds: 0.1
+    melon_seeds: 0.1
+    bone_meal: 0.5
+    bone: 1.0
+    rabbit: 1.5
+    rabbit_hide: 0.8
+    feather: 0.5
+    hay_block: 10
+    honeycomb: 2
+    honey_bottle: 2
+    brown_mushroom: 0.5
+    red_mushroom: 0.5
+    poppy: 0.3
+    dandelion: 0.3
+    blue_orchid: 0.4
+    allium: 0.4
+    cornflower: 0.4
+    sunflower: 0.5
+    wither_rose: 3
+    cooked_cod: 8
+    cooked_salmon: 9
+    kelp: 0.3
+    dried_kelp: 0.5
+    sea_pickle: 1.5
+    seagrass: 0.3
+    ink_sac: 1.5
+    glow_ink_sac: 3
+    sponge: 8
+    wet_sponge: 6
+    turtle_egg: 5
+    turtle_scute: 8
+    cod_bucket: 8
+    tropical_fish_bucket: 14
+    lily_pad: 0.5
+    fishing_rod: 3
+    name_tag: 30
+    saddle: 25
+    diamond_shovel: 30
+    diamond_hoe: 35
+    diamond_helmet: 40
+    diamond_chestplate: 64
+    diamond_leggings: 56
+    diamond_boots: 36
+    chainmail_helmet: 10
+    chainmail_chestplate: 18
+    chainmail_leggings: 16
+    chainmail_boots: 9
+    golden_helmet: 12
+    golden_chestplate: 20
+    golden_leggings: 18
+    golden_boots: 11
+    golden_sword: 6
+    golden_pickaxe: 8
+    golden_axe: 8
+    golden_shovel: 5
+    golden_hoe: 5
+    netherite_helmet: 200
+    netherite_chestplate: 280
+    netherite_leggings: 250
+    netherite_boots: 180
+    netherite_sword: 240
+    netherite_pickaxe: 260
+    netherite_axe: 260
+    netherite_shovel: 220
+    netherite_hoe: 230
+    bow: 4
+    crossbow: 6
+    flint_and_steel: 2
+    shears: 2
+    bucket: 4
+    spider_eye: 2
+    golden_carrot: 3
+    rabbit_foot: 7
+    phantom_membrane: 10
+    nether_wart_block: 18
+    sugar: 0.3
+    glass_bottle: 0.5
+    dragon_breath: 25
+    turtle_helmet: 25
+    gunpowder: 2
+    slime_ball: 1.5
+    ender_eye: 22
+    enchanted_book: 25
+    book: 2
+    bookshelf: 6
+    paper: 0.3
+    writable_book: 3
+    lapis_block: 18
+    amethyst_block: 16
+    glowstone: 4
+    sea_lantern: 6
+    stone: 0.3
+    cobblestone: 0.1
+    smooth_stone_slab: 0.5
+    chiseled_stone_bricks: 1.2
+    cracked_stone_bricks: 0.9
+    mossy_stone_bricks: 1.2
+    deepslate: 0.3
+    cobbled_deepslate: 0.2
+    polished_deepslate: 0.5
+    deepslate_bricks: 0.8
+    deepslate_tiles: 0.8
+    tuff: 0.2
+    calcite: 0.5
+    dripstone_block: 0.5
+    sandstone: 0.5
+    smooth_sandstone: 0.8
+    red_sandstone: 0.5
+    prismarine: 3
+    prismarine_bricks: 4
+    dark_prismarine: 4
+    purpur_block: 4
+    end_stone: 1
+    end_stone_bricks: 5
+    nether_bricks: 1.5
+    red_nether_bricks: 2
+    blackstone: 1
+    polished_blackstone_bricks: 2.5
+    gilded_blackstone: 6
+    glass: 0.3
+    glass_pane: 0.2
+    terracotta: 0.5
+    white_concrete: 0.6
+    quartz_pillar: 3
+    quartz_bricks: 3
+    copper_block: 18
+    cut_copper: 18
+    oxidized_copper: 18
   trading_posts:
   - world: tofuNomics
     name: §6総合取引所
@@ -864,6 +1080,24 @@ npc_system:
     - lapis_lazuli
     - copper_ore
     - copper_ingot
+    - deepslate_coal_ore
+    - deepslate_iron_ore
+    - deepslate_gold_ore
+    - deepslate_diamond_ore
+    - deepslate_emerald_ore
+    - deepslate_redstone_ore
+    - deepslate_lapis_ore
+    - deepslate_copper_ore
+    - nether_gold_ore
+    - nether_quartz_ore
+    - ancient_debris
+    - netherite_scrap
+    - netherite_ingot
+    - raw_iron
+    - raw_gold
+    - raw_copper
+    - quartz
+    - amethyst_shard
     purchase_prices:
       wooden_pickaxe: 15
       stone_pickaxe: 15
@@ -891,6 +1125,24 @@ npc_system:
     - lapis_lazuli
     - copper_ore
     - copper_ingot
+    - deepslate_coal_ore
+    - deepslate_iron_ore
+    - deepslate_gold_ore
+    - deepslate_diamond_ore
+    - deepslate_emerald_ore
+    - deepslate_redstone_ore
+    - deepslate_lapis_ore
+    - deepslate_copper_ore
+    - nether_gold_ore
+    - nether_quartz_ore
+    - ancient_debris
+    - netherite_scrap
+    - netherite_ingot
+    - raw_iron
+    - raw_gold
+    - raw_copper
+    - quartz
+    - amethyst_shard
     purchase_prices:
       wooden_pickaxe: 15
       stone_pickaxe: 15
@@ -918,6 +1170,24 @@ npc_system:
     - lapis_lazuli
     - copper_ore
     - copper_ingot
+    - deepslate_coal_ore
+    - deepslate_iron_ore
+    - deepslate_gold_ore
+    - deepslate_diamond_ore
+    - deepslate_emerald_ore
+    - deepslate_redstone_ore
+    - deepslate_lapis_ore
+    - deepslate_copper_ore
+    - nether_gold_ore
+    - nether_quartz_ore
+    - ancient_debris
+    - netherite_scrap
+    - netherite_ingot
+    - raw_iron
+    - raw_gold
+    - raw_copper
+    - quartz
+    - amethyst_shard
     purchase_prices:
       wooden_pickaxe: 15
       stone_pickaxe: 15
@@ -942,6 +1212,32 @@ npc_system:
     - oak_planks
     - birch_planks
     - spruce_planks
+    - jungle_planks
+    - acacia_planks
+    - dark_oak_planks
+    - mangrove_planks
+    - cherry_planks
+    - crimson_planks
+    - warped_planks
+    - bamboo_planks
+    - bamboo
+    - stick
+    - stripped_oak_log
+    - stripped_birch_log
+    - stripped_spruce_log
+    - stripped_jungle_log
+    - stripped_acacia_log
+    - stripped_dark_oak_log
+    - stripped_mangrove_log
+    - stripped_cherry_log
+    - oak_sapling
+    - birch_sapling
+    - spruce_sapling
+    - jungle_sapling
+    - acacia_sapling
+    - dark_oak_sapling
+    - cherry_sapling
+    - mangrove_propagule
     purchase_prices:
       wooden_axe: 15
       stone_axe: 15
@@ -966,6 +1262,32 @@ npc_system:
     - oak_planks
     - birch_planks
     - spruce_planks
+    - jungle_planks
+    - acacia_planks
+    - dark_oak_planks
+    - mangrove_planks
+    - cherry_planks
+    - crimson_planks
+    - warped_planks
+    - bamboo_planks
+    - bamboo
+    - stick
+    - stripped_oak_log
+    - stripped_birch_log
+    - stripped_spruce_log
+    - stripped_jungle_log
+    - stripped_acacia_log
+    - stripped_dark_oak_log
+    - stripped_mangrove_log
+    - stripped_cherry_log
+    - oak_sapling
+    - birch_sapling
+    - spruce_sapling
+    - jungle_sapling
+    - acacia_sapling
+    - dark_oak_sapling
+    - cherry_sapling
+    - mangrove_propagule
     purchase_prices:
       wooden_axe: 15
       stone_axe: 15
@@ -990,6 +1312,32 @@ npc_system:
     - oak_planks
     - birch_planks
     - spruce_planks
+    - jungle_planks
+    - acacia_planks
+    - dark_oak_planks
+    - mangrove_planks
+    - cherry_planks
+    - crimson_planks
+    - warped_planks
+    - bamboo_planks
+    - bamboo
+    - stick
+    - stripped_oak_log
+    - stripped_birch_log
+    - stripped_spruce_log
+    - stripped_jungle_log
+    - stripped_acacia_log
+    - stripped_dark_oak_log
+    - stripped_mangrove_log
+    - stripped_cherry_log
+    - oak_sapling
+    - birch_sapling
+    - spruce_sapling
+    - jungle_sapling
+    - acacia_sapling
+    - dark_oak_sapling
+    - cherry_sapling
+    - mangrove_propagule
     purchase_prices:
       wooden_axe: 15
       stone_axe: 15
@@ -1012,12 +1360,37 @@ npc_system:
     - sugar_cane
     - cocoa_beans
     - beef
-    - pork
+    - porkchop
     - chicken
     - mutton
     - leather
     - milk_bucket
     - egg
+    - nether_wart
+    - melon_slice
+    - glow_berries
+    - apple
+    - wheat_seeds
+    - beetroot_seeds
+    - pumpkin_seeds
+    - melon_seeds
+    - bone_meal
+    - bone
+    - rabbit
+    - rabbit_hide
+    - feather
+    - hay_block
+    - honeycomb
+    - honey_bottle
+    - brown_mushroom
+    - red_mushroom
+    - poppy
+    - dandelion
+    - blue_orchid
+    - allium
+    - cornflower
+    - sunflower
+    - wither_rose
     purchase_prices:
       wooden_hoe: 15
       stone_hoe: 15
@@ -1041,12 +1414,37 @@ npc_system:
     - sugar_cane
     - cocoa_beans
     - beef
-    - pork
+    - porkchop
     - chicken
     - mutton
     - leather
     - milk_bucket
     - egg
+    - nether_wart
+    - melon_slice
+    - glow_berries
+    - apple
+    - wheat_seeds
+    - beetroot_seeds
+    - pumpkin_seeds
+    - melon_seeds
+    - bone_meal
+    - bone
+    - rabbit
+    - rabbit_hide
+    - feather
+    - hay_block
+    - honeycomb
+    - honey_bottle
+    - brown_mushroom
+    - red_mushroom
+    - poppy
+    - dandelion
+    - blue_orchid
+    - allium
+    - cornflower
+    - sunflower
+    - wither_rose
     purchase_prices:
       wooden_hoe: 15
       stone_hoe: 15
@@ -1070,12 +1468,37 @@ npc_system:
     - sugar_cane
     - cocoa_beans
     - beef
-    - pork
+    - porkchop
     - chicken
     - mutton
     - leather
     - milk_bucket
     - egg
+    - nether_wart
+    - melon_slice
+    - glow_berries
+    - apple
+    - wheat_seeds
+    - beetroot_seeds
+    - pumpkin_seeds
+    - melon_seeds
+    - bone_meal
+    - bone
+    - rabbit
+    - rabbit_hide
+    - feather
+    - hay_block
+    - honeycomb
+    - honey_bottle
+    - brown_mushroom
+    - red_mushroom
+    - poppy
+    - dandelion
+    - blue_orchid
+    - allium
+    - cornflower
+    - sunflower
+    - wither_rose
     purchase_prices:
       wooden_hoe: 15
       stone_hoe: 15
@@ -1099,12 +1522,37 @@ npc_system:
     - sugar_cane
     - cocoa_beans
     - beef
-    - pork
+    - porkchop
     - chicken
     - mutton
     - leather
     - milk_bucket
     - egg
+    - nether_wart
+    - melon_slice
+    - glow_berries
+    - apple
+    - wheat_seeds
+    - beetroot_seeds
+    - pumpkin_seeds
+    - melon_seeds
+    - bone_meal
+    - bone
+    - rabbit
+    - rabbit_hide
+    - feather
+    - hay_block
+    - honeycomb
+    - honey_bottle
+    - brown_mushroom
+    - red_mushroom
+    - poppy
+    - dandelion
+    - blue_orchid
+    - allium
+    - cornflower
+    - sunflower
+    - wither_rose
     purchase_prices:
       wooden_hoe: 15
       stone_hoe: 15
@@ -1128,12 +1576,37 @@ npc_system:
     - sugar_cane
     - cocoa_beans
     - beef
-    - pork
+    - porkchop
     - chicken
     - mutton
     - leather
     - milk_bucket
     - egg
+    - nether_wart
+    - melon_slice
+    - glow_berries
+    - apple
+    - wheat_seeds
+    - beetroot_seeds
+    - pumpkin_seeds
+    - melon_seeds
+    - bone_meal
+    - bone
+    - rabbit
+    - rabbit_hide
+    - feather
+    - hay_block
+    - honeycomb
+    - honey_bottle
+    - brown_mushroom
+    - red_mushroom
+    - poppy
+    - dandelion
+    - blue_orchid
+    - allium
+    - cornflower
+    - sunflower
+    - wither_rose
     purchase_prices:
       wooden_hoe: 15
       stone_hoe: 15
@@ -1157,12 +1630,37 @@ npc_system:
     - sugar_cane
     - cocoa_beans
     - beef
-    - pork
+    - porkchop
     - chicken
     - mutton
     - leather
     - milk_bucket
     - egg
+    - nether_wart
+    - melon_slice
+    - glow_berries
+    - apple
+    - wheat_seeds
+    - beetroot_seeds
+    - pumpkin_seeds
+    - melon_seeds
+    - bone_meal
+    - bone
+    - rabbit
+    - rabbit_hide
+    - feather
+    - hay_block
+    - honeycomb
+    - honey_bottle
+    - brown_mushroom
+    - red_mushroom
+    - poppy
+    - dandelion
+    - blue_orchid
+    - allium
+    - cornflower
+    - sunflower
+    - wither_rose
     purchase_prices:
       wooden_hoe: 15
       stone_hoe: 15
@@ -1185,6 +1683,24 @@ npc_system:
     - prismarine_crystals
     - nautilus_shell
     - heart_of_the_sea
+    - cooked_cod
+    - cooked_salmon
+    - kelp
+    - dried_kelp
+    - sea_pickle
+    - seagrass
+    - ink_sac
+    - glow_ink_sac
+    - sponge
+    - wet_sponge
+    - turtle_egg
+    - turtle_scute
+    - cod_bucket
+    - tropical_fish_bucket
+    - lily_pad
+    - fishing_rod
+    - name_tag
+    - saddle
     purchase_prices:
       string: 5
   - world: tofuNomics
@@ -1205,6 +1721,24 @@ npc_system:
     - prismarine_crystals
     - nautilus_shell
     - heart_of_the_sea
+    - cooked_cod
+    - cooked_salmon
+    - kelp
+    - dried_kelp
+    - sea_pickle
+    - seagrass
+    - ink_sac
+    - glow_ink_sac
+    - sponge
+    - wet_sponge
+    - turtle_egg
+    - turtle_scute
+    - cod_bucket
+    - tropical_fish_bucket
+    - lily_pad
+    - fishing_rod
+    - name_tag
+    - saddle
     purchase_prices:
       string: 5
   - world: tofuNomics
@@ -1225,6 +1759,24 @@ npc_system:
     - prismarine_crystals
     - nautilus_shell
     - heart_of_the_sea
+    - cooked_cod
+    - cooked_salmon
+    - kelp
+    - dried_kelp
+    - sea_pickle
+    - seagrass
+    - ink_sac
+    - glow_ink_sac
+    - sponge
+    - wet_sponge
+    - turtle_egg
+    - turtle_scute
+    - cod_bucket
+    - tropical_fish_bucket
+    - lily_pad
+    - fishing_rod
+    - name_tag
+    - saddle
     purchase_prices:
       string: 5
   - world: tofuNomics
@@ -1245,6 +1797,24 @@ npc_system:
     - prismarine_crystals
     - nautilus_shell
     - heart_of_the_sea
+    - cooked_cod
+    - cooked_salmon
+    - kelp
+    - dried_kelp
+    - sea_pickle
+    - seagrass
+    - ink_sac
+    - glow_ink_sac
+    - sponge
+    - wet_sponge
+    - turtle_egg
+    - turtle_scute
+    - cod_bucket
+    - tropical_fish_bucket
+    - lily_pad
+    - fishing_rod
+    - name_tag
+    - saddle
     purchase_prices:
       string: 5
   - world: tofuNomics
@@ -1265,6 +1835,24 @@ npc_system:
     - prismarine_crystals
     - nautilus_shell
     - heart_of_the_sea
+    - cooked_cod
+    - cooked_salmon
+    - kelp
+    - dried_kelp
+    - sea_pickle
+    - seagrass
+    - ink_sac
+    - glow_ink_sac
+    - sponge
+    - wet_sponge
+    - turtle_egg
+    - turtle_scute
+    - cod_bucket
+    - tropical_fish_bucket
+    - lily_pad
+    - fishing_rod
+    - name_tag
+    - saddle
     purchase_prices:
       string: 5
   - world: tofuNomics
@@ -1285,6 +1873,24 @@ npc_system:
     - prismarine_crystals
     - nautilus_shell
     - heart_of_the_sea
+    - cooked_cod
+    - cooked_salmon
+    - kelp
+    - dried_kelp
+    - sea_pickle
+    - seagrass
+    - ink_sac
+    - glow_ink_sac
+    - sponge
+    - wet_sponge
+    - turtle_egg
+    - turtle_scute
+    - cod_bucket
+    - tropical_fish_bucket
+    - lily_pad
+    - fishing_rod
+    - name_tag
+    - saddle
     purchase_prices:
       string: 5
   - world: tofuNomics
@@ -1318,6 +1924,36 @@ npc_system:
     - diamond_leggings
     - diamond_boots
     - anvil
+    - iron_hoe
+    - diamond_hoe
+    - chainmail_helmet
+    - chainmail_chestplate
+    - chainmail_leggings
+    - chainmail_boots
+    - golden_helmet
+    - golden_chestplate
+    - golden_leggings
+    - golden_boots
+    - golden_sword
+    - golden_pickaxe
+    - golden_axe
+    - golden_shovel
+    - golden_hoe
+    - netherite_helmet
+    - netherite_chestplate
+    - netherite_leggings
+    - netherite_boots
+    - netherite_sword
+    - netherite_pickaxe
+    - netherite_axe
+    - netherite_shovel
+    - netherite_hoe
+    - shield
+    - bow
+    - crossbow
+    - flint_and_steel
+    - shears
+    - bucket
     purchase_prices:
       coal: 10
       stone: 10
@@ -1352,6 +1988,36 @@ npc_system:
     - diamond_leggings
     - diamond_boots
     - anvil
+    - iron_hoe
+    - diamond_hoe
+    - chainmail_helmet
+    - chainmail_chestplate
+    - chainmail_leggings
+    - chainmail_boots
+    - golden_helmet
+    - golden_chestplate
+    - golden_leggings
+    - golden_boots
+    - golden_sword
+    - golden_pickaxe
+    - golden_axe
+    - golden_shovel
+    - golden_hoe
+    - netherite_helmet
+    - netherite_chestplate
+    - netherite_leggings
+    - netherite_boots
+    - netherite_sword
+    - netherite_pickaxe
+    - netherite_axe
+    - netherite_shovel
+    - netherite_hoe
+    - shield
+    - bow
+    - crossbow
+    - flint_and_steel
+    - shears
+    - bucket
     purchase_prices:
       coal: 10
       stone: 10
@@ -1386,6 +2052,36 @@ npc_system:
     - diamond_leggings
     - diamond_boots
     - anvil
+    - iron_hoe
+    - diamond_hoe
+    - chainmail_helmet
+    - chainmail_chestplate
+    - chainmail_leggings
+    - chainmail_boots
+    - golden_helmet
+    - golden_chestplate
+    - golden_leggings
+    - golden_boots
+    - golden_sword
+    - golden_pickaxe
+    - golden_axe
+    - golden_shovel
+    - golden_hoe
+    - netherite_helmet
+    - netherite_chestplate
+    - netherite_leggings
+    - netherite_boots
+    - netherite_sword
+    - netherite_pickaxe
+    - netherite_axe
+    - netherite_shovel
+    - netherite_hoe
+    - shield
+    - bow
+    - crossbow
+    - flint_and_steel
+    - shears
+    - bucket
     purchase_prices:
       coal: 10
       stone: 10
@@ -1420,6 +2116,36 @@ npc_system:
     - diamond_leggings
     - diamond_boots
     - anvil
+    - iron_hoe
+    - diamond_hoe
+    - chainmail_helmet
+    - chainmail_chestplate
+    - chainmail_leggings
+    - chainmail_boots
+    - golden_helmet
+    - golden_chestplate
+    - golden_leggings
+    - golden_boots
+    - golden_sword
+    - golden_pickaxe
+    - golden_axe
+    - golden_shovel
+    - golden_hoe
+    - netherite_helmet
+    - netherite_chestplate
+    - netherite_leggings
+    - netherite_boots
+    - netherite_sword
+    - netherite_pickaxe
+    - netherite_axe
+    - netherite_shovel
+    - netherite_hoe
+    - shield
+    - bow
+    - crossbow
+    - flint_and_steel
+    - shears
+    - bucket
     purchase_prices:
       coal: 10
       stone: 10
@@ -1454,6 +2180,36 @@ npc_system:
     - diamond_leggings
     - diamond_boots
     - anvil
+    - iron_hoe
+    - diamond_hoe
+    - chainmail_helmet
+    - chainmail_chestplate
+    - chainmail_leggings
+    - chainmail_boots
+    - golden_helmet
+    - golden_chestplate
+    - golden_leggings
+    - golden_boots
+    - golden_sword
+    - golden_pickaxe
+    - golden_axe
+    - golden_shovel
+    - golden_hoe
+    - netherite_helmet
+    - netherite_chestplate
+    - netherite_leggings
+    - netherite_boots
+    - netherite_sword
+    - netherite_pickaxe
+    - netherite_axe
+    - netherite_shovel
+    - netherite_hoe
+    - shield
+    - bow
+    - crossbow
+    - flint_and_steel
+    - shears
+    - bucket
     purchase_prices:
       coal: 10
       stone: 10
@@ -1488,6 +2244,36 @@ npc_system:
     - diamond_leggings
     - diamond_boots
     - anvil
+    - iron_hoe
+    - diamond_hoe
+    - chainmail_helmet
+    - chainmail_chestplate
+    - chainmail_leggings
+    - chainmail_boots
+    - golden_helmet
+    - golden_chestplate
+    - golden_leggings
+    - golden_boots
+    - golden_sword
+    - golden_pickaxe
+    - golden_axe
+    - golden_shovel
+    - golden_hoe
+    - netherite_helmet
+    - netherite_chestplate
+    - netherite_leggings
+    - netherite_boots
+    - netherite_sword
+    - netherite_pickaxe
+    - netherite_axe
+    - netherite_shovel
+    - netherite_hoe
+    - shield
+    - bow
+    - crossbow
+    - flint_and_steel
+    - shears
+    - bucket
     purchase_prices:
       coal: 10
       stone: 10
@@ -1512,6 +2298,22 @@ npc_system:
     - gunpowder
     - dragon_breath
     - brewing_stand
+    - fermented_spider_eye
+    - glistering_melon_slice
+    - magma_cream
+    - blaze_rod
+    - ender_pearl
+    - ghast_tear
+    - experience_bottle
+    - spider_eye
+    - golden_carrot
+    - rabbit_foot
+    - phantom_membrane
+    - nether_wart_block
+    - sugar
+    - turtle_helmet
+    - slime_ball
+    - ender_eye
     purchase_prices:
       glass_bottle: 5
       brewing_stand: 100
@@ -1536,6 +2338,22 @@ npc_system:
     - gunpowder
     - dragon_breath
     - brewing_stand
+    - fermented_spider_eye
+    - glistering_melon_slice
+    - magma_cream
+    - blaze_rod
+    - ender_pearl
+    - ghast_tear
+    - experience_bottle
+    - spider_eye
+    - golden_carrot
+    - rabbit_foot
+    - phantom_membrane
+    - nether_wart_block
+    - sugar
+    - turtle_helmet
+    - slime_ball
+    - ender_eye
     purchase_prices:
       glass_bottle: 5
       brewing_stand: 100
@@ -1560,6 +2378,22 @@ npc_system:
     - gunpowder
     - dragon_breath
     - brewing_stand
+    - fermented_spider_eye
+    - glistering_melon_slice
+    - magma_cream
+    - blaze_rod
+    - ender_pearl
+    - ghast_tear
+    - experience_bottle
+    - spider_eye
+    - golden_carrot
+    - rabbit_foot
+    - phantom_membrane
+    - nether_wart_block
+    - sugar
+    - turtle_helmet
+    - slime_ball
+    - ender_eye
     purchase_prices:
       glass_bottle: 5
       brewing_stand: 100
@@ -1579,6 +2413,12 @@ npc_system:
     - bookshelf
     - book
     - enchanting_table
+    - paper
+    - writable_book
+    - lapis_block
+    - amethyst_block
+    - glowstone
+    - sea_lantern
     purchase_prices:
       book: 10
       lapis_lazuli: 25
@@ -1598,6 +2438,12 @@ npc_system:
     - bookshelf
     - book
     - enchanting_table
+    - paper
+    - writable_book
+    - lapis_block
+    - amethyst_block
+    - glowstone
+    - sea_lantern
     purchase_prices:
       book: 10
       lapis_lazuli: 25
@@ -1617,6 +2463,12 @@ npc_system:
     - bookshelf
     - book
     - enchanting_table
+    - paper
+    - writable_book
+    - lapis_block
+    - amethyst_block
+    - glowstone
+    - sea_lantern
     purchase_prices:
       book: 10
       lapis_lazuli: 25
@@ -1649,6 +2501,39 @@ npc_system:
     - light_gray_concrete
     - bricks
     - sandstone
+    - smooth_stone
+    - polished_blackstone
+    - smooth_stone_slab
+    - chiseled_stone_bricks
+    - cracked_stone_bricks
+    - mossy_stone_bricks
+    - deepslate
+    - cobbled_deepslate
+    - polished_deepslate
+    - deepslate_bricks
+    - deepslate_tiles
+    - tuff
+    - calcite
+    - dripstone_block
+    - smooth_sandstone
+    - red_sandstone
+    - prismarine
+    - prismarine_bricks
+    - dark_prismarine
+    - purpur_block
+    - end_stone
+    - end_stone_bricks
+    - nether_bricks
+    - red_nether_bricks
+    - blackstone
+    - polished_blackstone_bricks
+    - gilded_blackstone
+    - glass_pane
+    - quartz_pillar
+    - quartz_bricks
+    - copper_block
+    - cut_copper
+    - oxidized_copper
     purchase_prices:
       lantern: 5
       torch: 5
@@ -1682,6 +2567,39 @@ npc_system:
     - light_gray_concrete
     - bricks
     - sandstone
+    - smooth_stone
+    - polished_blackstone
+    - smooth_stone_slab
+    - chiseled_stone_bricks
+    - cracked_stone_bricks
+    - mossy_stone_bricks
+    - deepslate
+    - cobbled_deepslate
+    - polished_deepslate
+    - deepslate_bricks
+    - deepslate_tiles
+    - tuff
+    - calcite
+    - dripstone_block
+    - smooth_sandstone
+    - red_sandstone
+    - prismarine
+    - prismarine_bricks
+    - dark_prismarine
+    - purpur_block
+    - end_stone
+    - end_stone_bricks
+    - nether_bricks
+    - red_nether_bricks
+    - blackstone
+    - polished_blackstone_bricks
+    - gilded_blackstone
+    - glass_pane
+    - quartz_pillar
+    - quartz_bricks
+    - copper_block
+    - cut_copper
+    - oxidized_copper
     purchase_prices:
       lantern: 5
       torch: 5
@@ -1715,6 +2633,39 @@ npc_system:
     - light_gray_concrete
     - bricks
     - sandstone
+    - smooth_stone
+    - polished_blackstone
+    - smooth_stone_slab
+    - chiseled_stone_bricks
+    - cracked_stone_bricks
+    - mossy_stone_bricks
+    - deepslate
+    - cobbled_deepslate
+    - polished_deepslate
+    - deepslate_bricks
+    - deepslate_tiles
+    - tuff
+    - calcite
+    - dripstone_block
+    - smooth_sandstone
+    - red_sandstone
+    - prismarine
+    - prismarine_bricks
+    - dark_prismarine
+    - purpur_block
+    - end_stone
+    - end_stone_bricks
+    - nether_bricks
+    - red_nether_bricks
+    - blackstone
+    - polished_blackstone_bricks
+    - gilded_blackstone
+    - glass_pane
+    - quartz_pillar
+    - quartz_bricks
+    - copper_block
+    - cut_copper
+    - oxidized_copper
     purchase_prices:
       lantern: 5
       torch: 5
@@ -1748,6 +2699,39 @@ npc_system:
     - light_gray_concrete
     - bricks
     - sandstone
+    - smooth_stone
+    - polished_blackstone
+    - smooth_stone_slab
+    - chiseled_stone_bricks
+    - cracked_stone_bricks
+    - mossy_stone_bricks
+    - deepslate
+    - cobbled_deepslate
+    - polished_deepslate
+    - deepslate_bricks
+    - deepslate_tiles
+    - tuff
+    - calcite
+    - dripstone_block
+    - smooth_sandstone
+    - red_sandstone
+    - prismarine
+    - prismarine_bricks
+    - dark_prismarine
+    - purpur_block
+    - end_stone
+    - end_stone_bricks
+    - nether_bricks
+    - red_nether_bricks
+    - blackstone
+    - polished_blackstone_bricks
+    - gilded_blackstone
+    - glass_pane
+    - quartz_pillar
+    - quartz_bricks
+    - copper_block
+    - cut_copper
+    - oxidized_copper
     purchase_prices:
       lantern: 5
       torch: 5
@@ -1781,6 +2765,39 @@ npc_system:
     - light_gray_concrete
     - bricks
     - sandstone
+    - smooth_stone
+    - polished_blackstone
+    - smooth_stone_slab
+    - chiseled_stone_bricks
+    - cracked_stone_bricks
+    - mossy_stone_bricks
+    - deepslate
+    - cobbled_deepslate
+    - polished_deepslate
+    - deepslate_bricks
+    - deepslate_tiles
+    - tuff
+    - calcite
+    - dripstone_block
+    - smooth_sandstone
+    - red_sandstone
+    - prismarine
+    - prismarine_bricks
+    - dark_prismarine
+    - purpur_block
+    - end_stone
+    - end_stone_bricks
+    - nether_bricks
+    - red_nether_bricks
+    - blackstone
+    - polished_blackstone_bricks
+    - gilded_blackstone
+    - glass_pane
+    - quartz_pillar
+    - quartz_bricks
+    - copper_block
+    - cut_copper
+    - oxidized_copper
     purchase_prices:
       lantern: 5
       torch: 5
@@ -1814,6 +2831,39 @@ npc_system:
     - light_gray_concrete
     - bricks
     - sandstone
+    - smooth_stone
+    - polished_blackstone
+    - smooth_stone_slab
+    - chiseled_stone_bricks
+    - cracked_stone_bricks
+    - mossy_stone_bricks
+    - deepslate
+    - cobbled_deepslate
+    - polished_deepslate
+    - deepslate_bricks
+    - deepslate_tiles
+    - tuff
+    - calcite
+    - dripstone_block
+    - smooth_sandstone
+    - red_sandstone
+    - prismarine
+    - prismarine_bricks
+    - dark_prismarine
+    - purpur_block
+    - end_stone
+    - end_stone_bricks
+    - nether_bricks
+    - red_nether_bricks
+    - blackstone
+    - polished_blackstone_bricks
+    - gilded_blackstone
+    - glass_pane
+    - quartz_pillar
+    - quartz_bricks
+    - copper_block
+    - cut_copper
+    - oxidized_copper
     purchase_prices:
       lantern: 5
       torch: 5
@@ -1839,6 +2889,22 @@ npc_system:
     - gunpowder
     - dragon_breath
     - brewing_stand
+    - fermented_spider_eye
+    - glistering_melon_slice
+    - magma_cream
+    - blaze_rod
+    - ender_pearl
+    - ghast_tear
+    - experience_bottle
+    - spider_eye
+    - golden_carrot
+    - rabbit_foot
+    - phantom_membrane
+    - nether_wart_block
+    - sugar
+    - turtle_helmet
+    - slime_ball
+    - ender_eye
     purchase_prices:
       glass_bottle: 5
       brewing_stand: 100
@@ -1863,6 +2929,22 @@ npc_system:
     - gunpowder
     - dragon_breath
     - brewing_stand
+    - fermented_spider_eye
+    - glistering_melon_slice
+    - magma_cream
+    - blaze_rod
+    - ender_pearl
+    - ghast_tear
+    - experience_bottle
+    - spider_eye
+    - golden_carrot
+    - rabbit_foot
+    - phantom_membrane
+    - nether_wart_block
+    - sugar
+    - turtle_helmet
+    - slime_ball
+    - ender_eye
     purchase_prices:
       glass_bottle: 5
       brewing_stand: 100
@@ -1887,6 +2969,22 @@ npc_system:
     - gunpowder
     - dragon_breath
     - brewing_stand
+    - fermented_spider_eye
+    - glistering_melon_slice
+    - magma_cream
+    - blaze_rod
+    - ender_pearl
+    - ghast_tear
+    - experience_bottle
+    - spider_eye
+    - golden_carrot
+    - rabbit_foot
+    - phantom_membrane
+    - nether_wart_block
+    - sugar
+    - turtle_helmet
+    - slime_ball
+    - ender_eye
     purchase_prices:
       glass_bottle: 5
       brewing_stand: 100
@@ -1906,6 +3004,12 @@ npc_system:
     - bookshelf
     - book
     - enchanting_table
+    - paper
+    - writable_book
+    - lapis_block
+    - amethyst_block
+    - glowstone
+    - sea_lantern
     purchase_prices:
       book: 10
       lapis_lazuli: 25
@@ -1925,6 +3029,12 @@ npc_system:
     - bookshelf
     - book
     - enchanting_table
+    - paper
+    - writable_book
+    - lapis_block
+    - amethyst_block
+    - glowstone
+    - sea_lantern
     purchase_prices:
       book: 10
       lapis_lazuli: 25
@@ -1944,6 +3054,12 @@ npc_system:
     - bookshelf
     - book
     - enchanting_table
+    - paper
+    - writable_book
+    - lapis_block
+    - amethyst_block
+    - glowstone
+    - sea_lantern
     purchase_prices:
       book: 10
       lapis_lazuli: 25
@@ -1976,6 +3092,39 @@ npc_system:
     - light_gray_concrete
     - bricks
     - sandstone
+    - smooth_stone
+    - polished_blackstone
+    - smooth_stone_slab
+    - chiseled_stone_bricks
+    - cracked_stone_bricks
+    - mossy_stone_bricks
+    - deepslate
+    - cobbled_deepslate
+    - polished_deepslate
+    - deepslate_bricks
+    - deepslate_tiles
+    - tuff
+    - calcite
+    - dripstone_block
+    - smooth_sandstone
+    - red_sandstone
+    - prismarine
+    - prismarine_bricks
+    - dark_prismarine
+    - purpur_block
+    - end_stone
+    - end_stone_bricks
+    - nether_bricks
+    - red_nether_bricks
+    - blackstone
+    - polished_blackstone_bricks
+    - gilded_blackstone
+    - glass_pane
+    - quartz_pillar
+    - quartz_bricks
+    - copper_block
+    - cut_copper
+    - oxidized_copper
     purchase_prices:
       lantern: 5
       torch: 5
@@ -2009,6 +3158,39 @@ npc_system:
     - light_gray_concrete
     - bricks
     - sandstone
+    - smooth_stone
+    - polished_blackstone
+    - smooth_stone_slab
+    - chiseled_stone_bricks
+    - cracked_stone_bricks
+    - mossy_stone_bricks
+    - deepslate
+    - cobbled_deepslate
+    - polished_deepslate
+    - deepslate_bricks
+    - deepslate_tiles
+    - tuff
+    - calcite
+    - dripstone_block
+    - smooth_sandstone
+    - red_sandstone
+    - prismarine
+    - prismarine_bricks
+    - dark_prismarine
+    - purpur_block
+    - end_stone
+    - end_stone_bricks
+    - nether_bricks
+    - red_nether_bricks
+    - blackstone
+    - polished_blackstone_bricks
+    - gilded_blackstone
+    - glass_pane
+    - quartz_pillar
+    - quartz_bricks
+    - copper_block
+    - cut_copper
+    - oxidized_copper
     purchase_prices:
       lantern: 5
       torch: 5
@@ -2042,6 +3224,39 @@ npc_system:
     - light_gray_concrete
     - bricks
     - sandstone
+    - smooth_stone
+    - polished_blackstone
+    - smooth_stone_slab
+    - chiseled_stone_bricks
+    - cracked_stone_bricks
+    - mossy_stone_bricks
+    - deepslate
+    - cobbled_deepslate
+    - polished_deepslate
+    - deepslate_bricks
+    - deepslate_tiles
+    - tuff
+    - calcite
+    - dripstone_block
+    - smooth_sandstone
+    - red_sandstone
+    - prismarine
+    - prismarine_bricks
+    - dark_prismarine
+    - purpur_block
+    - end_stone
+    - end_stone_bricks
+    - nether_bricks
+    - red_nether_bricks
+    - blackstone
+    - polished_blackstone_bricks
+    - gilded_blackstone
+    - glass_pane
+    - quartz_pillar
+    - quartz_bricks
+    - copper_block
+    - cut_copper
+    - oxidized_copper
     purchase_prices:
       lantern: 5
       torch: 5
@@ -2075,6 +3290,39 @@ npc_system:
     - light_gray_concrete
     - bricks
     - sandstone
+    - smooth_stone
+    - polished_blackstone
+    - smooth_stone_slab
+    - chiseled_stone_bricks
+    - cracked_stone_bricks
+    - mossy_stone_bricks
+    - deepslate
+    - cobbled_deepslate
+    - polished_deepslate
+    - deepslate_bricks
+    - deepslate_tiles
+    - tuff
+    - calcite
+    - dripstone_block
+    - smooth_sandstone
+    - red_sandstone
+    - prismarine
+    - prismarine_bricks
+    - dark_prismarine
+    - purpur_block
+    - end_stone
+    - end_stone_bricks
+    - nether_bricks
+    - red_nether_bricks
+    - blackstone
+    - polished_blackstone_bricks
+    - gilded_blackstone
+    - glass_pane
+    - quartz_pillar
+    - quartz_bricks
+    - copper_block
+    - cut_copper
+    - oxidized_copper
     purchase_prices:
       lantern: 5
       torch: 5
@@ -2108,6 +3356,39 @@ npc_system:
     - light_gray_concrete
     - bricks
     - sandstone
+    - smooth_stone
+    - polished_blackstone
+    - smooth_stone_slab
+    - chiseled_stone_bricks
+    - cracked_stone_bricks
+    - mossy_stone_bricks
+    - deepslate
+    - cobbled_deepslate
+    - polished_deepslate
+    - deepslate_bricks
+    - deepslate_tiles
+    - tuff
+    - calcite
+    - dripstone_block
+    - smooth_sandstone
+    - red_sandstone
+    - prismarine
+    - prismarine_bricks
+    - dark_prismarine
+    - purpur_block
+    - end_stone
+    - end_stone_bricks
+    - nether_bricks
+    - red_nether_bricks
+    - blackstone
+    - polished_blackstone_bricks
+    - gilded_blackstone
+    - glass_pane
+    - quartz_pillar
+    - quartz_bricks
+    - copper_block
+    - cut_copper
+    - oxidized_copper
     purchase_prices:
       lantern: 5
       torch: 5
@@ -2141,6 +3422,39 @@ npc_system:
     - light_gray_concrete
     - bricks
     - sandstone
+    - smooth_stone
+    - polished_blackstone
+    - smooth_stone_slab
+    - chiseled_stone_bricks
+    - cracked_stone_bricks
+    - mossy_stone_bricks
+    - deepslate
+    - cobbled_deepslate
+    - polished_deepslate
+    - deepslate_bricks
+    - deepslate_tiles
+    - tuff
+    - calcite
+    - dripstone_block
+    - smooth_sandstone
+    - red_sandstone
+    - prismarine
+    - prismarine_bricks
+    - dark_prismarine
+    - purpur_block
+    - end_stone
+    - end_stone_bricks
+    - nether_bricks
+    - red_nether_bricks
+    - blackstone
+    - polished_blackstone_bricks
+    - gilded_blackstone
+    - glass_pane
+    - quartz_pillar
+    - quartz_bricks
+    - copper_block
+    - cut_copper
+    - oxidized_copper
     purchase_prices:
       lantern: 5
       torch: 5
@@ -2176,6 +3490,36 @@ npc_system:
     - diamond_leggings
     - diamond_boots
     - anvil
+    - iron_hoe
+    - diamond_hoe
+    - chainmail_helmet
+    - chainmail_chestplate
+    - chainmail_leggings
+    - chainmail_boots
+    - golden_helmet
+    - golden_chestplate
+    - golden_leggings
+    - golden_boots
+    - golden_sword
+    - golden_pickaxe
+    - golden_axe
+    - golden_shovel
+    - golden_hoe
+    - netherite_helmet
+    - netherite_chestplate
+    - netherite_leggings
+    - netherite_boots
+    - netherite_sword
+    - netherite_pickaxe
+    - netherite_axe
+    - netherite_shovel
+    - netherite_hoe
+    - shield
+    - bow
+    - crossbow
+    - flint_and_steel
+    - shears
+    - bucket
     purchase_prices:
       coal: 10
       stone: 10
@@ -2210,6 +3554,36 @@ npc_system:
     - diamond_leggings
     - diamond_boots
     - anvil
+    - iron_hoe
+    - diamond_hoe
+    - chainmail_helmet
+    - chainmail_chestplate
+    - chainmail_leggings
+    - chainmail_boots
+    - golden_helmet
+    - golden_chestplate
+    - golden_leggings
+    - golden_boots
+    - golden_sword
+    - golden_pickaxe
+    - golden_axe
+    - golden_shovel
+    - golden_hoe
+    - netherite_helmet
+    - netherite_chestplate
+    - netherite_leggings
+    - netherite_boots
+    - netherite_sword
+    - netherite_pickaxe
+    - netherite_axe
+    - netherite_shovel
+    - netherite_hoe
+    - shield
+    - bow
+    - crossbow
+    - flint_and_steel
+    - shears
+    - bucket
     purchase_prices:
       coal: 10
       stone: 10
@@ -2244,6 +3618,36 @@ npc_system:
     - diamond_leggings
     - diamond_boots
     - anvil
+    - iron_hoe
+    - diamond_hoe
+    - chainmail_helmet
+    - chainmail_chestplate
+    - chainmail_leggings
+    - chainmail_boots
+    - golden_helmet
+    - golden_chestplate
+    - golden_leggings
+    - golden_boots
+    - golden_sword
+    - golden_pickaxe
+    - golden_axe
+    - golden_shovel
+    - golden_hoe
+    - netherite_helmet
+    - netherite_chestplate
+    - netherite_leggings
+    - netherite_boots
+    - netherite_sword
+    - netherite_pickaxe
+    - netherite_axe
+    - netherite_shovel
+    - netherite_hoe
+    - shield
+    - bow
+    - crossbow
+    - flint_and_steel
+    - shears
+    - bucket
     purchase_prices:
       coal: 10
       stone: 10
@@ -2278,6 +3682,36 @@ npc_system:
     - diamond_leggings
     - diamond_boots
     - anvil
+    - iron_hoe
+    - diamond_hoe
+    - chainmail_helmet
+    - chainmail_chestplate
+    - chainmail_leggings
+    - chainmail_boots
+    - golden_helmet
+    - golden_chestplate
+    - golden_leggings
+    - golden_boots
+    - golden_sword
+    - golden_pickaxe
+    - golden_axe
+    - golden_shovel
+    - golden_hoe
+    - netherite_helmet
+    - netherite_chestplate
+    - netherite_leggings
+    - netherite_boots
+    - netherite_sword
+    - netherite_pickaxe
+    - netherite_axe
+    - netherite_shovel
+    - netherite_hoe
+    - shield
+    - bow
+    - crossbow
+    - flint_and_steel
+    - shears
+    - bucket
     purchase_prices:
       coal: 10
       stone: 10
@@ -2312,6 +3746,36 @@ npc_system:
     - diamond_leggings
     - diamond_boots
     - anvil
+    - iron_hoe
+    - diamond_hoe
+    - chainmail_helmet
+    - chainmail_chestplate
+    - chainmail_leggings
+    - chainmail_boots
+    - golden_helmet
+    - golden_chestplate
+    - golden_leggings
+    - golden_boots
+    - golden_sword
+    - golden_pickaxe
+    - golden_axe
+    - golden_shovel
+    - golden_hoe
+    - netherite_helmet
+    - netherite_chestplate
+    - netherite_leggings
+    - netherite_boots
+    - netherite_sword
+    - netherite_pickaxe
+    - netherite_axe
+    - netherite_shovel
+    - netherite_hoe
+    - shield
+    - bow
+    - crossbow
+    - flint_and_steel
+    - shears
+    - bucket
     purchase_prices:
       coal: 10
       stone: 10
@@ -2346,6 +3810,36 @@ npc_system:
     - diamond_leggings
     - diamond_boots
     - anvil
+    - iron_hoe
+    - diamond_hoe
+    - chainmail_helmet
+    - chainmail_chestplate
+    - chainmail_leggings
+    - chainmail_boots
+    - golden_helmet
+    - golden_chestplate
+    - golden_leggings
+    - golden_boots
+    - golden_sword
+    - golden_pickaxe
+    - golden_axe
+    - golden_shovel
+    - golden_hoe
+    - netherite_helmet
+    - netherite_chestplate
+    - netherite_leggings
+    - netherite_boots
+    - netherite_sword
+    - netherite_pickaxe
+    - netherite_axe
+    - netherite_shovel
+    - netherite_hoe
+    - shield
+    - bow
+    - crossbow
+    - flint_and_steel
+    - shears
+    - bucket
     purchase_prices:
       coal: 10
       stone: 10
@@ -2400,6 +3894,19 @@ npc_system:
       dark_oak_log: dark_oak_planks
       crimson_stem: crimson_planks
       warped_stem: warped_planks
+      mangrove_log: mangrove_planks
+      cherry_log: cherry_planks
+      bamboo_block: bamboo_planks
+      stripped_oak_log: oak_planks
+      stripped_birch_log: birch_planks
+      stripped_spruce_log: spruce_planks
+      stripped_jungle_log: jungle_planks
+      stripped_acacia_log: acacia_planks
+      stripped_dark_oak_log: dark_oak_planks
+      stripped_mangrove_log: mangrove_planks
+      stripped_cherry_log: cherry_planks
+      stripped_crimson_stem: crimson_planks
+      stripped_warped_stem: warped_planks
     messages:
       greeting: §6いらっしゃいませ、%player%さん！木材加工サービスへようこそ。
       service_start: §a原木を板材に加工いたします。
@@ -2410,6 +3917,7 @@ npc_system:
       success: §a%log_amount%個の原木を%plank_amount%個の板材に加工しました。
       fee_charged: '§e加工料金: %fee%'
       outside_hours: §c申し訳ありませんが、営業時間外です。
+    planks_per_log: 4
   bank_npc:
     locations:
     - world: tofuNomics
@@ -2581,6 +4089,227 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      guide_book:
+        enabled: true
+        title: '&6&l鉱夫ガイドブック'
+        author: TofuNomics職業組合
+        pages:
+        - '&0&l【鉱夫の仕事】
+
+
+          &0鉱夫は鉱物資源と
+
+          石材の供給を担当
+
+          する職業です。
+
+
+          採掘で経験値と
+
+          報酬を獲得できます。
+
+          '
+        - '&0&l【主な収入源】
+
+
+          &8採掘した鉱石を
+
+          &8取引所NPCで売却！
+
+
+          &0・石炭/鉄が基本
+
+          &0・金/ダイヤが高額
+
+          &0・エメラルドも◎
+
+
+          &eレベルUPで
+
+          &e売却ボーナス増加！
+
+          '
+        - '&0&l【経験値の上げ方】
+
+
+          &0対象の鉱石や石を
+
+          採掘すると職業
+
+          経験値を獲得！
+
+
+          &8■自分で掘った
+
+          　ブロックが対象
+
+          &8■設置した石は
+
+          　経験値対象外
+
+
+          &e掘るほど成長！
+
+          '
+        - '&0&l【経験値一覧①】
+
+
+          &8採掘1個あたり:
+
+
+          &8■石炭鉱石 25
+
+          &8■鉄鉱石 50
+
+          &8■金鉱石 80
+
+          &8■レッドストーン 30
+
+          &8■ラピスラズリ 40
+
+          &8■石 50
+
+          '
+        - '&0&l【経験値一覧②】
+
+
+          &8採掘1個あたり:
+
+
+          &8■ダイヤ鉱石 200
+
+          &8■エメラルド鉱石 200
+
+          &8■ネザークォーツ 60
+
+          &8■古代の残骸 500
+
+
+          &e希少な鉱石ほど
+
+          &e経験値も大量！
+
+          '
+        - '&0&l【必要経験値】
+
+
+          &8レベルUPに必要な
+
+          &8累計経験値:
+
+
+          &8■Lv5: 1,393
+
+          &8■Lv10: 6,502
+
+          &8■Lv25: 41,918
+
+          &8■Lv50: 162,694
+
+          &8■Lv100: 619,023
+
+
+          &8高Lvほど経験値
+
+          &8効率が低下します
+
+          '
+        - '&0&l【職業スキル①】
+
+
+          &6幸運の一撃
+
+          &8Lv10〜 発動5〜25%
+
+          &8ドロップ量が1.5倍
+
+
+          &6鉱脈発見
+
+          &8Lv25〜 発動8〜30%
+
+          &8周囲3マスも採掘
+
+          '
+        - '&0&l【職業スキル②】
+
+
+          &6採掘の極意
+
+          &8Lv50〜 発動10〜40%
+
+          &8ツール耐久を
+
+          &830%節約できる
+
+
+          &eスキルはレベルUPで
+
+          &e発動率が上昇！
+
+          '
+        - '&0&l【レベルUP特典】
+
+
+          &8到達報酬:
+
+          &8■Lv10: 200金塊
+
+          &8■Lv25: 500金塊
+
+          &8　＋ダイヤのツルハシ
+
+          &8■Lv50: 1000金塊
+
+          &8■Lv75: 2000金塊
+
+
+          &8レベルに応じて
+
+          &8称号も変化！
+
+
+          &eLv50で転職可能！
+
+          '
+        - '&0&l【稼ぐコツ】
+
+
+          &8■まず石炭と鉄を
+
+          　集めて売ろう
+
+          &8■ツルハシの耐久
+
+          　に注意
+
+          &8■ダイヤ/エメラルド
+
+          　は特に高経験値
+
+          &8■洞窟や廃坑が
+
+          　おすすめ
+
+          '
+        - '&0&l【便利なコマンド】
+
+
+          &0/jobs stats
+
+          &8→ 職業の統計情報
+
+
+          &0/jobs info
+
+          &8→ 職業の詳細
+
+
+          &0/jobs guide
+
+          &8→ この本を再取得
+
+          '
     woodcutter:
       display_name: 木こり
       description: 木材の供給を担当
@@ -2588,6 +4317,212 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      guide_book:
+        enabled: true
+        title: '&2&l木こりガイドブック'
+        author: TofuNomics職業組合
+        pages:
+        - '&0&l【木こりの仕事】
+
+
+          &0木こりは木材の
+
+          供給を担当する
+
+          職業です。
+
+
+          伐採で経験値と
+
+          報酬を獲得できます。
+
+          '
+        - '&0&l【主な収入源】
+
+
+          &8原木を取引所NPCで
+
+          &8売却して稼ごう！
+
+
+          &0・苗木も売れる
+
+          &0・ダークオークが
+
+          　 高額
+
+          &0・レベルUPで
+
+          　 売却ボーナス増加
+
+          '
+        - '&0&l【経験値の上げ方】
+
+
+          &0対象の原木を
+
+          伐採すると職業
+
+          経験値を獲得！
+
+
+          &8■原木の種類で
+
+          　経験値が変化
+
+          &8■苗木を植えて
+
+          　持続的に伐採
+
+
+          &a森を育てよう！
+
+          '
+        - '&0&l【経験値一覧】
+
+
+          &8伐採1本あたり:
+
+
+          &8■オーク原木 30
+
+          &8■白樺原木 30
+
+          &8■トウヒ原木 30
+
+          &8■ジャングル原木 40
+
+          &8■アカシア原木 40
+
+          &8■ダークオーク原木 40
+
+          &8■歪んだ幹 50
+
+          &8■真紅の幹 50
+
+          '
+        - '&0&l【必要経験値】
+
+
+          &8レベルUPに必要な
+
+          &8累計経験値:
+
+
+          &8■Lv5: 1,393
+
+          &8■Lv10: 6,502
+
+          &8■Lv25: 41,918
+
+          &8■Lv50: 162,694
+
+          &8■Lv100: 619,023
+
+
+          &8高Lvほど経験値
+
+          &8効率が低下します
+
+          '
+        - '&0&l【職業スキル①】
+
+
+          &2一斉伐採
+
+          &8Lv15〜 発動10〜35%
+
+          &8木全体を一括伐採
+
+          &8(最大64ブロック)
+
+
+          &2苗木の恵み
+
+          &8Lv30〜 発動15〜50%
+
+          &8苗木が追加ドロップ
+
+          '
+        - '&0&l【職業スキル②】
+
+
+          &2森の番人
+
+          &8Lv45〜 発動5〜20%
+
+          &8木材の品質が
+
+          &81.8倍に向上
+
+
+          &aスキルはレベルUPで
+
+          &a発動率が上昇！
+
+          '
+        - '&0&l【レベルUP特典】
+
+
+          &8到達報酬:
+
+          &8■Lv10: 200金塊
+
+          &8■Lv25: 500金塊
+
+          &8　＋ダイヤの斧
+
+          &8■Lv50: 1000金塊
+
+          &8■Lv75: 2000金塊
+
+
+          &8レベルに応じて
+
+          &8称号も変化！
+
+
+          &aLv50で転職可能！
+
+          '
+        - '&0&l【稼ぐコツ】
+
+
+          &8■オークや白樺は
+
+          　育てやすい
+
+          &8■苗木を植えて
+
+          　持続可能に
+
+          &8■ダークオークが
+
+          　高値で売れる
+
+          &8■斧の耐久に
+
+          　注意しよう
+
+          '
+        - '&0&l【便利なコマンド】
+
+
+          &0/jobs stats
+
+          &8→ 職業の統計情報
+
+
+          &0/jobs info
+
+          &8→ 職業の詳細
+
+
+          &0/jobs guide
+
+          &8→ この本を再取得
+
+          '
     farmer:
       display_name: 農家
       description: 農作物・畜産物の供給を担当
@@ -2595,6 +4530,226 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      guide_book:
+        enabled: true
+        title: '&a&l農家ガイドブック'
+        author: TofuNomics職業組合
+        pages:
+        - '&0&l【農家の仕事】
+
+
+          &0農家は農作物と
+
+          畜産物の供給を
+
+          担当する職業です。
+
+
+          収穫で経験値と
+
+          報酬を獲得できます。
+
+          '
+        - '&0&l【主な収入源】
+
+
+          &8農作物を取引所NPCで
+
+          &8売却して稼ごう！
+
+
+          &0・小麦/にんじんが
+
+          　 基本
+
+          &0・かぼちゃ/スイカ
+
+          　 が高額
+
+          &0・レベルUPで
+
+          　 売却ボーナス増加
+
+          '
+        - '&0&l【経験値の上げ方】
+
+
+          &0育てた農作物を
+
+          収穫すると職業
+
+          経験値を獲得！
+
+
+          &8■成熟した作物を
+
+          　収穫しよう
+
+          &8■種を撒いて
+
+          　再び育てよう
+
+
+          &a畑を広げよう！
+
+          '
+        - '&0&l【経験値一覧①】
+
+
+          &8収穫1個あたり:
+
+
+          &8■小麦 30
+
+          &8■にんじん 25
+
+          &8■じゃがいも 25
+
+          &8■ビートルート 30
+
+          &8■サトウキビ 20
+
+          '
+        - '&0&l【経験値一覧②】
+
+
+          &8収穫1個あたり:
+
+
+          &8■かぼちゃ 35
+
+          &8■スイカ 30
+
+          &8■カカオ豆 30
+
+          &8■ネザーウォート 35
+
+
+          &e作物の種類で
+
+          &e経験値が変化
+
+          '
+        - '&0&l【必要経験値】
+
+
+          &8レベルUPに必要な
+
+          &8累計経験値:
+
+
+          &8■Lv5: 1,393
+
+          &8■Lv10: 6,502
+
+          &8■Lv25: 41,918
+
+          &8■Lv50: 162,694
+
+          &8■Lv100: 619,023
+
+
+          &8高Lvほど経験値
+
+          &8効率が低下します
+
+          '
+        - '&0&l【職業スキル①】
+
+
+          &a豊穣の恵み
+
+          &8Lv10〜 発動12〜40%
+
+          &8収穫量が50%増加
+
+
+          &a双子の奇跡
+
+          &8Lv15〜 発動10〜25%
+
+          &8繁殖で双子が誕生
+
+          '
+        - '&0&l【職業スキル②】
+
+
+          &a成長促進
+
+          &8Lv30〜 発動20〜60%
+
+          &8作物の成長が
+
+          &825%加速
+
+
+          &a品種改良
+
+          &8Lv50〜 発動5〜15%
+
+          &8品質が2.0倍に
+
+          '
+        - '&0&l【レベルUP特典】
+
+
+          &8到達報酬:
+
+          &8■Lv10: 200金塊
+
+          &8■Lv25: 500金塊
+
+          &8■Lv50: 1000金塊
+
+          &8■Lv75: 2000金塊
+
+
+          &8レベルに応じて
+
+          &8称号も変化！
+
+
+          &aLv50で転職可能！
+
+          '
+        - '&0&l【稼ぐコツ】
+
+
+          &8■水源の近くに
+
+          　畑を作ろう
+
+          &8■かぼちゃ/スイカが
+
+          　高値で売れる
+
+          &8■骨粉で成長を
+
+          　早めよう
+
+          &8■動物の繁殖でも
+
+          　収入を得られる
+
+          '
+        - '&0&l【便利なコマンド】
+
+
+          &0/jobs stats
+
+          &8→ 職業の統計情報
+
+
+          &0/jobs info
+
+          &8→ 職業の詳細
+
+
+          &0/jobs guide
+
+          &8→ この本を再取得
+
+          '
     fisherman:
       display_name: 釣り人
       description: 魚と宝の供給を担当
@@ -2602,6 +4757,206 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      guide_book:
+        enabled: true
+        title: '&b&l釣り人ガイドブック'
+        author: TofuNomics職業組合
+        pages:
+        - '&0&l【釣り人の仕事】
+
+
+          &0釣り人は魚と宝の
+
+          供給を担当する
+
+          職業です。
+
+
+          釣りで経験値と
+
+          報酬を獲得できます。
+
+          '
+        - '&0&l【主な収入源】
+
+
+          &8釣った魚を取引所
+
+          &8NPCで売却！
+
+
+          &0・タラ/サケが基本
+
+          &0・宝物もドロップ
+
+          &0・レベルUPで
+
+          　 売却ボーナス増加
+
+
+          &bレア魚は高額！
+
+          '
+        - '&0&l【経験値の上げ方】
+
+
+          &0釣りをすると
+
+          職業経験値を
+
+          獲得できます。
+
+
+          &8■魚や宝物を
+
+          　釣り上げよう
+
+          &8■雨や夜は
+
+          　経験値ボーナス
+
+
+          &b釣り続けよう！
+
+          '
+        - '&0&l【経験値一覧】
+
+
+          &8釣り1回あたり:
+
+
+          &8■魚を釣る 100
+
+          &8■生物を釣る 150
+
+          &8■宝物ボーナス +150
+
+
+          &8天候ボーナス:
+
+          &8■雨天時 経験値1.2倍
+
+          &8■夜間 経験値1.15倍
+
+          '
+        - '&0&l【必要経験値】
+
+
+          &8レベルUPに必要な
+
+          &8累計経験値:
+
+
+          &8■Lv5: 1,393
+
+          &8■Lv10: 6,502
+
+          &8■Lv25: 41,918
+
+          &8■Lv50: 162,694
+
+          &8■Lv100: 619,023
+
+
+          &8高Lvほど経験値
+
+          &8効率が低下します
+
+          '
+        - '&0&l【職業スキル①】
+
+
+          &b大物釣り
+
+          &8Lv20〜 発動8〜30%
+
+          &8魚のサイズが1.5倍
+
+
+          &b宝探し
+
+          &8Lv35〜 発動5〜20%
+
+          &8宝物の確率が1.8倍
+
+          '
+        - '&0&l【職業スキル②】
+
+
+          &b海の加護
+
+          &8Lv50〜 常時発動
+
+          &8天候による
+
+          &8釣果のムラを解消
+
+
+          &bスキルはレベルUPで
+
+          &b発動率が上昇！
+
+          '
+        - '&0&l【レベルUP特典】
+
+
+          &8到達報酬:
+
+          &8■Lv10: 200金塊
+
+          &8■Lv25: 500金塊
+
+          &8■Lv50: 1000金塊
+
+          &8■Lv75: 2000金塊
+
+
+          &8レベルに応じて
+
+          &8称号も変化！
+
+
+          &bLv50で転職可能！
+
+          '
+        - '&0&l【稼ぐコツ】
+
+
+          &8■雨の日は
+
+          　釣り効率UP
+
+          &8■宝釣りエンチャント
+
+          　を付けよう
+
+          &8■開けた水場が
+
+          　ベスト
+
+          &8■宝物は高値で
+
+          　売れる
+
+          '
+        - '&0&l【便利なコマンド】
+
+
+          &0/jobs stats
+
+          &8→ 職業の統計情報
+
+
+          &0/jobs info
+
+          &8→ 職業の詳細
+
+
+          &0/jobs guide
+
+          &8→ この本を再取得
+
+          '
     blacksmith:
       display_name: 鍛冶屋
       description: ツール、武器、防具の生産と修理を担当
@@ -2609,6 +4964,231 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      guide_book:
+        enabled: true
+        title: '&8&l鍛冶屋ガイドブック'
+        author: TofuNomics職業組合
+        pages:
+        - '&0&l【鍛冶屋の仕事】
+
+
+          &0鍛冶屋はツール、
+
+          武器、防具の生産
+
+          と修理を担当する
+
+          職業です。
+
+
+          作成で経験値と
+
+          報酬を獲得できます。
+
+          '
+        - '&0&l【主な収入源】
+
+
+          &8作成した装備を
+
+          &8取引所NPCで売却！
+
+
+          &0・鉄装備が基本
+
+          &0・ダイヤ装備が高額
+
+          &0・レベルUPで
+
+          　 売却ボーナス増加
+
+
+          &7高品質ほど高額！
+
+          '
+        - '&0&l【経験値の上げ方】
+
+
+          &0作業台で装備や
+
+          ツールを作成すると
+
+          職業経験値を獲得！
+
+
+          &8■高品質な装備
+
+          　ほど高経験値
+
+          &8■素材は鉱夫から
+
+          　仕入れよう
+
+
+          &7名工を目指せ！
+
+          '
+        - '&0&l【経験値一覧①】
+
+
+          &8作成1個あたり:
+
+
+          &8■鉄インゴット 50
+
+          &8■金インゴット 80
+
+          &8■鉄の剣 120
+
+          &8■鉄ツルハシ/斧 150
+
+          &8■鉄シャベル 90
+
+          &8■鉄防具 各100
+
+          &8■盾 80
+
+          '
+        - '&0&l【経験値一覧②】
+
+
+          &8作成1個あたり:
+
+
+          &8■ダイヤの剣 300
+
+          &8■ダイヤツール 350
+
+          &8■ダイヤ防具 各250
+
+          &8■ネザライト 750
+
+          &8■金リンゴ 150
+
+
+          &e高級品ほど高経験値
+
+          '
+        - '&0&l【必要経験値】
+
+
+          &8レベルUPに必要な
+
+          &8累計経験値:
+
+
+          &8■Lv5: 1,393
+
+          &8■Lv10: 6,502
+
+          &8■Lv25: 41,918
+
+          &8■Lv50: 162,694
+
+          &8■Lv100: 619,023
+
+
+          &8高Lvほど経験値
+
+          &8効率が低下します
+
+          '
+        - '&0&l【職業スキル①】
+
+
+          &7完璧な修理
+
+          &8Lv10〜 発動15〜50%
+
+          &8修理時に耐久を
+
+          &820%上乗せ
+
+
+          &7名工の技
+
+          &8Lv25〜 発動10〜35%
+
+          &8装備の品質1.5倍
+
+          '
+        - '&0&l【職業スキル②】
+
+
+          &7神器創造
+
+          &8Lv60〜 発動2〜8%
+
+          &8特殊エンチャントが
+
+          &8付与される
+
+
+          &7スキルはレベルUPで
+
+          &7発動率が上昇！
+
+          '
+        - '&0&l【レベルUP特典】
+
+
+          &8到達報酬:
+
+          &8■Lv10: 200金塊
+
+          &8■Lv25: 500金塊
+
+          &8■Lv50: 1000金塊
+
+          &8■Lv75: 2000金塊
+
+
+          &8レベルに応じて
+
+          &8称号も変化！
+
+
+          &7Lv50で転職可能！
+
+          '
+        - '&0&l【稼ぐコツ】
+
+
+          &8■まず鉄装備から
+
+          　作り始めよう
+
+          &8■作業台と金床を
+
+          　用意しよう
+
+          &8■ダイヤ装備は
+
+          　高値で売れる
+
+          &8■鉱夫と協力して
+
+          　素材を確保
+
+          '
+        - '&0&l【便利なコマンド】
+
+
+          &0/jobs stats
+
+          &8→ 職業の統計情報
+
+
+          &0/jobs info
+
+          &8→ 職業の詳細
+
+
+          &0/jobs guide
+
+          &8→ この本を再取得
+
+          '
     alchemist:
       display_name: ポーション屋
       description: ポーションの生産を担当
@@ -2616,6 +5196,208 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      guide_book:
+        enabled: true
+        title: '&5&lポーション屋ガイドブック'
+        author: TofuNomics職業組合
+        pages:
+        - '&0&l【ポーション屋の仕事】
+
+
+          &0ポーション屋は
+
+          各種ポーションの
+
+          生産を担当する
+
+          職業です。
+
+
+          醸造で経験値と
+
+          報酬を獲得できます。
+
+          '
+        - '&0&l【主な収入源】
+
+
+          &8ポーションを取引所
+
+          &8NPCで売却！
+
+
+          &0・基本ポーション
+
+          　 から始めよう
+
+          &0・高効果ほど高額
+
+          &0・レベルUPで
+
+          　 売却ボーナス増加
+
+          '
+        - '&0&l【経験値の上げ方】
+
+
+          &0醸造台でポーション
+
+          を醸造すると職業
+
+          経験値を獲得！
+
+
+          &8■醸造が完了する
+
+          　たびに経験値
+
+          &8■醸造台の近くに
+
+          　いる必要あり
+
+
+          &5醸造を続けよう！
+
+          '
+        - '&0&l【経験値一覧】
+
+
+          &8醸造1回あたり:
+
+
+          &8■ポーション醸造 100
+
+
+          &7※醸造台での醸造が
+
+          &7完了するたびに
+
+          &7経験値を獲得
+
+
+          &eどの種類でも
+
+          &e経験値は同じです
+
+          '
+        - '&0&l【必要経験値】
+
+
+          &8レベルUPに必要な
+
+          &8累計経験値:
+
+
+          &8■Lv5: 1,393
+
+          &8■Lv10: 6,502
+
+          &8■Lv25: 41,918
+
+          &8■Lv50: 162,694
+
+          &8■Lv100: 619,023
+
+
+          &8高Lvほど経験値
+
+          &8効率が低下します
+
+          '
+        - '&0&l【職業スキル①】
+
+
+          &5材料節約
+
+          &8Lv15〜 発動20〜60%
+
+          &8醸造材料を50%節約
+
+
+          &5二重醸造
+
+          &8Lv30〜 発動10〜25%
+
+          &8ポーションが追加生成
+
+          '
+        - '&0&l【職業スキル②】
+
+
+          &5錬金の極意
+
+          &8Lv50〜 発動15〜40%
+
+          &8ポーションの効果
+
+          &8時間が1.5倍に
+
+
+          &5スキルはレベルUPで
+
+          &5発動率が上昇！
+
+          '
+        - '&0&l【レベルUP特典】
+
+
+          &8到達報酬:
+
+          &8■Lv10: 200金塊
+
+          &8■Lv25: 500金塊
+
+          &8■Lv50: 1000金塊
+
+          &8■Lv75: 2000金塊
+
+
+          &8レベルに応じて
+
+          &8称号も変化！
+
+
+          &5Lv50で転職可能！
+
+          '
+        - '&0&l【稼ぐコツ】
+
+
+          &8■醸造台とブレイズ
+
+          　パウダーが必須
+
+          &8■ネザーウォートを
+
+          　確保しよう
+
+          &8■高効果ポーション
+
+          　ほど高値で売れる
+
+          &8■残留ポーションが
+
+          　最も高額
+
+          '
+        - '&0&l【便利なコマンド】
+
+
+          &0/jobs stats
+
+          &8→ 職業の統計情報
+
+
+          &0/jobs info
+
+          &8→ 職業の詳細
+
+
+          &0/jobs guide
+
+          &8→ この本を再取得
+
+          '
     enchanter:
       display_name: エンチャンター
       description: エンチャントサービスを担当
@@ -2623,6 +5405,209 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      guide_book:
+        enabled: true
+        title: '&d&lエンチャンターガイドブック'
+        author: TofuNomics職業組合
+        pages:
+        - '&0&l【エンチャンターの仕事】
+
+
+          &0エンチャンターは
+
+          エンチャントサービス
+
+          を担当する職業です。
+
+
+          エンチャントで
+
+          経験値と報酬を
+
+          獲得できます。
+
+          '
+        - '&0&l【主な収入源】
+
+
+          &8エンチャント済み
+
+          &8アイテムを取引所
+
+          &8NPCで売却！
+
+
+          &0・高レベルエンチャ
+
+          　 ほど高額
+
+          &0・レベルUPで
+
+          　 売却ボーナス増加
+
+          '
+        - '&0&l【経験値の上げ方】
+
+
+          &0エンチャント台で
+
+          エンチャントすると
+
+          職業経験値を獲得！
+
+
+          &8■付与レベルの
+
+          　合計が高いほど
+
+          　経験値も多い
+
+
+          &dラピスを用意！
+
+          '
+        - '&0&l【経験値一覧】
+
+
+          &8エンチャント1回:
+
+          &8(付与Lv合計で変化)
+
+
+          &8■合計Lv1 150
+
+          &8■合計Lv2 250
+
+          &8■合計Lv3 400
+
+          &8■合計Lv4 550
+
+          &8■合計Lv5 750
+
+
+          &d高レベルほど高経験値
+
+          '
+        - '&0&l【必要経験値】
+
+
+          &8レベルUPに必要な
+
+          &8累計経験値:
+
+
+          &8■Lv5: 1,393
+
+          &8■Lv10: 6,502
+
+          &8■Lv25: 41,918
+
+          &8■Lv50: 162,694
+
+          &8■Lv100: 619,023
+
+
+          &8高Lvほど経験値
+
+          &8効率が低下します
+
+          '
+        - '&0&l【職業スキル①】
+
+
+          &d経験値節約
+
+          &8Lv10〜 発動25〜70%
+
+          &8エンチャントコスト
+
+          &8を30%削減
+
+
+          &dボーナスエンチャント
+
+          &8Lv25〜 発動8〜25%
+
+          &8エンチャレベル+1
+
+          '
+        - '&0&l【職業スキル②】
+
+
+          &d魔術の神秘
+
+          &8Lv45〜 発動5〜15%
+
+          &8希少エンチャントの
+
+          &8確率が2.0倍に
+
+
+          &dスキルはレベルUPで
+
+          &d発動率が上昇！
+
+          '
+        - '&0&l【レベルUP特典】
+
+
+          &8到達報酬:
+
+          &8■Lv10: 200金塊
+
+          &8■Lv25: 500金塊
+
+          &8■Lv50: 1000金塊
+
+          &8■Lv75: 2000金塊
+
+
+          &8レベルに応じて
+
+          &8称号も変化！
+
+
+          &dLv50で転職可能！
+
+          '
+        - '&0&l【稼ぐコツ】
+
+
+          &8■本棚15個で
+
+          　最大レベル解放
+
+          &8■経験値を貯めて
+
+          　おこう
+
+          &8■高レベルエンチャント
+
+          　は高値で売れる
+
+          &8■ラピスラズリを
+
+          　常備しよう
+
+          '
+        - '&0&l【便利なコマンド】
+
+
+          &0/jobs stats
+
+          &8→ 職業の統計情報
+
+
+          &0/jobs info
+
+          &8→ 職業の詳細
+
+
+          &0/jobs guide
+
+          &8→ この本を再取得
+
+          '
     architect:
       display_name: 建築家
       description: 建築と装飾を担当
@@ -2630,6 +5615,226 @@ jobs:
       base_income_multiplier: 1.0
       exp_multiplier: 10.0
       base_sell_bonus: 0.05
+      guide_book:
+        enabled: true
+        title: '&e&l建築家ガイドブック'
+        author: TofuNomics職業組合
+        pages:
+        - '&0&l【建築家の仕事】
+
+
+          &0建築家は建築と
+
+          装飾を担当する
+
+          職業です。
+
+
+          建築で経験値と
+
+          報酬を獲得できます。
+
+          '
+        - '&0&l【主な収入源】
+
+
+          &8建築ブロックを
+
+          &8取引所NPCで売却！
+
+
+          &0・石系ブロックが
+
+          　 基本
+
+          &0・装飾ブロックが
+
+          　 高額
+
+          &0・レベルUPで
+
+          　 売却ボーナス増加
+
+          '
+        - '&0&l【経験値の上げ方】
+
+
+          &0対象ブロックを
+
+          設置すると職業
+
+          経験値を獲得！
+
+
+          &8■設置するブロック
+
+          　の種類で変化
+
+          &8■装飾ブロックは
+
+          　高経験値
+
+
+          &e建てて稼ごう！
+
+          '
+        - '&0&l【経験値一覧①】
+
+
+          &8ブロック設置1個:
+
+
+          &8■石 8
+
+          &8■丸石 5
+
+          &8■各種板材 6
+
+          &8■レンガ 20
+
+          &8■ガラス 10
+
+          '
+        - '&0&l【経験値一覧②】
+
+
+          &8ブロック設置1個:
+
+
+          &8■石レンガ 15
+
+          &8■クォーツブロック 30
+
+          &8■プリズマリン 40
+
+          &8■プルプァブロック 50
+
+          &8■エンドレンガ 60
+
+
+          &e装飾系ほど高経験値
+
+          '
+        - '&0&l【必要経験値】
+
+
+          &8レベルUPに必要な
+
+          &8累計経験値:
+
+
+          &8■Lv5: 1,393
+
+          &8■Lv10: 6,502
+
+          &8■Lv25: 41,918
+
+          &8■Lv50: 162,694
+
+          &8■Lv100: 619,023
+
+
+          &8高Lvほど経験値
+
+          &8効率が低下します
+
+          '
+        - '&0&l【職業スキル①】
+
+
+          &e材料節約
+
+          &8Lv10〜 発動15〜45%
+
+          &8建築材料を25%節約
+
+
+          &e建築の美学
+
+          &8Lv30〜 発動20〜60%
+
+          &8美観ボーナスで
+
+          &8価値が1.5倍
+
+          '
+        - '&0&l【職業スキル②】
+
+
+          &e巨匠の設計
+
+          &8Lv50〜 規模で発動
+
+          &8100ブロック以上の
+
+          &8建築でボーナス
+
+
+          &eスキルはレベルUPで
+
+          &e効果が上昇！
+
+          '
+        - '&0&l【レベルUP特典】
+
+
+          &8到達報酬:
+
+          &8■Lv10: 200金塊
+
+          &8■Lv25: 500金塊
+
+          &8■Lv50: 1000金塊
+
+          &8■Lv75: 2000金塊
+
+
+          &8レベルに応じて
+
+          &8称号も変化！
+
+
+          &eLv50で転職可能！
+
+          '
+        - '&0&l【稼ぐコツ】
+
+
+          &8■石系ブロックが
+
+          　基本素材
+
+          &8■装飾ブロックは
+
+          　高値で売れる
+
+          &8■大規模建築で
+
+          　スキル発動
+
+          &8■染料で彩りを
+
+          　加えよう
+
+          '
+        - '&0&l【便利なコマンド】
+
+
+          &0/jobs stats
+
+          &8→ 職業の統計情報
+
+
+          &0/jobs info
+
+          &8→ 職業の詳細
+
+
+          &0/jobs guide
+
+          &8→ この本を再取得
+
+          '
 land_protection:
   worldguard_integration: true
   urban_land_price: 100.0
@@ -2673,9 +5878,6 @@ events:
   excluded_worlds:
   - creative_world
   - test_world
-  - world
-  - world_nether
-  - world_the_end
   excluded_game_modes:
   - ADVENTURE
   caching:
@@ -2727,14 +5929,14 @@ trade_system:
   confirmation_required: true
   global_price_multiplier: 1.0
   job_price_multipliers:
-    miner: 1.5
+    miner: 1.2
     woodcutter: 1.0
     farmer: 1.0
-    fisherman: 1.5
-    blacksmith: 2.0
-    alchemist: 2.0
-    enchanter: 2.0
-    architect: 1.5
+    fisherman: 1.2
+    blacksmith: 1.4
+    alchemist: 1.4
+    enchanter: 1.4
+    architect: 1.2
   history:
     max_days: 30
     max_records_per_player: 1000
@@ -2919,7 +6121,10 @@ job_skills:
 leveling:
   experience:
     base_multiplier: 100
-    exponent: 2.0
+    exponent: 1.9
+    level_penalty:
+      factor: 0.005
+      minimum: 0.4
     level_scaling:
       early_levels:
         min_level: 1
@@ -3424,3 +6629,65 @@ city_map:
   - '§7  - §b🏪 取引所§7: アイテムの売買'
   - '§7  - §b🍖 食料店§7: 食料の購入'
   - '§7  - §b🏘️ 商店街§7: プレイヤー間取引'
+api:
+  tohu_app:
+    enabled: true
+    base_url: https://tohu-backend-prod-994007613494.asia-northeast1.run.app
+    token: ''
+    world_id: 5
+    retry:
+      max_attempts: 3
+      initial_delay_seconds: 5
+    debug: true
+tutorial:
+  enabled: true
+  auto_start: true
+  start_delay_seconds: 10
+  step_message_delay: 60
+  completion_rewards:
+    enabled: true
+    money: 50.0
+  messages:
+    start:
+    - '&e%player%さん、ようこそ！基本を案内します &7(/tutorial skip でスキップ)'
+    step1:
+      title: '&6【1/4】&f職業に就こう → &e/jobs join <職業名>'
+      description:
+      - '&7職業: 鉱夫, 木こり, 農家, 釣り人, 鍛冶屋, ポーション屋, エンチャンター, 建築家'
+      complete: '&a✓ 職業に就職しました！'
+    step2:
+      title: '&6【2/4】&fお金を稼ごう'
+      description:
+      - '&7職業に応じた作業（採掘、伐採、収穫など）をしてみましょう'
+      complete: '&a✓ 初めての収入を獲得！'
+    step3:
+      title: '&6【3/4】&f銀行NPCに話しかけよう'
+      description:
+      - '&7街にいる銀行員を右クリックして預け入れ・引き出しができます'
+      complete: '&a✓ 銀行を利用しました！'
+    step4:
+      title: '&6【4/4】&f取引NPCでアイテムを売ろう'
+      description:
+      - '&7街にいる商人を右クリックしてアイテムを売買できます'
+      complete: '&a✓ 取引所を利用しました！'
+    completed:
+    - '&a🎉 チュートリアル完了！自由に経済活動を楽しんでください'
+    completed_reward: '&6報酬: &f%money%%currency% &6獲得！'
+    skip_confirm: '&eチュートリアルをスキップしますか？ &f/tutorial skip confirm &eで確定'
+    skip_success: '&aチュートリアルをスキップしました。'
+    skip_note: '&7いつでも &f/tutorial restart &7でやり直せます。'
+    progress:
+      header: '&6▬▬▬▬▬▬▬▬ チュートリアル進捗 ▬▬▬▬▬▬▬▬'
+      current_step: '&e現在のステップ: &f%step%'
+      step_complete: '&a✓ %step_name% - 完了'
+      step_current: '&e→ %step_name% - 進行中'
+      step_pending: '&7○ %step_name% - 未完了'
+    already_completed: '&eチュートリアルは既に完了しています。'
+    not_started: '&cチュートリアルがまだ開始されていません。'
+    restart_success: '&aチュートリアルを最初からやり直します。'
+    admin_reset_success: '&a%player%さんのチュートリアルをリセットしました。'
+guide_book_settings:
+  enabled: true
+  prevent_duplicate: true
+  drop_when_full: true
+  give_message: '&a【職業ガイド】&f%job%のガイドブックを受け取りました！'

--- a/src/test/java/org/tofu/tofunomics/commands/PayCommandTest.java
+++ b/src/test/java/org/tofu/tofunomics/commands/PayCommandTest.java
@@ -82,6 +82,12 @@ public class PayCommandTest {
         when(targetPlayer.getUniqueId()).thenReturn(targetUuid);
         when(fromPlayer.getName()).thenReturn("TestSender");
         when(targetPlayer.getName()).thenReturn("TestReceiver");
+
+        // ワールド制限チェック用モック（経済機能が有効なワールドとして扱う）
+        org.bukkit.World mockWorld = mock(org.bukkit.World.class);
+        when(mockWorld.getName()).thenReturn("tofuNomics");
+        when(fromPlayer.getWorld()).thenReturn(mockWorld);
+        when(configManager.isEconomyEnabledInWorld(anyString())).thenReturn(true);
     }
 
     @Test

--- a/src/test/java/org/tofu/tofunomics/config/ConfigMaterialValidationTest.java
+++ b/src/test/java/org/tofu/tofunomics/config/ConfigMaterialValidationTest.java
@@ -1,0 +1,91 @@
+package org.tofu.tofunomics.config;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * config.ymlのMaterial名整合テスト
+ *
+ * item_prices / food_items / processing_npc.wood_types に記載された
+ * すべてのアイテム名がMinecraft(Bukkit) Material enumとして有効であることを検証する。
+ * 1.21のenum名ミス（例: scute→turtle_scute）の混入をCIで自動検出するための回帰防止テスト。
+ */
+public class ConfigMaterialValidationTest {
+
+    private static YamlConfiguration config;
+
+    @BeforeClass
+    public static void loadConfig() {
+        File file = new File("src/main/resources/config.yml");
+        assertTrue("config.ymlが存在すること: " + file.getAbsolutePath(), file.exists());
+        config = YamlConfiguration.loadConfiguration(file);
+    }
+
+    private static boolean isValidMaterial(String name) {
+        try {
+            Material.valueOf(name.toUpperCase());
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private static List<String> invalidKeys(String path) {
+        ConfigurationSection section = config.getConfigurationSection(path);
+        assertNotNull("セクションが存在すること: " + path, section);
+        List<String> invalid = new ArrayList<>();
+        for (String key : section.getKeys(false)) {
+            if (!isValidMaterial(key)) {
+                invalid.add(key);
+            }
+        }
+        return invalid;
+    }
+
+    @Test
+    public void item_pricesの全キーが有効なMaterialである() {
+        List<String> invalid = invalidKeys("npc_system.item_prices");
+        assertTrue("無効なMaterial名: " + invalid, invalid.isEmpty());
+    }
+
+    @Test
+    public void food_itemsの全キーが有効なMaterialである() {
+        List<String> invalid = invalidKeys("npc_system.food_npc.food_items");
+        assertTrue("無効なMaterial名: " + invalid, invalid.isEmpty());
+    }
+
+    @Test
+    public void wood_typesの原木と板材が有効なMaterialである() {
+        ConfigurationSection section = config.getConfigurationSection("npc_system.processing_npc.wood_types");
+        assertNotNull("wood_typesセクションが存在すること", section);
+        List<String> invalid = new ArrayList<>();
+        for (String logKey : section.getKeys(false)) {
+            if (!isValidMaterial(logKey)) {
+                invalid.add("log:" + logKey);
+            }
+            String planks = section.getString(logKey);
+            if (planks == null || !isValidMaterial(planks)) {
+                invalid.add("planks:" + planks);
+            }
+        }
+        assertTrue("無効なMaterial名: " + invalid, invalid.isEmpty());
+    }
+
+    @Test
+    public void item_pricesが十分な品目数を持つ() {
+        ConfigurationSection section = config.getConfigurationSection("npc_system.item_prices");
+        assertNotNull(section);
+        // 拡充後は100品目以上であること
+        assertTrue("item_pricesは100品目以上であること: " + section.getKeys(false).size(),
+            section.getKeys(false).size() >= 100);
+    }
+}

--- a/src/test/java/org/tofu/tofunomics/npc/ProcessingNPCManagerTest.java
+++ b/src/test/java/org/tofu/tofunomics/npc/ProcessingNPCManagerTest.java
@@ -1,0 +1,113 @@
+package org.tofu.tofunomics.npc;
+
+import org.bukkit.Material;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.economy.CurrencyConverter;
+import org.tofu.tofunomics.jobs.JobManager;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 加工NPCのconfig駆動マッピングのテスト
+ * wood_types設定からの動的読み込み・フォールバック・無効Material名のスキップを検証
+ */
+public class ProcessingNPCManagerTest {
+
+    @Mock
+    private TofuNomics plugin;
+    @Mock
+    private ConfigManager configManager;
+    @Mock
+    private NPCManager npcManager;
+    @Mock
+    private CurrencyConverter currencyConverter;
+    @Mock
+    private JobManager jobManager;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        // 無効Material名のスキップ時に警告ログ出力で使用される
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("ProcessingNPCManagerTest"));
+        when(configManager.getProcessingPlanksPerLog()).thenReturn(4);
+    }
+
+    private ProcessingNPCManager newManager() {
+        return new ProcessingNPCManager(plugin, configManager, npcManager, currencyConverter, jobManager);
+    }
+
+    @Test
+    public void configの木材マッピングが反映される() {
+        Map<String, String> woodTypes = new LinkedHashMap<>();
+        woodTypes.put("oak_log", "oak_planks");
+        woodTypes.put("mangrove_log", "mangrove_planks");
+        woodTypes.put("cherry_log", "cherry_planks");
+        woodTypes.put("bamboo_block", "bamboo_planks");
+        when(configManager.getProcessingWoodTypes()).thenReturn(woodTypes);
+
+        ProcessingNPCManager manager = newManager();
+
+        assertTrue(manager.isProcessableLog(Material.OAK_LOG));
+        assertTrue(manager.isProcessableLog(Material.MANGROVE_LOG));
+        assertTrue(manager.isProcessableLog(Material.CHERRY_LOG));
+        assertEquals(Material.MANGROVE_PLANKS, manager.getPlanksFromLog(Material.MANGROVE_LOG));
+        assertEquals(Material.BAMBOO_PLANKS, manager.getPlanksFromLog(Material.BAMBOO_BLOCK));
+        // config未定義の木材は加工対象外
+        assertFalse(manager.isProcessableLog(Material.SPRUCE_LOG));
+    }
+
+    @Test
+    public void configが空ならデフォルト8種にフォールバックする() {
+        when(configManager.getProcessingWoodTypes()).thenReturn(new LinkedHashMap<>());
+
+        ProcessingNPCManager manager = newManager();
+
+        assertTrue(manager.isProcessableLog(Material.OAK_LOG));
+        assertTrue(manager.isProcessableLog(Material.SPRUCE_LOG));
+        assertTrue(manager.isProcessableLog(Material.BIRCH_LOG));
+        assertTrue(manager.isProcessableLog(Material.JUNGLE_LOG));
+        assertTrue(manager.isProcessableLog(Material.ACACIA_LOG));
+        assertTrue(manager.isProcessableLog(Material.DARK_OAK_LOG));
+        assertTrue(manager.isProcessableLog(Material.CRIMSON_STEM));
+        assertTrue(manager.isProcessableLog(Material.WARPED_STEM));
+        assertEquals(Material.OAK_PLANKS, manager.getPlanksFromLog(Material.OAK_LOG));
+    }
+
+    @Test
+    public void 無効なMaterial名はスキップされ有効なもののみ登録される() {
+        Map<String, String> woodTypes = new LinkedHashMap<>();
+        woodTypes.put("oak_log", "oak_planks");
+        woodTypes.put("not_a_real_log", "not_a_real_planks");  // 無効
+        woodTypes.put("birch_log", "totally_invalid_output");  // 出力が無効
+        when(configManager.getProcessingWoodTypes()).thenReturn(woodTypes);
+
+        ProcessingNPCManager manager = newManager();
+
+        assertTrue(manager.isProcessableLog(Material.OAK_LOG));
+        // 無効エントリは登録されない（getでnull）
+        assertNull(manager.getPlanksFromLog(Material.BIRCH_LOG));
+    }
+
+    @Test
+    public void 全エントリ無効ならデフォルトにフォールバックする() {
+        Map<String, String> woodTypes = new LinkedHashMap<>();
+        woodTypes.put("not_a_real_log", "not_a_real_planks");
+        when(configManager.getProcessingWoodTypes()).thenReturn(woodTypes);
+
+        ProcessingNPCManager manager = newManager();
+
+        // 全て無効 → デフォルト8種にフォールバック
+        assertTrue(manager.isProcessableLog(Material.OAK_LOG));
+        assertTrue(manager.isProcessableLog(Material.WARPED_STEM));
+    }
+}


### PR DESCRIPTION
## 概要
進行中の作業をまとめてバンドルしたPRです。

### 1. NPC取引アイテムの網羅的拡充
- **item_prices**: 職業別アイテムを約180種追加（合計253品目）。鉱物/木材/農作物/海洋素材/装備/醸造素材/エンチャント関連/建材を網羅。全Material名をspigot-api 1.21.11のenumと照合済み（無効ゼロ・重複ゼロ）。
- **加工NPCのconfig駆動化**: `ConfigManager.getProcessingWoodTypes()` / `getProcessingPlanksPerLog()` を追加。`ProcessingNPCManager` を `wood_types` 設定からの動的読み込みに変更（無効Material名はスキップ、空config時はデフォルト8種にフォールバック）。mangrove/cherry/bamboo/剥いだ原木を追加。今後はconfig編集だけで加工木材を増やせる。
- **food_npc**: 高級食料9種（golden_apple等）を追加、八百屋/特産品店の品揃え拡充。
- **trading_posts items 一括拡充スクリプト**: `scripts/bulk_update_trading_items.py`（職業別追加・座標保護）、`scripts/merge_config_to_server.py`（ローカル値ブロックをサーバーconfigへ安全マージ）。

### 2. ワールド制限（既存コミット）
- TofuNomicsを `tofunomics` ワールド限定で動作させる制限を追加。
- 対象外ワールドでのヒントスコアボード表示・ルール同意システム動作の不具合修正。
- plugin.ymlにWorldGuard依存を宣言。

### 3. その他のWIP（NPC/GUI改善など）
- コマンド・DAO・GUI・通知系の改善をまとめて含む。

## テスト
- 新規: `ConfigMaterialValidationTest`（config.ymlのMaterial名整合・品目数）、`ProcessingNPCManagerTest`（config駆動マッピング・フォールバック・無効名スキップ）。
- **全175テスト緑 / BUILD SUCCESS**。

## デプロイ状況
- JAR + マージ済みconfig.ymlを本番サーバーへデプロイ済み。
- 保護フィールド（NPC座標/id/purchase_prices/food_npc.locations/bank_npcs）は**0件変化**を検証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)