### PR TITLE
feat: 管理者向け職業完全リセットコマンドを追加

### DIFF
--- a/src/main/java/org/tofu/tofunomics/commands/JobsCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/JobsCommand.java
@@ -350,14 +350,17 @@ public class JobsCommand implements CommandExecutor {
         if (args.length < 2) {
             sender.sendMessage(ChatColor.RED + "使用法: /jobs admin <サブコマンド>");
             sender.sendMessage(ChatColor.YELLOW + "  forceleave <player> <jobName> - プレイヤーを強制的に辞職させる");
+            sender.sendMessage(ChatColor.YELLOW + "  reset - 自分の全職業データを完全リセット（テスト用）");
             return true;
         }
-        
+
         String subCommand = args[1].toLowerCase();
-        
+
         switch (subCommand) {
             case "forceleave":
                 return handleJobAdminForceLeave(sender, args);
+            case "reset":
+                return handleJobAdminReset(sender);
             default:
                 sender.sendMessage(ChatColor.RED + "不明なサブコマンド: " + subCommand);
                 return true;
@@ -406,10 +409,31 @@ public class JobsCommand implements CommandExecutor {
                 sender.sendMessage(ChatColor.RED + "職業の強制辞職に失敗しました。");
                 break;
         }
-        
+
         return true;
     }
-    
+
+    /**
+     * 管理者による自分の全職業リセットコマンド（テストプレイ用）。
+     * 実行者自身の player_jobs / job_history / job_changes をすべて削除し初期状態に戻す。
+     */
+    private boolean handleJobAdminReset(CommandSender sender) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "このコマンドはプレイヤーのみ実行できます。");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (jobManager.resetAllJobs(player)) {
+            player.sendMessage(ChatColor.GREEN + "全職業データをリセットしました（レベル・経験値・履歴をすべて初期化）。");
+        } else {
+            player.sendMessage(ChatColor.RED + "職業データのリセットに失敗しました。サーバーログを確認してください。");
+        }
+
+        return true;
+    }
+
     private void sendHelpMessage(Player player) {
         player.sendMessage(ChatColor.GOLD + "=== Jobs コマンドヘルプ ===");
         player.sendMessage(ChatColor.YELLOW + "/jobs list " + ChatColor.WHITE + "- 利用可能な職業一覧を表示");

--- a/src/main/java/org/tofu/tofunomics/jobs/JobManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobManager.java
@@ -12,7 +12,9 @@ import org.tofu.tofunomics.models.Job;
 import org.tofu.tofunomics.models.PlayerJob;
 import org.tofu.tofunomics.TofuNomics;
 
+import java.sql.SQLException;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Logger;
 
 public class JobManager {
@@ -218,13 +220,16 @@ public class JobManager {
      * @return すべての削除に成功した場合true
      */
     public boolean resetAllJobs(Player player) {
-        java.util.UUID uuid = player.getUniqueId();
+        UUID uuid = player.getUniqueId();
         String uuidString = uuid.toString();
         boolean success = true;
 
+        // player_jobsの削除が失敗してもjob_historyの削除は試みる。
+        // 万一player_jobsだけ削除できた場合は履歴が残る不整合が生じうるが、
+        // テスト用途であり、再実行すれば解消できるため許容する。
         try {
             playerJobDAO.deleteAllPlayerJobs(uuid);
-        } catch (java.sql.SQLException e) {
+        } catch (SQLException e) {
             TofuNomics.getInstance().getLogger().warning("職業データの削除に失敗しました: " + uuidString + " - " + e.getMessage());
             success = false;
         }
@@ -237,6 +242,11 @@ public class JobManager {
         // 日次変更制限の記録を削除（本日変更していなければ記録自体が存在せずfalseが返るが、
         // それは正常な状態なので成否判定には含めない）
         jobChangeDAO.deleteJobChange(uuidString);
+
+        if (success) {
+            TofuNomics.getInstance().getLogger().info(
+                "管理者コマンドにより職業データをリセットしました: " + player.getName() + " (" + uuidString + ")");
+        }
 
         return success;
     }

--- a/src/main/java/org/tofu/tofunomics/jobs/JobManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobManager.java
@@ -208,6 +208,38 @@ public class JobManager {
     public List<PlayerJob> getPlayerJobs(Player player) {
         return playerJobDAO.getPlayerJobsByUUID(player.getUniqueId().toString());
     }
+
+    /**
+     * プレイヤーの全職業データを完全にリセットする（管理者テストプレイ用）。
+     * player_jobs（現在の職業・レベル・経験値）、job_history（過去の最高レベル履歴）、
+     * job_changes（日次変更制限記録）をすべて削除し、初期状態（無職・履歴なし）に戻す。
+     * forceLeaveJob()は履歴を保存し日次制限にも引っかかるため、完全初期化には使用しない。
+     *
+     * @return すべての削除に成功した場合true
+     */
+    public boolean resetAllJobs(Player player) {
+        java.util.UUID uuid = player.getUniqueId();
+        String uuidString = uuid.toString();
+        boolean success = true;
+
+        try {
+            playerJobDAO.deleteAllPlayerJobs(uuid);
+        } catch (java.sql.SQLException e) {
+            TofuNomics.getInstance().getLogger().warning("職業データの削除に失敗しました: " + uuidString + " - " + e.getMessage());
+            success = false;
+        }
+
+        if (!jobHistoryDAO.deleteAllHistoriesByUUID(uuidString)) {
+            TofuNomics.getInstance().getLogger().warning("職業履歴の削除に失敗しました: " + uuidString);
+            success = false;
+        }
+
+        // 日次変更制限の記録を削除（本日変更していなければ記録自体が存在せずfalseが返るが、
+        // それは正常な状態なので成否判定には含めない）
+        jobChangeDAO.deleteJobChange(uuidString);
+
+        return success;
+    }
     
     public PlayerJob getPlayerJob(Player player, String jobName) {
         Job job = jobDAO.getJobByNameSafe(jobName);


### PR DESCRIPTION
## 概要
管理者によるテストプレイ用に、職業データを初期状態に戻す `/jobs admin reset` コマンドを追加しました。

## 背景
これまで職業を戻す手段は `/jobs leave`（レベル50以上のみ）と `/jobs admin forceleave <player> <jobName>`（1職業ずつ・履歴は残る）しかなく、テストのたびに完全な初期状態へ戻せませんでした。

## 変更内容
- `JobManager#resetAllJobs(Player)` を追加
  - `player_jobs`（現在の職業・レベル・経験値）
  - `job_history`（過去の最高レベル履歴）
  - `job_changes`（日次変更制限記録）
  - を一括削除し、再就職でレベル1から始まる完全初期状態に戻す
  - `forceLeaveJob()` は履歴保存・日次制限の影響があるため流用せず、既存DAOメソッドを直接利用
- `JobsCommand` に `reset` サブコマンドとハンドラを追加（実行者自身が対象、引数なし）
- 権限は既存の `tofunomics.jobs.admin`（default: op）を流用。plugin.yml 変更なし

## 仕様
- コマンド: `/jobs admin reset`
- 対象: コマンド実行者自身のみ
- 範囲: 全職業を完全初期化

## テスト
- `mvn clean package` ビルド成功
- 職業関連DAOテスト 54件すべてpass（JobChangeDAO / JobHistoryDAO / PlayerJobDAO）

## 動作確認（要ゲーム内検証）
- [ ] 複数職業に就いてレベルを上げた後 `/jobs admin reset` → 成功メッセージ
- [ ] `/jobs stats` で無職になっていること
- [ ] 再就職でレベル1・経験値0から始まること（履歴復元なし）
- [ ] 同日に再変更しても日次制限に引っかからないこと
- [ ] 権限のないプレイヤーは権限エラーになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)