### PR TITLE
fix: システムNPCが再起動後に消失する不具合を修正

### DIFF
--- a/src/main/java/org/tofu/tofunomics/npc/NPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/NPCManager.java
@@ -84,7 +84,9 @@ public class NPCManager {
             villager.setSilent(true);
             villager.setInvulnerable(true);
             villager.setRemoveWhenFarAway(false);
-            // エンティティ衝突による押し出しを無効化し、その場に固定する
+            // チャンクセーブでエンティティを永続化（消失防止の本質。これがあれば setGravity(false) と併用しても保持される）
+            villager.setPersistent(true);
+            // エンティティ衝突・重力を無効化してその場に固定（永続化は setPersistent で担保済み）
             villager.setCollidable(false);
             villager.setGravity(false);
             villager.setVelocity(new org.bukkit.util.Vector(0, 0, 0));
@@ -154,7 +156,9 @@ public class NPCManager {
         villager.setInvulnerable(true);
         villager.setRemoveWhenFarAway(false);
         villager.setCustomNameVisible(true);
-        // エンティティ衝突による押し出しを無効化し、その場に固定する
+        // チャンクセーブでエンティティを永続化（消失防止の本質。これがあれば setGravity(false) と併用しても保持される）
+        villager.setPersistent(true);
+        // エンティティ衝突・重力を無効化してその場に固定（永続化は setPersistent で担保済み）
         villager.setCollidable(false);
         villager.setGravity(false);
         villager.setVelocity(new org.bukkit.util.Vector(0, 0, 0));


### PR DESCRIPTION
## 概要
1.21環境で、サーバー再起動後に銀行/取引/食料/加工の**全システムNPCが消失**する不具合を修正します。

## 原因
`NPCManager.createNPC` / `reapplyNPCSettings` でVillagerに `setPersistent(true)` が設定されておらず、起動直後（プレイヤー不在でNPC座標チャンクが未ロード）に生成されたエンティティが**ワールドセーブで永続化されず消失**していました。

- 6/5デプロイのコミット bd3906b で `setGravity(false)` 等のNPC固定化設定が追加され、本番(lobby-1.21)で初めて顕在化
- 起動時に132体生成されるも全て `isValid()==false`（`/tofunomics npc list` で全て無効）、再起動で旧NBTも復元されず

## 修正
`createNPC` / `reapplyNPCSettings` の両方で `setPersistent(true)` を明示追加し、チャンクセーブでの永続化を保証。固定化設定（`setGravity(false)` 等）は維持。

## 検証
本番 lobby-1.21 にデプロイし、リロード後に**NPC消失の再発なし・NPC固定**を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)