### PR TITLE
feat: 1.21深層岩・新ブロックを職業システムに対応

### DIFF
--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -331,14 +331,17 @@ public class UnifiedEventHandler implements Listener {
      * 鉱石ブロックかどうかを判定
      */
     private boolean isOreBlock(Material blockType) {
-        return blockType == Material.COAL_ORE || 
+        // 深層岩鉱石（DEEPSLATE_*_ORE）も通常鉱石へ正規化して判定対象に含める
+        blockType = org.tofu.tofunomics.util.BlockNormalizer.normalizeForJob(blockType);
+        return blockType == Material.COAL_ORE ||
                blockType == Material.IRON_ORE || 
                blockType == Material.GOLD_ORE || 
                blockType == Material.DIAMOND_ORE || 
                blockType == Material.EMERALD_ORE || 
                blockType == Material.LAPIS_ORE || 
-               blockType == Material.REDSTONE_ORE || 
+               blockType == Material.REDSTONE_ORE ||
                blockType == Material.NETHER_QUARTZ_ORE ||
+               blockType == Material.COPPER_ORE ||
                blockType == Material.ANCIENT_DEBRIS;
     }
     
@@ -361,7 +364,11 @@ public class UnifiedEventHandler implements Listener {
         // 鉱石類は設置禁止のため追跡不要（isOreBlockで判定）
         
         // STONE, COBBLESTONE（無限経験値防止）
-        if (blockType == Material.STONE || blockType == Material.COBBLESTONE) {
+        // 深層岩石材（DEEPSLATE/COBBLED_DEEPSLATE/TUFF）はSTONEへ正規化され採掘経験値の対象になるため、
+        // 設置→採掘による無限経験値を防ぐべく追跡する
+        if (blockType == Material.STONE || blockType == Material.COBBLESTONE ||
+            blockType == Material.DEEPSLATE || blockType == Material.COBBLED_DEEPSLATE ||
+            blockType == Material.TUFF) {
             return true;
         }
         

--- a/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
+++ b/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
@@ -92,6 +92,7 @@ public class JobExperienceManager implements Listener {
         miningExperience.put(Material.LAPIS_ORE, 4.0);
         miningExperience.put(Material.REDSTONE_ORE, 3.0);
         miningExperience.put(Material.NETHER_QUARTZ_ORE, 6.0);
+        miningExperience.put(Material.COPPER_ORE, 5.0);  // 1.17追加。鉄鉱石相当
         miningExperience.put(Material.ANCIENT_DEBRIS, 50.0);
         // STONE: 自然生成のみ経験値獲得（プレイヤー設置はUnifiedEventHandlerで除外）
         miningExperience.put(Material.STONE, 5.0);  // 0.5 → 5.0（メッセージ表示のため）
@@ -106,6 +107,8 @@ public class JobExperienceManager implements Listener {
         loggingExperience.put(Material.DARK_OAK_LOG, 3.0);
         loggingExperience.put(Material.WARPED_STEM, 4.0);
         loggingExperience.put(Material.CRIMSON_STEM, 4.0);
+        loggingExperience.put(Material.MANGROVE_LOG, 3.0);  // 1.19追加。jungle/acacia相当
+        loggingExperience.put(Material.CHERRY_LOG, 3.0);    // 1.20追加。jungle/acacia相当
         
         // 農業経験値テーブル
         farmingExperience.put(Material.WHEAT, 1.5);
@@ -160,8 +163,9 @@ public class JobExperienceManager implements Listener {
     @EventHandler
     public void onBlockBreak(BlockBreakEvent event) {
         Player player = event.getPlayer();
-        Material blockType = event.getBlock().getType();
-        
+        // 深層岩鉱石・深層岩石材を通常版へ正規化してから経験値マップを引く
+        Material blockType = org.tofu.tofunomics.util.BlockNormalizer.normalizeForJob(event.getBlock().getType());
+
         // 鉱夫の採掘経験値
         if (jobManager.hasJob(player, "miner") && miningExperience.containsKey(blockType)) {
             double baseExp = miningExperience.get(blockType);

--- a/src/main/java/org/tofu/tofunomics/income/JobIncomeManager.java
+++ b/src/main/java/org/tofu/tofunomics/income/JobIncomeManager.java
@@ -53,6 +53,7 @@ public class JobIncomeManager implements Listener {
         minerIncome.put(Material.EMERALD_ORE, new IncomeData(20.0, 35.0));
         minerIncome.put(Material.ANCIENT_DEBRIS, new IncomeData(100.0, 150.0));
         minerIncome.put(Material.NETHER_QUARTZ_ORE, new IncomeData(6.0, 10.0));
+        minerIncome.put(Material.COPPER_ORE, new IncomeData(5.0, 8.0));  // 1.17追加。鉄鉱石相当
         jobIncomeMap.put("miner", minerIncome);
         
         // 木こりの収入データ
@@ -65,6 +66,8 @@ public class JobIncomeManager implements Listener {
         woodcutterIncome.put(Material.DARK_OAK_LOG, new IncomeData(2.0, 4.0));
         woodcutterIncome.put(Material.WARPED_STEM, new IncomeData(5.0, 8.0));
         woodcutterIncome.put(Material.CRIMSON_STEM, new IncomeData(5.0, 8.0));
+        woodcutterIncome.put(Material.MANGROVE_LOG, new IncomeData(2.0, 4.0));  // 1.19追加。jungle/acacia相当
+        woodcutterIncome.put(Material.CHERRY_LOG, new IncomeData(2.0, 4.0));    // 1.20追加。jungle/acacia相当
         jobIncomeMap.put("woodcutter", woodcutterIncome);
         
         // 農家の収入データ
@@ -169,7 +172,10 @@ public class JobIncomeManager implements Listener {
         if (!jobManager.hasJob(player, jobName)) {
             return;
         }
-        
+
+        // 深層岩鉱石・深層岩石材を通常版へ正規化してから収入マップを引く
+        material = org.tofu.tofunomics.util.BlockNormalizer.normalizeForJob(material);
+
         Map<Material, IncomeData> jobIncome = jobIncomeMap.get(jobName);
         if (jobIncome == null || !jobIncome.containsKey(material)) {
             return;

--- a/src/main/java/org/tofu/tofunomics/jobs/JobBlockPermissionManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobBlockPermissionManager.java
@@ -75,7 +75,8 @@ public class JobBlockPermissionManager {
             Material.EMERALD_ORE,
             Material.LAPIS_ORE,
             Material.REDSTONE_ORE,
-            Material.NETHER_QUARTZ_ORE
+            Material.NETHER_QUARTZ_ORE,
+            Material.COPPER_ORE  // 1.17追加。深層岩鉱石は正規化で本セットへ寄せる
         ));
         jobRestrictedBlocks.put("miner", minerBlocks);
         
@@ -138,6 +139,9 @@ public class JobBlockPermissionManager {
         if (player.hasPermission("tofunomics.admin.break")) {
             return true;
         }
+
+        // 深層岩鉱石・深層岩石材を通常版へ正規化（深層岩鉱石の採掘抜け穴を塞ぐ）
+        blockType = org.tofu.tofunomics.util.BlockNormalizer.normalizeForJob(blockType);
 
         // 基本ブロックの場合は常に許可
         if (basicBlocks.contains(blockType)) {

--- a/src/main/java/org/tofu/tofunomics/util/BlockNormalizer.java
+++ b/src/main/java/org/tofu/tofunomics/util/BlockNormalizer.java
@@ -1,0 +1,50 @@
+package org.tofu.tofunomics.util;
+
+import org.bukkit.Material;
+
+/**
+ * ブロックの職業判定用正規化ユーティリティ
+ *
+ * 1.17「洞窟と崖」以降に追加された深層岩鉱石（DEEPSLATE_*_ORE）や
+ * 深層岩石材（DEEPSLATE / COBBLED_DEEPSLATE / TUFF）を、
+ * 1.16.5時代に作られた経験値・収入・採掘権限の各マップが想定する
+ * 「通常版ブロック」へ寄せるための変換を一元管理する。
+ *
+ * 注意: ここでの変換はあくまで「職業システムの内部判定用」であり、
+ *       実際のドロップ品やワールド改変には一切影響しない。
+ */
+public final class BlockNormalizer {
+
+    private BlockNormalizer() {
+        // ユーティリティクラスのためインスタンス化禁止
+    }
+
+    /**
+     * 職業判定用にMaterialを正規化する。
+     * 変換対象でないMaterialはそのまま返す。
+     *
+     * @param material 元のMaterial
+     * @return 正規化後のMaterial
+     */
+    public static Material normalizeForJob(Material material) {
+        if (material == null) {
+            return null;
+        }
+        switch (material) {
+            // 深層岩鉱石 → 通常鉱石
+            case DEEPSLATE_COAL_ORE:     return Material.COAL_ORE;
+            case DEEPSLATE_IRON_ORE:     return Material.IRON_ORE;
+            case DEEPSLATE_GOLD_ORE:     return Material.GOLD_ORE;
+            case DEEPSLATE_DIAMOND_ORE:  return Material.DIAMOND_ORE;
+            case DEEPSLATE_EMERALD_ORE:  return Material.EMERALD_ORE;
+            case DEEPSLATE_LAPIS_ORE:    return Material.LAPIS_ORE;
+            case DEEPSLATE_REDSTONE_ORE: return Material.REDSTONE_ORE;
+            case DEEPSLATE_COPPER_ORE:   return Material.COPPER_ORE;
+            // 深層岩石材 → 石（建材掘りの扱いをSTONEに寄せる。経験値マップにSTONEがあるため）
+            case DEEPSLATE:
+            case COBBLED_DEEPSLATE:
+            case TUFF:                   return Material.STONE;
+            default:                     return material;
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -146,7 +146,8 @@ jobs:
         - "LAPIS_ORE"
         - "REDSTONE_ORE"
         - "NETHER_QUARTZ_ORE"
-      
+        - "COPPER_ORE"
+
       # 木こり専用ブロック（木材類）- Minecraft 1.16.5対応
       woodcutter:
         # 葉ブロック類
@@ -219,7 +220,7 @@ jobs:
         - "ENCHANTING_TABLE"
         - "BOOKSHELF"
         - "LECTERN"
-        - "LAPIS_LAZULI_BLOCK"
+        - "LAPIS_BLOCK"
 
       architect:
         - "SCAFFOLDING"

--- a/src/test/java/org/tofu/tofunomics/util/BlockNormalizerTest.java
+++ b/src/test/java/org/tofu/tofunomics/util/BlockNormalizerTest.java
@@ -1,0 +1,48 @@
+package org.tofu.tofunomics.util;
+
+import org.bukkit.Material;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * BlockNormalizer の正規化ロジックのテスト
+ * 深層岩鉱石・深層岩石材が通常版へ正しく変換されることを検証
+ */
+public class BlockNormalizerTest {
+
+    @Test
+    public void 深層岩鉱石は通常鉱石へ正規化される() {
+        assertEquals(Material.COAL_ORE, BlockNormalizer.normalizeForJob(Material.DEEPSLATE_COAL_ORE));
+        assertEquals(Material.IRON_ORE, BlockNormalizer.normalizeForJob(Material.DEEPSLATE_IRON_ORE));
+        assertEquals(Material.GOLD_ORE, BlockNormalizer.normalizeForJob(Material.DEEPSLATE_GOLD_ORE));
+        assertEquals(Material.DIAMOND_ORE, BlockNormalizer.normalizeForJob(Material.DEEPSLATE_DIAMOND_ORE));
+        assertEquals(Material.EMERALD_ORE, BlockNormalizer.normalizeForJob(Material.DEEPSLATE_EMERALD_ORE));
+        assertEquals(Material.LAPIS_ORE, BlockNormalizer.normalizeForJob(Material.DEEPSLATE_LAPIS_ORE));
+        assertEquals(Material.REDSTONE_ORE, BlockNormalizer.normalizeForJob(Material.DEEPSLATE_REDSTONE_ORE));
+        assertEquals(Material.COPPER_ORE, BlockNormalizer.normalizeForJob(Material.DEEPSLATE_COPPER_ORE));
+    }
+
+    @Test
+    public void 深層岩石材は石へ正規化される() {
+        assertEquals(Material.STONE, BlockNormalizer.normalizeForJob(Material.DEEPSLATE));
+        assertEquals(Material.STONE, BlockNormalizer.normalizeForJob(Material.COBBLED_DEEPSLATE));
+        assertEquals(Material.STONE, BlockNormalizer.normalizeForJob(Material.TUFF));
+    }
+
+    @Test
+    public void 通常版ブロックはそのまま返る() {
+        assertEquals(Material.IRON_ORE, BlockNormalizer.normalizeForJob(Material.IRON_ORE));
+        assertEquals(Material.COPPER_ORE, BlockNormalizer.normalizeForJob(Material.COPPER_ORE));
+        assertEquals(Material.MANGROVE_LOG, BlockNormalizer.normalizeForJob(Material.MANGROVE_LOG));
+        assertEquals(Material.CHERRY_LOG, BlockNormalizer.normalizeForJob(Material.CHERRY_LOG));
+        assertEquals(Material.STONE, BlockNormalizer.normalizeForJob(Material.STONE));
+        assertEquals(Material.DIAMOND_SWORD, BlockNormalizer.normalizeForJob(Material.DIAMOND_SWORD));
+    }
+
+    @Test
+    public void nullはnullを返す() {
+        assertNull(BlockNormalizer.normalizeForJob(null));
+    }
+}


### PR DESCRIPTION
## 概要
1.16.5時代に作られた職業システムが、1.17「洞窟と崖」以降に追加された深層岩鉱石・新ブロックを想定していなかったため、1.21ワールドで地下採掘・伐採をしても職業システムが正しく機能しない問題を修正します。

仕様書 `SPECIFICATION_20260605_tofunomics_deepslate_support.md` に基づく対応です。

## 変更内容
- **`util/BlockNormalizer`（新規）**: 職業判定用の正規化を一元管理。深層岩鉱石→通常鉱石、深層岩石材(DEEPSLATE/COBBLED_DEEPSLATE/TUFF)→STONE
- **`JobExperienceManager`**: 破壊時に正規化を適用。`COPPER_ORE`(5.0)、`MANGROVE_LOG`/`CHERRY_LOG`(3.0)を経験値テーブルに追加
- **`JobIncomeManager`**: 収入判定に正規化を適用。同3種を収入テーブルに追加（※当該ブロック破壊収入ハンドラは現状無効化済みのため将来の再有効化に備えた整合性確保）
- **`JobBlockPermissionManager`**: 採掘権限判定に正規化を適用し**深層岩鉱石が誰でも掘れる抜け穴を解消**。`COPPER_ORE`をminer専用に追加
- **`UnifiedEventHandler`**: 深層岩鉱石の設置禁止、設置追跡に深層岩石材を追加し**設置→採掘による無限経験値を防止**
- **`config.yml`**: minerに`COPPER_ORE`追加、`LAPIS_LAZULI_BLOCK`→`LAPIS_BLOCK`のtypo修正

## 仕様書との実態差異（補足）
- `JobIncomeManager`のブロック破壊収入は既にコメントアウトで無効化済みでした。
- `JobBlockPermissionManager`はconfig駆動ではなくハードコードでした。抜け穴解消は正規化＋ハードコード集合への追加で実現しています（configも整合性のため更新）。

## テスト
- `mvn clean package` 成功（jar生成）
- 全179テスト合格（既存175 + 新規`BlockNormalizerTest` 4件）

## 残課題
- `JobExperienceManager`の経験値テーブルはハードコードのため、変更反映にはプラグイン再ロード/再起動が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)