### PR TITLE
config: 釣り人NPCの魚買取価格を修正（生＜調理済み）

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1744,8 +1744,9 @@ npc_system:
     milk_bucket: 2
     egg: 0.5
     # 魚類（リリース前バランス調整: 釣りの直接収入減額分を売却単価で補填）
-    cod: 7
-    salmon: 8
+    # 調理の手間を反映し、未調理(生)より調理済みを高く設定（cooked_cod/cooked_salmon参照）
+    cod: 5
+    salmon: 6
     tropical_fish: 11
     pufferfish: 14
     # 宝物・レア素材
@@ -1861,8 +1862,9 @@ npc_system:
     sunflower: 0.5
     wither_rose: 3
     # --- fisherman: 海洋素材 ---
-    cooked_cod: 5
-    cooked_salmon: 6
+    # 調理済みは未調理(生cod:5/salmon:6)より高く設定
+    cooked_cod: 7
+    cooked_salmon: 8
     kelp: 0.3
     dried_kelp: 0.5
     sea_pickle: 1.5


### PR DESCRIPTION
## 概要
職業NPC「釣り人(fisherman)」で魚を売ると、調理済みの魚の方が未調理(生)より**安く**買い取られていた問題を修正。調理の手間（かまど＋燃料）を反映し、調理済みの方が高く買い取られるよう `npc_system.item_prices` の値を入れ替えた。

## 変更内容
| アイテム | 変更前 | 変更後 |
|---|---|---|
| cod（生タラ） | 7 | 5 |
| cooked_cod（焼タラ） | 5 | 7 |
| salmon（生サケ） | 8 | 6 |
| cooked_salmon（焼サケ） | 6 | 8 |

## 価格パスの確認
- 釣り人NPCの買取価格は `TradingGUI` → `tradingPost.getItemPrice()`（`npc_system.item_prices`由来）→ `TradePriceManager.calculateFinalPrice()`（職業倍率1.2×グローバル倍率）で算出される。本セクションが唯一の基準。
- `TradePriceManager.java` の hardcoded 価格テーブルはチェスト取引(TradeChest)専用でNPC取引では未使用のため変更不要。
- 別NPC「魚屋(food_system.food_items)」や `tropical_fish`/`pufferfish`（調理版なし）は対象外。

## 最終買取額の目安（fisherman職, 倍率1.2）
- 生タラ 6 / 焼タラ 8.4
- 生サケ 7.2 / 焼サケ 9.6
→ いずれも「調理済み＞生」を満たす。

## 補足
本番(lobby-1.21)サーバーの config.yml も該当4行のみ同値にピンポイント修正済み（NPC座標等のサーバー固有設定は未変更）。リロード後に反映予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)