### PR TITLE
fix: 職業ボーナスを職業専用取引所のみに限定

### DIFF
--- a/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
@@ -146,6 +146,14 @@ public class TradingNPCManager {
         }
 
         /**
+         * 総合取引所（全職業対応）かどうか。
+         * 職業ボーナス（職業倍率・木こり原木2倍）を職業専用NPCに限定するための判定。
+         */
+        public boolean isGeneralStore() {
+            return acceptedJobTypes.isEmpty() || acceptedJobTypes.contains("all");
+        }
+
+        /**
          * 売却時の職業チェック（従来の厳格な制限）
          * @param jobType プレイヤーの職業
          * @return 売却可能な場合true
@@ -616,10 +624,12 @@ public class TradingNPCManager {
             
             if (basePrice > 0) {
                 int amount = item.getAmount();
-                double finalPrice = tradePriceManager.calculateFinalPrice(material.toString().toLowerCase(), playerJob, basePrice);
-                
-                // 木こりが原木を売る場合は価格を2倍に
-                if (isWoodcutter(player) && isLogItem(material)) {
+                // 職業ボーナスは職業専用取引所でのみ適用（総合取引所では素のitem_prices×1.0）
+                String effectiveJob = tradingPost.isGeneralStore() ? null : playerJob;
+                double finalPrice = tradePriceManager.calculateFinalPrice(material.toString().toLowerCase(), effectiveJob, basePrice);
+
+                // 木こりが原木を売る場合は価格を2倍に（職業専用取引所のみ）
+                if (!tradingPost.isGeneralStore() && isWoodcutter(player) && isLogItem(material)) {
                     finalPrice *= 2.0;
                     plugin.getLogger().info("木こりボーナス適用: " + material + " の価格を2倍に");
                 }
@@ -669,10 +679,12 @@ public class TradingNPCManager {
             
             if (basePrice > 0) {
                 int amount = item.getAmount();
-                double finalPrice = tradePriceManager.calculateFinalPrice(material.toString().toLowerCase(), playerJob, basePrice);
-                
-                // 木こりが原木を売る場合は価格を2倍に
-                if (isWoodcutter(player) && isLogItem(material)) {
+                // 職業ボーナスは職業専用取引所でのみ適用（総合取引所では素のitem_prices×1.0）
+                String effectiveJob = tradingPost.isGeneralStore() ? null : playerJob;
+                double finalPrice = tradePriceManager.calculateFinalPrice(material.toString().toLowerCase(), effectiveJob, basePrice);
+
+                // 木こりが原木を売る場合は価格を2倍に（職業専用取引所のみ）
+                if (!tradingPost.isGeneralStore() && isWoodcutter(player) && isLogItem(material)) {
                     finalPrice *= 2.0;
                     plugin.getLogger().info("木こりボーナス適用: " + material + " の価格を2倍に");
                 }
@@ -1060,8 +1072,9 @@ public class TradingNPCManager {
                 Material material = entry.getKey();
                 double price = entry.getValue();
                 
-                // 職業ボーナスを適用
-                double finalPrice = Math.ceil(tradePriceManager.calculateFinalPrice(material.toString().toLowerCase(), playerJob, price));
+                // 職業ボーナスは職業専用取引所でのみ適用
+                String effectivePriceJob = tradingPost.isGeneralStore() ? null : playerJob;
+                double finalPrice = Math.ceil(tradePriceManager.calculateFinalPrice(material.toString().toLowerCase(), effectivePriceJob, price));
                 String formattedPrice = currencyConverter.formatCurrency(finalPrice);
                 
                 player.sendMessage("§f• " + material.toString().toLowerCase() + ": §a" + formattedPrice);

--- a/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
@@ -270,14 +270,16 @@ public class TradingGUI implements Listener {
                 displayItem = createPurchaseItem(material, purchasePrice, playerJob, isCrossJob);
             } else {
                 // 売却モード
+                // 職業ボーナスは職業専用取引所でのみ適用（総合取引所では素の価格）
+                String effectiveJob = tradingPost.isGeneralStore() ? null : playerJob;
                 double finalPrice = tradePriceManager.calculateFinalPrice(
                     material.toString().toLowerCase(),
-                    playerJob,
+                    effectiveJob,
                     price
                 );
 
-                // 木こりが原木を見る場合、GUI表示にも木こりボーナスを適用
-                if ("woodcutter".equals(playerJob) && isLogItem(material)) {
+                // 木こりが原木を見る場合、GUI表示にも木こりボーナスを適用（職業専用取引所のみ）
+                if (!tradingPost.isGeneralStore() && "woodcutter".equals(playerJob) && isLogItem(material)) {
                     finalPrice *= 2.0;
                 }
 
@@ -302,7 +304,7 @@ public class TradingGUI implements Listener {
             Arrays.asList(
                 "§f現在の残高: §a" + currencyConverter.formatCurrency(balance),
                 "§f職業: §e" + (playerJob != null ? playerJob : "無職"),
-                "§f職業ボーナス: §a" + (playerJob != null ? String.format("%.0f%%", (configManager.getJobPriceMultiplier(playerJob) - 1.0) * 100) : "なし"),
+                "§f職業ボーナス: §a" + ((playerJob != null && !tradingPost.isGeneralStore()) ? String.format("%.0f%%", (configManager.getJobPriceMultiplier(playerJob) - 1.0) * 100) : "なし"),
                 "",
                 "§7アイテムをクリックして売却"
             )
@@ -855,10 +857,12 @@ public class TradingGUI implements Listener {
             double basePrice = tradingPost.getItemPrice(mat);
 
             if (basePrice > 0) {
-                double finalPrice = tradePriceManager.calculateFinalPrice(mat.toString().toLowerCase(), playerJob, basePrice);
+                // 職業ボーナスは職業専用取引所でのみ適用（総合取引所では素のitem_prices×1.0）
+                String effectiveJob = tradingPost.isGeneralStore() ? null : playerJob;
+                double finalPrice = tradePriceManager.calculateFinalPrice(mat.toString().toLowerCase(), effectiveJob, basePrice);
 
-                // 木こりが原木を売る場合は価格を2倍に
-                if ("woodcutter".equals(playerJob) && isLogItem(mat)) {
+                // 木こりが原木を売る場合は価格を2倍に（職業専用取引所のみ）
+                if (!tradingPost.isGeneralStore() && "woodcutter".equals(playerJob) && isLogItem(mat)) {
                     finalPrice *= 2.0;
                 }
 
@@ -1034,10 +1038,12 @@ public class TradingGUI implements Listener {
             double basePrice = tradingPost.getItemPrice(mat);
 
             if (basePrice > 0) {
-                double finalPrice = tradePriceManager.calculateFinalPrice(mat.toString().toLowerCase(), playerJob, basePrice);
+                // 職業ボーナスは職業専用取引所でのみ適用（総合取引所では素のitem_prices×1.0）
+                String effectiveJob = tradingPost.isGeneralStore() ? null : playerJob;
+                double finalPrice = tradePriceManager.calculateFinalPrice(mat.toString().toLowerCase(), effectiveJob, basePrice);
 
-                // 木こりが原木を売る場合は価格を2倍に
-                if ("woodcutter".equals(playerJob) && isLogItem(mat)) {
+                // 木こりが原木を売る場合は価格を2倍に（職業専用取引所のみ）
+                if (!tradingPost.isGeneralStore() && "woodcutter".equals(playerJob) && isLogItem(mat)) {
                     finalPrice *= 2.0;
                 }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1481,8 +1481,8 @@ npc_system:
       sweet_berries: 2      # スイートベリー      # スイートベリー
       
       # 魚屋用商品
-      cooked_cod: 7         # 焼いた鱈
-      cooked_salmon: 8      # 焼いた鮭
+      cooked_cod: 6         # 焼いた鱈
+      cooked_salmon: 7      # 焼いた鮭
       kelp: 1               # 昆布               # 昆布
       
       # 八百屋用商品

--- a/src/main/resources/server_config.yml
+++ b/src/main/resources/server_config.yml
@@ -761,8 +761,8 @@ npc_system:
       rabbit_stew: 4.0
       dried_kelp: 0.8
       sweet_berries: 1.2
-      cooked_cod: 7
-      cooked_salmon: 8
+      cooked_cod: 6
+      cooked_salmon: 7
       kelp: 0.5
       potato: 0.2
       beetroot: 1.2


### PR DESCRIPTION
## 概要
職業ボーナス（職業倍率・木こり原木2倍）を**職業専用取引所でのみ適用**し、総合取引所では素の価格で売却するよう変更します。これにより総合取引所経由の魚の荒稼ぎを根本的に解決します。

## 背景・問題
PR #37〜#39 で魚の価格を調整してきましたが、根本原因は「**総合取引所**（`accepted_jobs: [all]`）で全職業が売却でき、職業倍率（最大1.4倍）が適用される」ことでした。価格調整だけでは、職業倍率の高い職業（鍛冶/錬金/エンチャント=1.4）が総合取引所で売ると差益が出る構造が残っていました。

## 修正方針（ユーザー方針: 職業ボーナスは職業NPCのみ）
- **職業専用取引所**（釣り人取引所など）: 職業倍率・木こり2倍を適用（従来通り）
- **総合取引所**（`accepted_jobs:[all]`・空）: 職業ボーナスを無効化し `item_prices × 1.0` で売却

## 変更内容
- `TradingPost.isGeneralStore()` を追加（`accepted_jobs` が空または `"all"`）
- 売却処理・買取価格表示で総合取引所なら職業ボーナスを無効化:
  - `TradingNPCManager`: 売却2メソッド + チャット買取価格表
  - `TradingGUI`: 売却計算2箇所 + GUI価格表示 + 職業ボーナス%表示
- 総合取引所が1.0倍になったため魚屋の購入価格を6/7に戻す（`food_items`: cooked_cod 7→6, cooked_salmon 8→7）

## 検証（全職業・全取引所）
| アイテム | 魚屋購入 | 総合取引所(×1.0) | 釣り人取引所(×1.2) | 差益 |
|---|---|---|---|---|
| cooked_cod | 6 | 5（損） | 6 | **0** |
| cooked_salmon | 7 | 6（損） | 7 | **0** |

食料NPC購入品全件×全取引所×新ルールで差益の出るアイテムが0件であることを確認済み。ビルド成功。

## デプロイ注意
コード変更を含むため、反映には **jar差し替え＋plugman reload（またはサーバー再起動）** が必要です（`/tofunomics reload` ではクラスは再ロードされません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)