### PR TITLE
fix: 安価アイテム(単価1コイン未満)がGUIから売却できない問題を修正

### DIFF
--- a/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
@@ -644,8 +644,8 @@ public class TradingNPCManager {
         // 累積した合計を通貨換算（四捨五入）。1コイン以上で売却成立
         int payableNuggets = currencyConverter.convertBalanceToNuggets(totalEarnings);
         if (payableNuggets > 0) {
-            // インベントリに金塊として支払い
-            if (!currencyConverter.receiveCash(player, totalEarnings)) {
+            // 換算済みの金塊数を直接渡し、チェック値と支払い額を厳密に一致させる（二重丸め回避）
+            if (!currencyConverter.receiveCash(player, payableNuggets)) {
                 return new TradeResult(false, "インベントリに空きがありません。金塊を受け取るスペースを確保してください", 0.0, new HashMap<>());
             }
 
@@ -701,8 +701,8 @@ public class TradingNPCManager {
         // 累積した合計を通貨換算（四捨五入）。1コイン以上で売却成立
         int payableNuggets = currencyConverter.convertBalanceToNuggets(totalEarnings);
         if (payableNuggets > 0) {
-            // インベントリに金塊として支払い（スペースチェックスキップオプション付き）
-            if (!currencyConverter.receiveCash(player, totalEarnings, skipSpaceCheck)) {
+            // 換算済みの金塊数を直接渡し、チェック値と支払い額を厳密に一致させる（二重丸め回避）
+            if (!currencyConverter.receiveCash(player, payableNuggets, skipSpaceCheck)) {
                 return new TradeResult(false, "インベントリに空きがありません。金塊を受け取るスペースを確保してください", 0.0, new HashMap<>());
             }
 

--- a/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
@@ -634,23 +634,25 @@ public class TradingNPCManager {
                     plugin.getLogger().info("木こりボーナス適用: " + material + " の価格を2倍に");
                 }
                 
-                double itemTotal = finalPrice * amount;
-                
-                // 個数を掛けた後に切り捨て
-                itemTotal = Math.floor(itemTotal);
-                
-                totalEarnings += itemTotal;
+                // アイテム単位では切り捨てず、合計に端数を累積する
+                // （安価アイテムが floor で0になり売却不能になるのを防ぐ）
+                totalEarnings += finalPrice * amount;
                 soldItems.put(material, soldItems.getOrDefault(material, 0) + amount);
             }
         }
-        
-        if (totalEarnings > 0) {
+
+        // 累積した合計を通貨換算（四捨五入）。1コイン以上で売却成立
+        int payableNuggets = currencyConverter.convertBalanceToNuggets(totalEarnings);
+        if (payableNuggets > 0) {
             // インベントリに金塊として支払い
             if (!currencyConverter.receiveCash(player, totalEarnings)) {
                 return new TradeResult(false, "インベントリに空きがありません。金塊を受け取るスペースを確保してください", 0.0, new HashMap<>());
             }
-            
-            return new TradeResult(true, "取引が完了しました", totalEarnings, soldItems);
+
+            return new TradeResult(true, "取引が完了しました", payableNuggets, soldItems);
+        } else if (!soldItems.isEmpty()) {
+            // 売却対象はあったが、合計額が安すぎて1コインに満たない
+            return new TradeResult(false, "売却額が少なすぎます。もう少しまとめて売却してください", 0.0, new HashMap<>());
         } else {
             return new TradeResult(false, "売却可能なアイテムがありませんでした", 0.0, new HashMap<>());
         }
@@ -689,23 +691,25 @@ public class TradingNPCManager {
                     plugin.getLogger().info("木こりボーナス適用: " + material + " の価格を2倍に");
                 }
                 
-                double itemTotal = finalPrice * amount;
-                
-                // 個数を掛けた後に切り捨て
-                itemTotal = Math.floor(itemTotal);
-                
-                totalEarnings += itemTotal;
+                // アイテム単位では切り捨てず、合計に端数を累積する
+                // （安価アイテムが floor で0になり売却不能になるのを防ぐ）
+                totalEarnings += finalPrice * amount;
                 soldItems.put(material, soldItems.getOrDefault(material, 0) + amount);
             }
         }
-        
-        if (totalEarnings > 0) {
+
+        // 累積した合計を通貨換算（四捨五入）。1コイン以上で売却成立
+        int payableNuggets = currencyConverter.convertBalanceToNuggets(totalEarnings);
+        if (payableNuggets > 0) {
             // インベントリに金塊として支払い（スペースチェックスキップオプション付き）
             if (!currencyConverter.receiveCash(player, totalEarnings, skipSpaceCheck)) {
                 return new TradeResult(false, "インベントリに空きがありません。金塊を受け取るスペースを確保してください", 0.0, new HashMap<>());
             }
-            
-            return new TradeResult(true, "取引が完了しました", totalEarnings, soldItems);
+
+            return new TradeResult(true, "取引が完了しました", payableNuggets, soldItems);
+        } else if (!soldItems.isEmpty()) {
+            // 売却対象はあったが、合計額が安すぎて1コインに満たない
+            return new TradeResult(false, "売却額が少なすぎます。もう少しまとめて売却してください", 0.0, new HashMap<>());
         } else {
             return new TradeResult(false, "売却可能なアイテムがありませんでした", 0.0, new HashMap<>());
         }

--- a/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
@@ -866,12 +866,8 @@ public class TradingGUI implements Listener {
                     finalPrice *= 2.0;
                 }
 
-                double itemTotal = finalPrice * sellItem.getAmount();
-
-                // 個数を掛けた後に切り捨て
-                itemTotal = Math.floor(itemTotal);
-
-                totalEarnings += itemTotal;
+                // アイテム単位では切り捨てず合計に累積（processItemSaleの支払い計算と整合）
+                totalEarnings += finalPrice * sellItem.getAmount();
             }
         }
 
@@ -1047,12 +1043,8 @@ public class TradingGUI implements Listener {
                     finalPrice *= 2.0;
                 }
 
-                double itemTotal = finalPrice * sellItem.getAmount();
-
-                // 個数を掛けた後に切り捨て
-                itemTotal = Math.floor(itemTotal);
-
-                totalEarnings += itemTotal;
+                // アイテム単位では切り捨てず合計に累積（processItemSaleの支払い計算と整合）
+                totalEarnings += finalPrice * sellItem.getAmount();
             }
         }
 


