### PR TITLE
fix: 他ワールドで職業クラフト制限がかかる問題を修正＋制限ロジックを集約

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -420,7 +420,7 @@ public final class TofuNomics extends JavaPlugin {
             saveConfig(); // 設定を確実に保存
             configManager.reloadConfig(); // リロードで反映
             
-            // CraftRestrictionEventHandlerの初期化（緊急対応）
+            // CraftRestrictionEventHandlerの初期化（職業別クラフト制限の唯一の責任者）
             craftRestrictionEventHandler = new org.tofu.tofunomics.events.CraftRestrictionEventHandler(this);
             
             getLogger().info("Phase 6 クラフト制限システムを初期化しました");
@@ -560,7 +560,7 @@ public final class TofuNomics extends JavaPlugin {
                 getLogger().info("取引システムリスナーを登録しました");
             }
             
-            // Phase 6 クラフト制限イベントハンドラーの登録（緊急対応）
+            // Phase 6 クラフト制限イベントハンドラーの登録（職業別クラフト制限の唯一の責任者）
             if (craftRestrictionEventHandler != null) {
                 getServer().getPluginManager().registerEvents(craftRestrictionEventHandler, this);
                 getLogger().info("Phase 6 クラフト制限イベントハンドラーを登録しました");

--- a/src/main/java/org/tofu/tofunomics/events/CraftRestrictionEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/CraftRestrictionEventHandler.java
@@ -9,53 +9,79 @@ import org.bukkit.event.inventory.CraftItemEvent;
 import org.tofu.tofunomics.TofuNomics;
 
 /**
- * 専用のクラフト制限イベントハンドラー
- * UnifiedEventHandlerの問題回避のための緊急対応
+ * 職業別クラフト制限の唯一の責任を持つイベントハンドラー。
+ *
+ * UnifiedEventHandler の craft 処理は shouldProcessEvent でゲートされており、
+ * 無職・クリエイティブ・権限なしのプレイヤーでは制限がスキップされてしまう。
+ * そのため制限ロジックはこのハンドラーに集約する。
+ *
+ * 優先度を LOWEST にすることで、XP/クエストを付与する UnifiedEventHandler(HIGH)
+ * よりも先にキャンセルし、禁止クラフトに対する経験値付与を防ぐ。
+ * UnifiedEventHandler 側は ignoreCancelled = true のため、ここでキャンセルされた
+ * イベントは処理されない。
  */
 public class CraftRestrictionEventHandler implements Listener {
-    
+
     private final TofuNomics plugin;
-    
+
     public CraftRestrictionEventHandler(TofuNomics plugin) {
         this.plugin = plugin;
     }
-    
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = false)
     public void onCraftItem(CraftItemEvent event) {
-        plugin.getLogger().info("=== CraftRestrictionEventHandler 開始 ===");
-        
         if (!(event.getWhoClicked() instanceof Player)) {
-            plugin.getLogger().info("プレイヤー以外のクリック - 処理スキップ");
             return;
         }
-        
+
         Player player = (Player) event.getWhoClicked();
         Material craftedItem = event.getRecipe().getResult().getType();
-        
-        plugin.getLogger().info("プレイヤー: " + player.getName());
-        plugin.getLogger().info("クラフト対象: " + craftedItem.name());
-        
-        // JobCraftPermissionManagerの取得
-        if (plugin.getJobCraftPermissionManager() == null) {
-            plugin.getLogger().warning("JobCraftPermissionManager が null - 制限をスキップ");
+
+        // ワールドチェック（EventProcessor.isValidWorldと同等の判定）
+        // 対象外ワールドでは職業クラフト制限を適用しない
+        if (!isCraftRestrictionEnabledWorld(player)) {
             return;
         }
-        
-        plugin.getLogger().info("JobCraftPermissionManager 確認完了");
-        
+
+        // JobCraftPermissionManagerの取得
+        if (plugin.getJobCraftPermissionManager() == null) {
+            plugin.getLogger().warning("JobCraftPermissionManager が null - クラフト制限をスキップ");
+            return;
+        }
+
         // クラフト制限チェック
         if (!plugin.getJobCraftPermissionManager().canPlayerCraftItem(player, craftedItem)) {
             // クラフトを禁止
             event.setCancelled(true);
-            
+
             // 制限メッセージを送信
             String message = plugin.getJobCraftPermissionManager().getCraftDeniedMessage(player, craftedItem);
             player.sendMessage(message);
-            
-            plugin.getLogger().info("クラフト制限実行: " + player.getName() + " が " + craftedItem.name() + " のクラフトを禁止");
-            return;
+
+            plugin.getLogger().info("クラフト制限: " + player.getName() + " が " + craftedItem.name() + " のクラフトを禁止");
         }
-        
-        plugin.getLogger().info("クラフト許可: " + player.getName() + " が " + craftedItem.name() + " のクラフトを許可");
+    }
+
+    /**
+     * クラフト制限を適用すべきワールドかどうかを判定する。
+     * EventProcessor.isValidWorld() と同じ判定基準（除外ワールド + economy.enabled_worlds ホワイトリスト）。
+     * 対象外ワールドでは制限を適用しない。
+     */
+    private boolean isCraftRestrictionEnabledWorld(Player player) {
+        if (plugin.getConfigManager() == null) {
+            // 設定が取得できない場合は安全側（制限なし）に倒す
+            return true;
+        }
+
+        String worldName = player.getWorld().getName();
+
+        // 除外ワールドはスキップ
+        java.util.List<String> excludedWorlds = plugin.getConfigManager().getExcludedWorlds();
+        if (excludedWorlds != null && excludedWorlds.contains(worldName)) {
+            return false;
+        }
+
+        // 経済機能を有効にするワールドのホワイトリスト（空の場合は全ワールドで有効：後方互換）
+        return plugin.getConfigManager().isEconomyEnabledInWorld(worldName);
     }
 }

--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -203,23 +203,10 @@ public class UnifiedEventHandler implements Listener {
         if (!(event.getWhoClicked() instanceof Player)) return;
 
         Player player = (Player) event.getWhoClicked();
-        Material craftedItem = event.getRecipe().getResult().getType();
 
-        // クラフト制限チェック（優先度HIGH で先にチェック）
-        TofuNomics tofuPlugin = (TofuNomics) plugin;
-        if (tofuPlugin.getJobCraftPermissionManager() != null) {
-            if (!tofuPlugin.getJobCraftPermissionManager().canPlayerCraftItem(player, craftedItem)) {
-                // クラフトを禁止
-                event.setCancelled(true);
-
-                // 制限メッセージを送信
-                String message = tofuPlugin.getJobCraftPermissionManager().getCraftDeniedMessage(player, craftedItem);
-                player.sendMessage(message);
-                return;
-            }
-        } else {
-            plugin.getLogger().warning("JobCraftPermissionManager: 未初期化のため制限チェックをスキップ");
-        }
+        // 職業別クラフト制限は CraftRestrictionEventHandler(LOWEST) が担当する。
+        // そこでキャンセルされたイベントは ignoreCancelled = true により
+        // このハンドラーには届かないため、ここでは経験値・クエスト処理のみ行う。
 
         // キャッシュチェック
         if (eventCache.isRecentlyProcessed(player, "craft_item", 100)) {


### PR DESCRIPTION
## 概要

`tofuNomics` 以外のワールドで職業によるクラフト制限がかかってしまう問題（再発）を修正し、あわせて二重実装されていたクラフト制限ロジックを1箇所に集約しました。

## 根本原因

クラフト制限は2つのリスナーが同じ処理（`canPlayerCraftItem`）を実行していました。

| リスナー | priority | ワールドチェック |
|---|---|---|
| `UnifiedEventHandler.onCraftItem` | HIGH | あり（`shouldProcessEvent`→`EventProcessor.isValidWorld`） |
| `CraftRestrictionEventHandler.onCraftItem` | HIGHEST | **なし** ← 原因 |

以前の他ワールド制限修正は `EventProcessor.isValidWorld()` 経由（`UnifiedEventHandler`）にのみ効いており、緊急対応として別途追加された `CraftRestrictionEventHandler` はワールドチェックを持たず全ワールドで制限を適用していました。

さらに `CraftItemEvent` は `isJobOptionalEvent` に含まれないため、`UnifiedEventHandler` 経路は無職プレイヤーで `shouldProcessEvent` が false となり制限がスキップされます。つまり両者は等価ではなく、`CraftRestrictionEventHandler` が無職・クリエイティブ・権限なしのケースを担っていました。

## 変更内容

- **`CraftRestrictionEventHandler`（制限の唯一の責任者に昇格）**
  - ワールド判定 `isCraftRestrictionEnabledWorld` を追加（`events.excluded_worlds` ＋ `economy.enabled_worlds`、`EventProcessor.isValidWorld` と同等）→ 対象外ワールドでは制限スキップ
  - 優先度 `HIGHEST` → `LOWEST`：XP/クエスト付与より先にキャンセルし、禁止クラフトへのXP付与を防止
  - per-craft の INFO ログ大量出力を整理（拒否時のみ記録）
- **`UnifiedEventHandler.onCraftItem`**：重複していた制限ロジックを削除（`ignoreCancelled=true` によりキャンセル済みクラフトはXP付与されない）
- **`TofuNomics.java`**：初期化・登録箇所のコメントを実態に更新

## 効果

無職プレイヤーへの制限・XP付与順序・ワールド判定がすべて1箇所で一貫するようになりました。

## テスト

- `mvn clean test` 全179テスト成功（Failures: 0, Errors: 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)