### PR TITLE
feat: 食材を食べると職業経験値が上がる食事バフを追加

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -93,6 +93,9 @@ public final class TofuNomics extends JavaPlugin {
     private org.tofu.tofunomics.npc.FoodNPCManager foodNPCManager;
     private org.tofu.tofunomics.npc.ProcessingNPCManager processingNPCManager;
     private org.tofu.tofunomics.npc.NPCListener npcListener;
+    // 食事による職業経験値ブーストバフ
+    private org.tofu.tofunomics.food.FoodBuffManager foodBuffManager;
+    private org.tofu.tofunomics.food.FoodConsumeListener foodConsumeListener;
     private org.tofu.tofunomics.npc.gui.BankGUI bankGUI;
     private org.tofu.tofunomics.npc.gui.TradingGUI tradingGUI;
     private org.tofu.tofunomics.npc.gui.TradingModeSelectionGUI tradingModeSelectionGUI = null;
@@ -335,7 +338,12 @@ public final class TofuNomics extends JavaPlugin {
                 jobToolManager,
                 experienceManager
             );
-            
+
+            // 食事による職業経験値ブーストバフの初期化・注入
+            foodBuffManager = new org.tofu.tofunomics.food.FoodBuffManager(configManager);
+            jobExperienceManager.setFoodBuffManager(foodBuffManager);
+            foodConsumeListener = new org.tofu.tofunomics.food.FoodConsumeListener(configManager, foodBuffManager);
+
             // 収入システムは無効化: JobIncomeManagerの初期化はコメントアウト
             /*
             jobIncomeManager = new JobIncomeManager(
@@ -552,6 +560,12 @@ public final class TofuNomics extends JavaPlugin {
                 // getServer().getPluginManager().registerEvents(jobIncomeManager, this);  // 収入システムは無効化
                 getServer().getPluginManager().registerEvents(jobQuestManager, this);
                 getLogger().info("既存の個別イベントリスナーを登録しました");
+            }
+
+            // 食事による職業経験値ブーストバフリスナーの登録
+            if (foodConsumeListener != null) {
+                getServer().getPluginManager().registerEvents(foodConsumeListener, this);
+                getLogger().info("食事バフリスナーを登録しました");
             }
             
             // Phase 4 取引システムイベントリスナーの登録

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -2961,6 +2961,45 @@ public class ConfigManager {
         return config.getInt("npc_system.food_npc.inventory_system.daily_stock_limit", 64);
     }
     
+    // ===== 食事による職業経験値ブーストバフ（food_buff）=====
+
+    /**
+     * 食事バフ機能が有効かどうか
+     */
+    public boolean isFoodBuffEnabled() {
+        return config.getBoolean("food_buff.enabled", false);
+    }
+
+    /**
+     * 指定カテゴリ（bread/vegetable/fish/meat）の経験値ボーナス割合(%)を取得
+     */
+    public int getFoodBuffBonusPercent(String categoryKey) {
+        return config.getInt("food_buff.categories." + categoryKey + ".bonus_percent", 0);
+    }
+
+    /**
+     * 指定カテゴリ（bread/vegetable/fish/meat）のバフ持続時間(秒)を取得
+     */
+    public int getFoodBuffDurationSeconds(String categoryKey) {
+        return config.getInt("food_buff.categories." + categoryKey + ".duration_seconds", 0);
+    }
+
+    /**
+     * バフ付与時のメッセージテンプレートを取得
+     */
+    public String getFoodBuffAppliedMessage() {
+        return config.getString("food_buff.messages.buff_applied",
+            "&a食事の効果！ &e%category% &aで職業経験値 &e+%percent%%% &a（%duration%秒）");
+    }
+
+    /**
+     * より強いバフへ上書きされた時のメッセージテンプレートを取得
+     */
+    public String getFoodBuffReplacedMessage() {
+        return config.getString("food_buff.messages.buff_replaced",
+            "&aより強い食事効果に切り替わりました：&e%category% +%percent%%%");
+    }
+
     /**
      * 食料NPCの設定リストを取得
      */

--- a/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
+++ b/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
@@ -43,6 +43,9 @@ public class JobExperienceManager implements Listener {
     // バニラ経験値バーへの即時反映用（setter注入。null許容）
     private org.tofu.tofunomics.scoreboard.ScoreboardManager scoreboardManager;
 
+    // 食事による経験値ブーストバフ用（setter注入。null許容）
+    private org.tofu.tofunomics.food.FoodBuffManager foodBuffManager;
+
     // 経験値テーブル
     private final Map<Material, Double> miningExperience;
     private final Map<Material, Double> loggingExperience;
@@ -80,6 +83,13 @@ public class JobExperienceManager implements Listener {
      */
     public void setScoreboardManager(org.tofu.tofunomics.scoreboard.ScoreboardManager scoreboardManager) {
         this.scoreboardManager = scoreboardManager;
+    }
+
+    /**
+     * 食事による経験値ブーストバフ管理を注入する
+     */
+    public void setFoodBuffManager(org.tofu.tofunomics.food.FoodBuffManager foodBuffManager) {
+        this.foodBuffManager = foodBuffManager;
     }
 
     private void initializeExperienceTables() {
@@ -342,10 +352,14 @@ public class JobExperienceManager implements Listener {
         
         // 設定ファイルの経験値倍率を適用
         Job job = jobDAO.getJobByNameSafe(jobName);
-        double configMultiplier = job != null ? 
+        double configMultiplier = job != null ?
             configManager.getJobExpMultiplier(jobName) : 1.0;
-        
-        return baseExperience * levelPenalty * configMultiplier;
+
+        // 食事バフ倍率を適用（バフ無し・失効時は1.0で従来と同一）
+        double foodBuffMultiplier = (foodBuffManager != null) ?
+            foodBuffManager.getMultiplier(player) : 1.0;
+
+        return baseExperience * levelPenalty * configMultiplier * foodBuffMultiplier;
     }
     
     /**
@@ -364,8 +378,12 @@ public class JobExperienceManager implements Listener {
         if (!jobManager.hasJob(player, jobName)) {
             return false;
         }
-        
-        giveJobExperience(player, jobName, amount);
+
+        // 食事バフ倍率を適用（Mob討伐経験値などの経路でも一貫して反映。バフ無し時は1.0）
+        double foodBuffMultiplier = (foodBuffManager != null) ?
+            foodBuffManager.getMultiplier(player) : 1.0;
+
+        giveJobExperience(player, jobName, amount * foodBuffMultiplier);
         return true;
     }
 }

--- a/src/main/java/org/tofu/tofunomics/food/FoodBuffManager.java
+++ b/src/main/java/org/tofu/tofunomics/food/FoodBuffManager.java
@@ -1,0 +1,131 @@
+package org.tofu.tofunomics.food;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.tofu.tofunomics.config.ConfigManager;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 食事による職業経験値ブーストバフの管理クラス。
+ *
+ * 食材を食べると、そのカテゴリ（パン/野菜/魚/肉）に応じた一定時間の
+ * 職業経験値倍率バフを付与する。倍率は経験値獲得時（JobExperienceManager）に乗算される。
+ *
+ * 重複挙動: 上書き（一番強いものが有効）。
+ *   - より強い（または同等の）バフを食べた場合は上書き（持続時間もリセット）。
+ *   - 既存より弱いバフを食べても無視（下げない・延長しない）。
+ */
+public class FoodBuffManager {
+
+    private final ConfigManager configManager;
+
+    // プレイヤーUUID -> 有効中のバフ
+    private final Map<UUID, ActiveBuff> activeBuffs = new ConcurrentHashMap<>();
+
+    public FoodBuffManager(ConfigManager configManager) {
+        this.configManager = configManager;
+    }
+
+    /**
+     * 有効中のバフ情報
+     */
+    private static class ActiveBuff {
+        final double factor;       // 経験値倍率（例: +30% -> 1.30）
+        final long expiresAtMillis; // 失効時刻（エポックミリ秒）
+        final String displayName;  // カテゴリ表示名
+
+        ActiveBuff(double factor, long expiresAtMillis, String displayName) {
+            this.factor = factor;
+            this.expiresAtMillis = expiresAtMillis;
+            this.displayName = displayName;
+        }
+    }
+
+    /**
+     * 食材カテゴリに応じたバフを付与する。
+     * 既に有効なバフより弱い場合は何もしない（一番強いものが有効）。
+     */
+    public void applyBuff(Player player, FoodCategory category) {
+        if (player == null || category == null) {
+            return;
+        }
+        if (!configManager.isFoodBuffEnabled()) {
+            return;
+        }
+
+        String key = category.getConfigKey();
+        int bonusPercent = configManager.getFoodBuffBonusPercent(key);
+        int durationSeconds = configManager.getFoodBuffDurationSeconds(key);
+
+        // 効果が無い設定（0%や0秒）の場合はバフを付与しない
+        if (bonusPercent <= 0 || durationSeconds <= 0) {
+            return;
+        }
+
+        double newFactor = 1.0 + (bonusPercent / 100.0);
+        long now = System.currentTimeMillis();
+        long expiresAt = now + (durationSeconds * 1000L);
+
+        UUID uuid = player.getUniqueId();
+        ActiveBuff current = activeBuffs.get(uuid);
+        boolean currentValid = current != null && current.expiresAtMillis > now;
+
+        // 既存が有効かつ今回が弱い場合は何もしない（下げない・延長しない）
+        if (currentValid && newFactor < current.factor) {
+            return;
+        }
+
+        boolean replaced = currentValid;
+        activeBuffs.put(uuid, new ActiveBuff(newFactor, expiresAt, category.getDisplayName()));
+
+        sendBuffMessage(player, replaced, category, bonusPercent, durationSeconds);
+    }
+
+    /**
+     * プレイヤーの現在の経験値倍率を取得する。
+     * 有効なバフが無い、または失効済みの場合は 1.0 を返す（遅延失効）。
+     */
+    public double getMultiplier(Player player) {
+        if (player == null) {
+            return 1.0;
+        }
+        UUID uuid = player.getUniqueId();
+        ActiveBuff buff = activeBuffs.get(uuid);
+        if (buff == null) {
+            return 1.0;
+        }
+        if (buff.expiresAtMillis <= System.currentTimeMillis()) {
+            // 失効済みは破棄
+            activeBuffs.remove(uuid);
+            return 1.0;
+        }
+        return buff.factor;
+    }
+
+    /**
+     * プレイヤーの状態をクリアする（ログアウト時などに呼ぶ想定。任意）
+     */
+    public void clear(UUID uuid) {
+        if (uuid != null) {
+            activeBuffs.remove(uuid);
+        }
+    }
+
+    private void sendBuffMessage(Player player, boolean replaced, FoodCategory category,
+                                 int bonusPercent, int durationSeconds) {
+        String template = replaced
+            ? configManager.getFoodBuffReplacedMessage()
+            : configManager.getFoodBuffAppliedMessage();
+        if (template == null || template.isEmpty()) {
+            return;
+        }
+        String message = template
+            .replace("%category%", category.getDisplayName())
+            .replace("%percent%", String.valueOf(bonusPercent))
+            .replace("%duration%", String.valueOf(durationSeconds));
+        player.sendMessage(ChatColor.translateAlternateColorCodes('&', message));
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/food/FoodCategory.java
+++ b/src/main/java/org/tofu/tofunomics/food/FoodCategory.java
@@ -1,0 +1,99 @@
+package org.tofu.tofunomics.food;
+
+import org.bukkit.Material;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 食材バフのカテゴリ定義。
+ *
+ * 食材を食べた際に付与される職業経験値バフのカテゴリを表す。
+ * 各カテゴリは config.yml の {@code food_buff.categories.<configKey>} から
+ * 効果量（bonus_percent）と持続時間（duration_seconds）を引くためのキーを持つ。
+ *
+ * Material -> FoodCategory の対応は仕様であり頻繁に変えないため、
+ * 既存の経験値テーブル（JobExperienceManager）と同様にここへハードコードする。
+ */
+public enum FoodCategory {
+    BREAD("bread", "パン"),
+    VEGETABLE("vegetable", "野菜"),
+    FISH("fish", "魚"),
+    MEAT("meat", "肉");
+
+    private final String configKey;
+    private final String displayName;
+
+    FoodCategory(String configKey, String displayName) {
+        this.configKey = configKey;
+        this.displayName = displayName;
+    }
+
+    /**
+     * config.yml の food_buff.categories 配下で使用するキー（bread/vegetable/fish/meat）
+     */
+    public String getConfigKey() {
+        return configKey;
+    }
+
+    /**
+     * プレイヤー向け表示名（パン/野菜/魚/肉）
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    // Material -> カテゴリ の対応表
+    private static final Map<Material, FoodCategory> MATERIAL_MAP = new HashMap<>();
+
+    static {
+        // パン屋系
+        put(FoodCategory.BREAD,
+            "BREAD", "COOKIE", "CAKE", "PUMPKIN_PIE");
+
+        // 八百屋系（野菜・果物）
+        put(FoodCategory.VEGETABLE,
+            "CARROT", "APPLE", "POTATO", "BAKED_POTATO", "BEETROOT",
+            "MELON_SLICE", "MELON", "GOLDEN_CARROT", "GLOW_BERRIES",
+            "SWEET_BERRIES", "BEETROOT_SOUP", "MUSHROOM_STEW");
+
+        // 魚屋系（魚・海産物）
+        put(FoodCategory.FISH,
+            "COD", "SALMON", "COOKED_COD", "COOKED_SALMON",
+            "DRIED_KELP", "KELP", "TROPICAL_FISH", "PUFFERFISH");
+
+        // 精肉店系（肉類）
+        put(FoodCategory.MEAT,
+            "COOKED_BEEF", "COOKED_PORKCHOP", "COOKED_CHICKEN", "COOKED_MUTTON",
+            "COOKED_RABBIT", "RABBIT_STEW", "BEEF", "PORKCHOP",
+            "CHICKEN", "MUTTON", "RABBIT");
+
+        // 特殊食料（GOLDEN_APPLE / ENCHANTED_GOLDEN_APPLE / SUSPICIOUS_STEW /
+        // HONEY_BOTTLE / CHORUS_FRUIT / MILK_BUCKET 等）はバフ対象外とする。
+    }
+
+    /**
+     * Material名の配列を指定カテゴリにまとめて登録する。
+     * バージョン差でMaterialが存在しない場合（Material.matchMaterialがnull）はスキップする。
+     */
+    private static void put(FoodCategory category, String... materialNames) {
+        for (String name : materialNames) {
+            Material material = Material.matchMaterial(name);
+            if (material != null) {
+                MATERIAL_MAP.put(material, category);
+            }
+        }
+    }
+
+    /**
+     * 食材Materialから対応するバフカテゴリを取得する。
+     * 対象外の食材・非食材の場合は null を返す。
+     */
+    public static FoodCategory fromMaterial(Material material) {
+        if (material == null) {
+            return null;
+        }
+        return MATERIAL_MAP.get(material);
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/food/FoodConsumeListener.java
+++ b/src/main/java/org/tofu/tofunomics/food/FoodConsumeListener.java
@@ -1,0 +1,45 @@
+package org.tofu.tofunomics.food;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.tofu.tofunomics.config.ConfigManager;
+
+/**
+ * 食材を食べた時に職業経験値ブーストバフを付与するリスナー。
+ *
+ * PlayerItemConsumeEvent は実際に食料が食べられた時のみ発火するため、
+ * 満腹時には通常食料でバフが付かない（自然な制約）。
+ */
+public class FoodConsumeListener implements Listener {
+
+    private final ConfigManager configManager;
+    private final FoodBuffManager foodBuffManager;
+
+    public FoodConsumeListener(ConfigManager configManager, FoodBuffManager foodBuffManager) {
+        this.configManager = configManager;
+        this.foodBuffManager = foodBuffManager;
+    }
+
+    @EventHandler
+    public void onPlayerItemConsume(PlayerItemConsumeEvent event) {
+        if (!configManager.isFoodBuffEnabled()) {
+            return;
+        }
+        if (event.getItem() == null) {
+            return;
+        }
+
+        Material material = event.getItem().getType();
+        FoodCategory category = FoodCategory.fromMaterial(material);
+        if (category == null) {
+            // バフ対象外の食材
+            return;
+        }
+
+        Player player = event.getPlayer();
+        foodBuffManager.applyBuff(player, category);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3448,3 +3448,36 @@ guide_book_settings:
   
   # ガイドブック配布時のメッセージ
   give_message: "&a【職業ガイド】&f%job%のガイドブックを受け取りました！"
+
+# ===================================
+# 食事による職業経験値ブーストバフ設定
+# ===================================
+# 食材を食べると、一定時間その職業の経験値が上がりやすくなる。
+# カテゴリ（パン/野菜/魚/肉）ごとに効果量・持続時間を設定でき、
+# 高価な食材ほど強く・長いバフにすることで「高い食材を買う動機」を作る。
+# 重複時は一番強いバフが有効（弱い食材を食べても下がらない・延長されない）。
+food_buff:
+  # 機能の有効化（false で従来通りバフ無し）
+  enabled: true
+
+  # カテゴリ別のバフ設定
+  #   bonus_percent: 経験値の上昇割合(%)
+  #   duration_seconds: バフ持続時間(秒)
+  categories:
+    bread:
+      bonus_percent: 10
+      duration_seconds: 180
+    vegetable:
+      bonus_percent: 15
+      duration_seconds: 240
+    fish:
+      bonus_percent: 25
+      duration_seconds: 360
+    meat:
+      bonus_percent: 30
+      duration_seconds: 480
+
+  # メッセージ設定（%category%=カテゴリ名, %percent%=上昇割合, %duration%=秒）
+  messages:
+    buff_applied: "&a食事の効果！ &e%category% &aで職業経験値 &e+%percent%%% &a（%duration%秒）"
+    buff_replaced: "&aより強い食事効果に切り替わりました：&e%category% +%percent%%%"

--- a/src/test/java/org/tofu/tofunomics/food/FoodBuffManagerTest.java
+++ b/src/test/java/org/tofu/tofunomics/food/FoodBuffManagerTest.java
@@ -1,0 +1,107 @@
+package org.tofu.tofunomics.food;
+
+import org.bukkit.entity.Player;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.tofu.tofunomics.config.ConfigManager;
+
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * FoodBuffManager のバフ付与・倍率算出・上書きルールのテスト
+ */
+public class FoodBuffManagerTest {
+
+    @Mock
+    private ConfigManager configManager;
+
+    @Mock
+    private Player player;
+
+    private FoodBuffManager foodBuffManager;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(player.getUniqueId()).thenReturn(UUID.randomUUID());
+        when(configManager.isFoodBuffEnabled()).thenReturn(true);
+        when(configManager.getFoodBuffAppliedMessage()).thenReturn("applied");
+        when(configManager.getFoodBuffReplacedMessage()).thenReturn("replaced");
+
+        // パン +10% / 180秒, 肉 +30% / 480秒
+        when(configManager.getFoodBuffBonusPercent("bread")).thenReturn(10);
+        when(configManager.getFoodBuffDurationSeconds("bread")).thenReturn(180);
+        when(configManager.getFoodBuffBonusPercent("meat")).thenReturn(30);
+        when(configManager.getFoodBuffDurationSeconds("meat")).thenReturn(480);
+
+        foodBuffManager = new FoodBuffManager(configManager);
+    }
+
+    @Test
+    public void noBuffReturnsBaseMultiplier() {
+        assertEquals(1.0, foodBuffManager.getMultiplier(player), 0.0001);
+    }
+
+    @Test
+    public void eatingBreadGivesTenPercentBuff() {
+        foodBuffManager.applyBuff(player, FoodCategory.BREAD);
+        assertEquals(1.10, foodBuffManager.getMultiplier(player), 0.0001);
+    }
+
+    @Test
+    public void strongerBuffOverwritesWeaker() {
+        foodBuffManager.applyBuff(player, FoodCategory.BREAD); // +10%
+        foodBuffManager.applyBuff(player, FoodCategory.MEAT);  // +30%（上書き）
+        assertEquals(1.30, foodBuffManager.getMultiplier(player), 0.0001);
+    }
+
+    @Test
+    public void weakerBuffDoesNotReplaceStronger() {
+        foodBuffManager.applyBuff(player, FoodCategory.MEAT);  // +30%
+        foodBuffManager.applyBuff(player, FoodCategory.BREAD); // +10%（無視されるべき）
+        assertEquals(1.30, foodBuffManager.getMultiplier(player), 0.0001);
+    }
+
+    @Test
+    public void disabledConfigDoesNotApplyBuff() {
+        when(configManager.isFoodBuffEnabled()).thenReturn(false);
+        foodBuffManager.applyBuff(player, FoodCategory.MEAT);
+        assertEquals(1.0, foodBuffManager.getMultiplier(player), 0.0001);
+    }
+
+    @Test
+    public void zeroBonusDoesNotApplyBuff() {
+        when(configManager.getFoodBuffBonusPercent("bread")).thenReturn(0);
+        foodBuffManager.applyBuff(player, FoodCategory.BREAD);
+        assertEquals(1.0, foodBuffManager.getMultiplier(player), 0.0001);
+    }
+
+    @Test
+    public void clearRemovesBuff() {
+        foodBuffManager.applyBuff(player, FoodCategory.MEAT);
+        foodBuffManager.clear(player.getUniqueId());
+        assertEquals(1.0, foodBuffManager.getMultiplier(player), 0.0001);
+    }
+
+    @Test
+    public void expiredBuffReturnsBaseMultiplier() {
+        // 持続0秒（=即失効扱い）の設定では applyBuff が付与しないが、
+        // ここでは1秒設定で付与→経過で失効することを確認する
+        when(configManager.getFoodBuffDurationSeconds("bread")).thenReturn(1);
+        foodBuffManager.applyBuff(player, FoodCategory.BREAD);
+        assertEquals(1.10, foodBuffManager.getMultiplier(player), 0.0001);
+
+        // 1秒強待機して失効を確認（遅延失効）
+        try {
+            Thread.sleep(1100);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        assertEquals(1.0, foodBuffManager.getMultiplier(player), 0.0001);
+    }
+}

--- a/src/test/java/org/tofu/tofunomics/food/FoodCategoryTest.java
+++ b/src/test/java/org/tofu/tofunomics/food/FoodCategoryTest.java
@@ -1,0 +1,59 @@
+package org.tofu.tofunomics.food;
+
+import org.bukkit.Material;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * FoodCategory の Material -> カテゴリ対応のテスト
+ */
+public class FoodCategoryTest {
+
+    @Test
+    public void breadMaterialsMapToBread() {
+        assertEquals(FoodCategory.BREAD, FoodCategory.fromMaterial(Material.BREAD));
+        assertEquals(FoodCategory.BREAD, FoodCategory.fromMaterial(Material.COOKIE));
+        assertEquals(FoodCategory.BREAD, FoodCategory.fromMaterial(Material.CAKE));
+    }
+
+    @Test
+    public void vegetableMaterialsMapToVegetable() {
+        assertEquals(FoodCategory.VEGETABLE, FoodCategory.fromMaterial(Material.CARROT));
+        assertEquals(FoodCategory.VEGETABLE, FoodCategory.fromMaterial(Material.APPLE));
+        assertEquals(FoodCategory.VEGETABLE, FoodCategory.fromMaterial(Material.GOLDEN_CARROT));
+    }
+
+    @Test
+    public void fishMaterialsMapToFish() {
+        assertEquals(FoodCategory.FISH, FoodCategory.fromMaterial(Material.COD));
+        assertEquals(FoodCategory.FISH, FoodCategory.fromMaterial(Material.COOKED_SALMON));
+        assertEquals(FoodCategory.FISH, FoodCategory.fromMaterial(Material.DRIED_KELP));
+    }
+
+    @Test
+    public void meatMaterialsMapToMeat() {
+        assertEquals(FoodCategory.MEAT, FoodCategory.fromMaterial(Material.COOKED_BEEF));
+        assertEquals(FoodCategory.MEAT, FoodCategory.fromMaterial(Material.COOKED_CHICKEN));
+        assertEquals(FoodCategory.MEAT, FoodCategory.fromMaterial(Material.RABBIT_STEW));
+    }
+
+    @Test
+    public void specialAndNonFoodMaterialsReturnNull() {
+        // 特殊食料はバフ対象外
+        assertNull(FoodCategory.fromMaterial(Material.GOLDEN_APPLE));
+        assertNull(FoodCategory.fromMaterial(Material.ENCHANTED_GOLDEN_APPLE));
+        assertNull(FoodCategory.fromMaterial(Material.MILK_BUCKET));
+        // 非食材
+        assertNull(FoodCategory.fromMaterial(Material.STONE));
+        assertNull(FoodCategory.fromMaterial(null));
+    }
+
+    @Test
+    public void configKeysAreStable() {
+        assertEquals("bread", FoodCategory.BREAD.getConfigKey());
+        assertEquals("vegetable", FoodCategory.VEGETABLE.getConfigKey());
+        assertEquals("fish", FoodCategory.FISH.getConfigKey());
+        assertEquals("meat", FoodCategory.MEAT.getConfigKey());
+    }
+}


### PR DESCRIPTION
## 背景・目的

現状、NPCから購入できる食材は「食べてもゲーム的なメリットがない」ため、一番コスパの良い**パンしか買われない**状況が発生していた。高価な肉・魚を買う動機が存在しなかった。

本PRでは「**食材を食べると一定時間その職業の経験値が上がりやすくなる**」付加価値を追加し、高価な食材ほど強く・長いバフにすることで価格差に見合う価値を持たせ、「高い食材を買う動機」を作る。

## 仕様

- **発動方式**: カテゴリ別・価格比例
  - パン → +10% / 3分
  - 野菜 → +15% / 4分
  - 魚 → +25% / 6分
  - 肉 → +30% / 8分
- **対象職業**: 経験値を獲得した職業（＝現在の作業職業）にのみ倍率を適用
- **重複挙動**: 上書き（一番強いものが有効。弱い食材を食べても下がらない・延長されない）
- 職業と食材の対応関係は持たせない（どの職業でも食べた食材カテゴリに応じてバフが乗る）

## 変更内容

**新規**
- `food/FoodCategory.java` — Material→カテゴリ対応（仕様としてハードコード）
- `food/FoodBuffManager.java` — バフ保持・上書きルール・遅延失効
- `food/FoodConsumeListener.java` — `PlayerItemConsumeEvent` で食事を検知

**改修**
- `JobExperienceManager.java` — `applyJobMultiplier` とMob討伐経験値経路（`giveExperienceManual`）の両方にバフ倍率を乗算
- `TofuNomics.java` — `FoodBuffManager` の生成・注入・リスナー登録
- `ConfigManager.java` — `food_buff` 設定の getter 群
- `config.yml` — `food_buff` セクションを**新規追記のみ**（既存設定・NPC座標等には一切変更なし）

## 影響範囲 / 非対象

- 食材NPCの販売ロジック（価格・在庫・購入上限）は変更なし
- バフ無効時（`food_buff.enabled: false`）・バフ無し時は倍率 `1.0` で従来と完全に同一挙動

## テスト

- `FoodCategoryTest` / `FoodBuffManagerTest` 計14件追加（カテゴリ対応・上書きルール・失効判定）
- `mvn clean compile` BUILD SUCCESS、テスト全件パス

## デプロイ時の注意

config.yml は `food_buff` の新規追記のみ。サーバー反映時はローカルで上書きせず、`food_buff` セクションのみを安全手順で追加すること（NPC座標等のサーバー固有設定を保護）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)