### PR TITLE
feat: minerの売却に原石・石材を追加

### DIFF
--- a/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
@@ -610,11 +610,13 @@ public class TradingGUI implements Listener {
     
     // カテゴリ判定メソッド群
     private boolean isMiningItem(String materialName) {
-        return materialName.contains("ore") || materialName.contains("ingot") || 
-               materialName.contains("coal") || materialName.contains("diamond") || 
+        return materialName.contains("ore") || materialName.contains("ingot") ||
+               materialName.contains("coal") || materialName.contains("diamond") ||
                materialName.contains("emerald") || materialName.contains("redstone") ||
                materialName.contains("lapis") || materialName.contains("quartz") ||
-               materialName.contains("stone") || materialName.contains("cobblestone");
+               materialName.contains("stone") || materialName.contains("cobblestone") ||
+               materialName.contains("andesite") || materialName.contains("diorite") ||
+               materialName.contains("granite") || materialName.startsWith("raw_");
     }
     
     private boolean isFarmingItem(String materialName) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1798,6 +1798,10 @@ npc_system:
     raw_copper: 1.5
     quartz: 2
     amethyst_shard: 4
+    # 素手採掘でドロップする石材（序盤の収入源）
+    andesite: 0.3
+    diorite: 0.3
+    granite: 0.3
     # --- woodcutter: 板材・剥いだ原木・苗木・竹 ---
     jungle_planks: 0.12
     acacia_planks: 0.12


### PR DESCRIPTION
## 背景・目的

minerの売却まわりの2つの課題を解消する。

1. **鉱石ブロックと実ドロップの不一致**: 売却欄には `iron_ore` 等の鉱石ブロックが並ぶが、通常採掘で実際にドロップするのは「鉄の原石(raw_iron)」。掘ったものをそのまま売れるようにする。
2. **序盤の収入源が鉱石のみで厳しい**: 安山岩(andesite)など素手採掘で大量に出る石材を売却対象に加え、序盤の安定収入源にする。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `config.yml` | `item_prices` に `andesite`/`diorite`/`granite`（各0.3）を追加 |
| `TradingGUI.java` | `isMiningItem()` に `andesite`/`diorite`/`granite`/`raw_*` を追加し、原石・新規石材が MINING タブに並ぶよう改善 |

- `iron_ore` 等の鉱石ブロックはシルクタッチ採掘用に残置
- `raw_iron`/`raw_gold`/`raw_copper`・`stone`/`cobblestone` は既存のため変更なし（重複定義禁止ルール準拠）

## ⚠️ マージ後の手動対応（サーバー側）

売却NPCの品目はサーバー config の `trading_posts[].items` リストで決まる。miner 取引所が `items` を明示列挙している場合、新規アイテム（andesite/diorite/granite/raw_*）を `items` に追記しないと売却欄に出ない。`scripts/download_config.sh` → 編集 → `upload_config.sh` で反映する（`items` 未指定＝全アイテム対応なら不要）。

## 検証

- [x] `mvn clean package` 成功
- [ ] デプロイ後、miner 取引NPCの MINING タブに鉄の原石・安山岩等が表示され、想定価格で買い取られること

🤖 Generated with [Claude Code](https://claude.com/claude-code)