### PR DESCRIPTION
## 概要
取引GUIで安価なアイテム（単価1コイン未満：carrot/potato 0.9、egg 0.5、各種planks 0.12など）を売却しようとすると、所持しているのに「売却可能なアイテムがありませんでした」と表示され売却できない問題を修正しました。

## 根本原因
`TradingNPCManager.processItemSale()` がアイテム1種ごとに `Math.floor(単価 × 個数)` で金額を切り捨て、合計が `> 0` の時のみ売却成立としていた。

- carrot/potato（0.9）を1個 → `floor(0.9) = 0` → 失敗
- egg（0.5）を1個 → `floor(0.5) = 0` → 失敗
- planks（0.12）は9個以上売らないと1コインに届かない

一方で通貨換算 `convertBalanceToNuggets()` は `Math.round`（四捨五入）。売却側が `floor`、支払側が `round` と判定基準が不整合だったことが原因です。

## 修正内容
- アイテム単位の `Math.floor` 切り捨てを廃止し、端数を**合計に累積**してから通貨換算（四捨五入）で1コイン以上かを判定
- carrot/potato/egg は1個でも売却可能に。planks 等は数個まとめれば売却可能
- 合計が1コインに満たない場合は「売却額が少なすぎます。もう少しまとめて売却してください」と明確なメッセージを表示し、**アイテムは消費しない**（ロールバック維持）
- `TradingGUI` 側の事前スペース計算も同じ累積方式に揃え、実際の支払い額と整合

## 設計判断
ユーザー承認のもと「端数を累積し四捨五入で判定」方式を採用。原木・板材のスタック単位価格設計（経済バランス）を崩さず、安価アイテムの単品売却を可能にします。

## テスト
- [x] `mvn compile` 成功
- [ ] ゲーム内: carrot/potato/egg を1個売却 → 成功すること
- [ ] ゲーム内: planks を数個まとめて売却 → 成功すること
- [ ] ゲーム内: 極端に安いアイテム1個 → 「売却額が少なすぎます」表示＋アイテムが消えないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)