### PR TITLE
fix: /tofunomics reload でNPC価格が反映されない問題を修正

### DIFF
--- a/src/main/java/org/tofu/tofunomics/commands/TofuNomicsCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/TofuNomicsCommand.java
@@ -21,11 +21,15 @@ public class TofuNomicsCommand implements CommandExecutor, TabCompleter {
     private final TofuNomics plugin;
     private final ConfigManager configManager;
     private final NPCCommand npcCommand;
-    
-    public TofuNomicsCommand(TofuNomics plugin, ConfigManager configManager, NPCManager npcManager, 
+    private final TradingNPCManager tradingNPCManager;
+    private final FoodNPCManager foodNPCManager;
+
+    public TofuNomicsCommand(TofuNomics plugin, ConfigManager configManager, NPCManager npcManager,
                         BankNPCManager bankNPCManager, TradingNPCManager tradingNPCManager, FoodNPCManager foodNPCManager, ProcessingNPCManager processingNPCManager) {
     this.plugin = plugin;
     this.configManager = configManager;
+    this.tradingNPCManager = tradingNPCManager;
+    this.foodNPCManager = foodNPCManager;
     this.npcCommand = new NPCCommand(plugin, configManager, npcManager, bankNPCManager, tradingNPCManager, foodNPCManager, processingNPCManager);
 }
     
@@ -66,11 +70,20 @@ public class TofuNomicsCommand implements CommandExecutor, TabCompleter {
         sender.sendMessage("§eTofuNomicsプラグインをリロード中...");
         
         try {
-            // 設定リロード
-            plugin.reloadConfig();
-            
+            // 設定リロード（ConfigManager経由で内部キャッシュ・参照も更新）
+            configManager.reloadConfig();
+
+            // NPCの価格データを再構築（configファイルだけでなくメモリ上の価格も更新）
+            // これがないとfood_items/item_pricesの変更がreloadで反映されない
+            if (tradingNPCManager != null) {
+                tradingNPCManager.reloadTradingPosts();
+            }
+            if (foodNPCManager != null) {
+                foodNPCManager.reloadFoodPrices();
+            }
+
             sender.sendMessage("§aTofuNomicsプラグインのリロードが完了しました。");
-            sender.sendMessage("§e注意: 完全なリロードにはプラグインの再起動が推奨されます。");
+            sender.sendMessage("§7（取引所・食料NPCの価格も再構築済み）");
             plugin.getLogger().info("プラグインがリロードされました（実行者: " + sender.getName() + "）");
         } catch (Exception e) {
             sender.sendMessage("§cリロード中にエラーが発生しました: " + e.getMessage());

--- a/src/main/java/org/tofu/tofunomics/npc/FoodNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/FoodNPCManager.java
@@ -521,6 +521,22 @@ public class FoodNPCManager {
         initializeFoodNPCs();
         plugin.getLogger().info("食料NPCのリロードが完了しました");
     }
+
+    /**
+     * 食料NPCの価格のみを再構築する（NPCは再スポーンしない）
+     * config.ymlのfood_items/price_multiplier変更を /tofunomics reload で反映するために使用
+     */
+    public void reloadFoodPrices() {
+        int count = 0;
+        for (UUID npcId : new ArrayList<>(foodStores.keySet())) {
+            FoodStore old = foodStores.get(npcId);
+            if (old == null) continue;
+            Map<Material, Double> newPrices = buildFoodItemPrices(old.getNpcType());
+            foodStores.put(npcId, new FoodStore(old.getNpcId(), old.getName(), old.getLocation(), newPrices, old.getNpcType()));
+            count++;
+        }
+        plugin.getLogger().info("食料NPCの価格を再構築しました（" + count + "店舗）");
+    }
     
     /**
      * 指定プレイヤーの購入履歴取得


### PR DESCRIPTION
## 概要
`/tofunomics reload` を実行しても、food/trading NPCの価格が更新されない問題を修正します。

## 背景
PR #37 で魚価格(config)を修正・反映しましたが、`/tofunomics reload` 後もゲーム内のNPC購入価格が古いまま（3/4）でした。

## 根本原因
`handleReloadCommand` は `plugin.reloadConfig()` でconfigファイルを読み直すだけで、food/trading NPCが**起動時に構築した価格データ**（`FoodStore.itemPrices` / `TradingPost`）を再構築していませんでした。そのため config.yml の `food_items` / `item_prices` 変更が反映されず、プラグイン再起動が必須でした（コード内にも「完全なリロードには再起動推奨」と明記）。

## 修正内容
- **TofuNomicsCommand**: `plugin.reloadConfig()` → `configManager.reloadConfig()`（内部キャッシュ・参照も更新）に変更。さらにreload時に既存の `tradingNPCManager.reloadTradingPosts()` と新規 `foodNPCManager.reloadFoodPrices()` を呼んで価格を再構築。manager参照をフィールドに保持。
- **FoodNPCManager**: 価格のみ再構築する `reloadFoodPrices()` を追加。既存の `buildFoodItemPrices(npcType)` を使い、各 `FoodStore` を新価格で作り直す（**NPCは再スポーンしない**ため座標・エンティティに影響なし）。

## 効果
今後は `/tofunomics reload` だけで food_items / item_prices の変更が即反映され、サーバー/プラグイン再起動が不要になります。

## 検証
- ビルド成功（mvn clean package）
- デプロイ後 `/tofunomics reload` →（魚価格6/7、売却6/7が反映されること、NPCが消えないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)