### PR TITLE
fix: 総合取引所(全職業1.4倍)経由の魚の荒稼ぎを修正

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1481,8 +1481,8 @@ npc_system:
       sweet_berries: 2      # スイートベリー      # スイートベリー
       
       # 魚屋用商品
-      cooked_cod: 6         # 焼いた鱈
-      cooked_salmon: 7      # 焼いた鮭
+      cooked_cod: 7         # 焼いた鱈
+      cooked_salmon: 8      # 焼いた鮭
       kelp: 1               # 昆布               # 昆布
       
       # 八百屋用商品

--- a/src/main/resources/server_config.yml
+++ b/src/main/resources/server_config.yml
@@ -761,8 +761,8 @@ npc_system:
       rabbit_stew: 4.0
       dried_kelp: 0.8
       sweet_berries: 1.2
-      cooked_cod: 6
-      cooked_salmon: 7
+      cooked_cod: 7
+      cooked_salmon: 8
       kelp: 0.5
       potato: 0.2
       beetroot: 1.2


### PR DESCRIPTION
## 概要
PR #37 の魚価格修正に残っていた**荒稼ぎ経路**を塞ぎます（テストプレイヤーの指摘により発覚）。

## 見落としていた問題
PR #37 では釣り人専用取引所（職業倍率1.2）を前提に差益0としましたが、**総合取引所**（`§6総合取引所`・`24時間ショップ`、ともに `accepted_jobs: [all]`・`items: []`＝全アイテム対応）では**全職業のプレイヤーが魚を売却**でき、最大職業倍率 **1.4倍**（鍛冶/錬金/エンチャント）が適用されます。

その結果、修正後も差益が残っていました:
| アイテム | 魚屋購入 | 総合取引所売却(×1.4) | 差益 |
|---|---|---|---|
| cooked_cod | 6 | floor(5×1.4)=7 | +1 |
| cooked_salmon | 7 | floor(6×1.4)=8 | +1 |

## 修正内容
最大1.4倍売却でも差益0以下になるよう、魚屋の購入価格を引き上げ（売却=item_pricesは5/6据え置き）:
- `food_items`: `cooked_cod` 6→**7**, `cooked_salmon` 7→**8**

## 検証（全職業・全取引所を網羅）
| アイテム | 購入 | 売却×1.4 | 売却×1.2(釣り人) | 差益(最大) |
|---|---|---|---|---|
| cooked_cod | 7 | 7 | 6 | **0** |
| cooked_salmon | 8 | 8 | 7 | **0** |

食料NPC購入品全件×全取引所×全職業倍率を検証し、差益の出るアイテムが0件であることを確認済み。釣り人(1.2)の漁業収入(売却6/7)は維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)