### PR TITLE
fix: 住居賃貸システムの重大バグと残課題を修正

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -1151,7 +1151,9 @@ public final class TofuNomics extends JavaPlugin {
         int intervalSeconds = getConfig().getInt("housing_rental.expire_check_interval", 3600);
         long intervalTicks = intervalSeconds * 20L; // 秒をTickに変換
         
-        getServer().getScheduler().runTaskTimerAsynchronously(this, () -> {
+        // processExpiredRentalsはWorld/Player等のBukkit APIを使用するため、
+        // 必ずメインスレッドで実行する（非同期スレッドからの呼び出しはクラッシュの原因になる）
+        getServer().getScheduler().runTaskTimer(this, () -> {
             try {
                 housingRentalManager.processExpiredRentals();
             } catch (Exception e) {

--- a/src/main/java/org/tofu/tofunomics/commands/HousingCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/HousingCommand.java
@@ -429,8 +429,8 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
      * 管理者: 物件一覧
      */
     private boolean handleAdminList(CommandSender sender) {
-        List<HousingProperty> properties = rentalManager.getAvailableProperties();
-        
+        List<HousingProperty> properties = rentalManager.getAllProperties();
+
         sender.sendMessage("§6========= 全物件一覧 =========");
         for (HousingProperty property : properties) {
             sender.sendMessage(String.format(
@@ -459,16 +459,12 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
             int propertyId = Integer.parseInt(args[1]);
             double newDailyRent = Double.parseDouble(args[2]);
 
-            HousingProperty property = rentalManager.getProperty(propertyId);
-            if (property == null) {
-                sender.sendMessage("§c物件が見つかりません");
-                return true;
+            HousingRentalManager.RentalResult result = rentalManager.updatePropertyRent(propertyId, newDailyRent);
+            if (result.isSuccess()) {
+                sender.sendMessage("§a物件#" + propertyId + "の日額賃料を" + newDailyRent + "に変更しました");
+            } else {
+                sender.sendMessage("§c" + result.getMessage());
             }
-
-            property.setDailyRent(newDailyRent);
-            // TODO: propertyDAO.updateProperty(property) を呼び出す処理をHousingRentalManagerに追加
-
-            sender.sendMessage("§a物件#" + propertyId + "の日額賃料を" + newDailyRent + "に変更しました");
 
         } catch (NumberFormatException e) {
             sender.sendMessage("§c数値の形式が正しくありません");

--- a/src/main/java/org/tofu/tofunomics/dao/HousingRentalDAO.java
+++ b/src/main/java/org/tofu/tofunomics/dao/HousingRentalDAO.java
@@ -272,8 +272,10 @@ public class HousingRentalDAO {
             rental.setEndTick(rs.getLong("end_tick"));
         } catch (SQLException e) {
             // カラムが存在しない場合（後方互換性のため）
+            // endTickに0を設定すると期限切れ判定で即時期限切れ扱いになり
+            // 全契約が誤って強制終了されるため、安全側（期限切れにしない値）に倒す
             rental.setStartTick(0);
-            rental.setEndTick(0);
+            rental.setEndTick(Long.MAX_VALUE);
         }
         
         rental.setStatus(rs.getString("status"));

--- a/src/main/java/org/tofu/tofunomics/housing/HousingRentalManager.java
+++ b/src/main/java/org/tofu/tofunomics/housing/HousingRentalManager.java
@@ -133,8 +133,13 @@ public class HousingRentalManager {
     /**
      * 賃貸契約を締結
      */
-    public RentalResult rentProperty(UUID tenantUuid, int propertyId, String period, int units) {
+    public synchronized RentalResult rentProperty(UUID tenantUuid, int propertyId, String period, int units) {
         try {
+            // 契約期間（単位数）の妥当性チェック（0以下だと即時期限切れや永久契約を招くため弾く）
+            if (units <= 0) {
+                return new RentalResult(false, "契約期間は1以上を指定してください");
+            }
+
             // 物件の確認
             HousingProperty property = propertyDAO.getProperty(propertyId);
             if (property == null) {
@@ -215,6 +220,8 @@ public class HousingRentalManager {
                             player.addBankBalance(bankBalance);
                             playerDAO.updatePlayer(player);
                         }
+                        // 作成済みの契約レコードを削除（物件が永久ロックされるのを防ぐ）
+                        rentalDAO.deleteRental(rentalId);
                         return new RentalResult(false, "支払い処理に失敗しました");
                     }
                 }
@@ -265,8 +272,13 @@ public class HousingRentalManager {
     /**
      * 契約を延長
      */
-    public RentalResult extendRental(UUID tenantUuid, int propertyId, int additionalDays) {
+    public synchronized RentalResult extendRental(UUID tenantUuid, int propertyId, int additionalDays) {
         try {
+            // 追加日数の妥当性チェック（0以下を弾く）
+            if (additionalDays <= 0) {
+                return new RentalResult(false, "追加日数は1以上を指定してください");
+            }
+
             HousingRental rental = rentalDAO.getActiveRentalByProperty(propertyId);
             
             if (rental == null) {
@@ -300,14 +312,10 @@ public class HousingRentalManager {
                     currencyConverter.formatCurrency(totalBalance) + ")");
             }
             
-            // 契約延長
-            rental.extend(additionalDays, additionalCost);
-            rentalDAO.updateRental(rental);
-            
-            // 支払い処理（銀行残高優先、足りない分を現金から）
+            // 先に支払い処理を行い、成功した場合のみ契約を延長する（DB不整合・無料延長を防ぐ）
             org.tofu.tofunomics.models.Player player = playerDAO.getOrCreatePlayer(tenantUuid);
             double bankBalance = player.getBankBalance();
-            
+
             if (bankBalance >= additionalCost) {
                 // 銀行残高のみで支払い可能
                 player.removeBankBalance(additionalCost);
@@ -315,27 +323,28 @@ public class HousingRentalManager {
             } else {
                 // 銀行残高+現金で支払い
                 double remainingCost = additionalCost;
-                
+
                 if (bankBalance > 0) {
                     // 銀行残高を全額使用
                     player.removeBankBalance(bankBalance);
                     playerDAO.updatePlayer(player);
                     remainingCost -= bankBalance;
                 }
-                
+
                 // 残りを現金から支払い
                 if (!currencyConverter.payWithCash(onlinePlayer, remainingCost)) {
-                    // 支払い失敗時はロールバック（銀行残高と契約状態を戻す）
+                    // 支払い失敗時は銀行残高を戻す（契約は未変更のため巻き戻し不要）
                     if (bankBalance > 0) {
                         player.addBankBalance(bankBalance);
                         playerDAO.updatePlayer(player);
                     }
-                    // 契約延長を元に戻す
-                    rental.extend(-additionalDays, -additionalCost);
-                    rentalDAO.updateRental(rental);
                     return new RentalResult(false, "支払い処理に失敗しました");
                 }
             }
+
+            // 支払い成功後に契約を延長
+            rental.extend(additionalDays, additionalCost);
+            rentalDAO.updateRental(rental);
             
             // 履歴追加
             HousingRentalHistory history = new HousingRentalHistory(
@@ -492,6 +501,18 @@ public class HousingRentalManager {
     }
 
     /**
+     * 全物件一覧を取得（運営用：賃貸中の物件も含む）
+     */
+    public List<HousingProperty> getAllProperties() {
+        try {
+            return propertyDAO.getAllProperties();
+        } catch (SQLException e) {
+            logger.severe("全物件一覧の取得に失敗しました: " + e.getMessage());
+            return List.of();
+        }
+    }
+
+    /**
      * 物件情報を取得
      */
     public HousingProperty getProperty(int propertyId) {
@@ -575,6 +596,28 @@ public class HousingRentalManager {
             
         } catch (SQLException e) {
             logger.severe("物件の削除に失敗しました: " + e.getMessage());
+            return new RentalResult(false, "データベースエラーが発生しました");
+        }
+    }
+
+    /**
+     * 物件の日額賃料を更新（運営用）
+     * 週額・月額は日額から自動計算されるため、ここでは日額のみ更新する
+     */
+    public RentalResult updatePropertyRent(int propertyId, double newDailyRent) {
+        try {
+            HousingProperty property = propertyDAO.getProperty(propertyId);
+            if (property == null) {
+                return new RentalResult(false, "物件が見つかりません");
+            }
+
+            property.setDailyRent(newDailyRent);
+            propertyDAO.updateProperty(property);
+
+            logger.info("物件の賃料を変更しました: ID " + propertyId + " -> 日額 " + newDailyRent);
+            return new RentalResult(true, "賃料を変更しました");
+        } catch (SQLException e) {
+            logger.severe("賃料変更に失敗しました: " + e.getMessage());
             return new RentalResult(false, "データベースエラーが発生しました");
         }
     }

--- a/src/main/java/org/tofu/tofunomics/housing/HousingRentalManager.java
+++ b/src/main/java/org/tofu/tofunomics/housing/HousingRentalManager.java
@@ -343,8 +343,16 @@ public class HousingRentalManager {
             }
 
             // 支払い成功後に契約を延長
-            rental.extend(additionalDays, additionalCost);
-            rentalDAO.updateRental(rental);
+            try {
+                rental.extend(additionalDays, additionalCost);
+                rentalDAO.updateRental(rental);
+            } catch (SQLException e) {
+                // 契約更新に失敗した場合は支払い済み金額を銀行へ返金（資産消失を防ぐ）
+                player.addBankBalance(additionalCost);
+                playerDAO.updatePlayer(player);
+                logger.severe("契約延長のDB更新に失敗したため返金しました: " + e.getMessage());
+                return new RentalResult(false, "データベースエラーが発生しました（料金は返金されました）");
+            }
             
             // 履歴追加
             HousingRentalHistory history = new HousingRentalHistory(
@@ -366,7 +374,7 @@ public class HousingRentalManager {
     /**
      * 契約をキャンセル
      */
-    public RentalResult cancelRental(UUID tenantUuid, int propertyId) {
+    public synchronized RentalResult cancelRental(UUID tenantUuid, int propertyId) {
         try {
             HousingRental rental = rentalDAO.getActiveRentalByProperty(propertyId);
             
@@ -612,6 +620,9 @@ public class HousingRentalManager {
             }
 
             property.setDailyRent(newDailyRent);
+            // 週額・月額を日額からの自動計算に委ねるためリセット（古い固定値が残るのを防ぐ）
+            property.setWeeklyRent(null);
+            property.setMonthlyRent(null);
             propertyDAO.updateProperty(property);
 
             logger.info("物件の賃料を変更しました: ID " + propertyId + " -> 日額 " + newDailyRent);


### PR DESCRIPTION
## 概要
住居賃貸システムの調査で発見した不具合（重大3件＋残課題5件）を修正します。

## 重大3件（運用前に必須）
| 問題 | 修正 |
|---|---|
| 非同期スレッドからWorld/Player APIを呼び出し → **クラッシュ** | 期限チェックタスクを `runTaskTimerAsynchronously` → `runTaskTimer`（メインスレッド）へ変更 |
| 支払い失敗時にゾンビ契約が残り **物件が永久ロック** | 支払い失敗時に `rentalDAO.deleteRental(rentalId)` を実行 |
| `setrent` が未保存（TODO放置）→ **再起動で賃料が戻る** | `updatePropertyRent()` を追加しDBへ永続化 |

## 残課題5件（中・低リスク）
- 契約期間・延長日数の `0`/負数入力をガード（即期限切れ・永久契約を防止）
- `/housing admin list` で賃貸中を含む**全物件**を表示（`getAllProperties()`）
- 契約延長を**支払い成功後にDB更新**する順序へ変更（無料延長・残高消失を防止）
- `start_tick/end_tick` カラム欠落時のフォールバックを安全側（`Long.MAX_VALUE`）へ変更し誤期限切れを防止
- `rentProperty`/`extendRental` を `synchronized` 化し同時実行の競合（TOCTOU）を緩和

## 変更ファイル
- `TofuNomics.java`
- `housing/HousingRentalManager.java`
- `commands/HousingCommand.java`
- `dao/HousingRentalDAO.java`

## 確認
- [x] `mvn clean compile` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)