### PR TITLE
fix: 食べ物の職業経験値バフをTofuNomicsワールドに限定

### DIFF
--- a/src/main/java/org/tofu/tofunomics/food/FoodConsumeListener.java
+++ b/src/main/java/org/tofu/tofunomics/food/FoodConsumeListener.java
@@ -28,6 +28,10 @@ public class FoodConsumeListener implements Listener {
         if (!configManager.isFoodBuffEnabled()) {
             return;
         }
+        // 経済機能が有効なワールド以外ではバフを付与しない
+        if (!configManager.isEconomyEnabledInWorld(event.getPlayer().getWorld().getName())) {
+            return;
+        }
         if (event.getItem() == null) {
             return;
         }


### PR DESCRIPTION
## 概要
食材を食べた際の職業経験値ブーストバフ（`food_buff`）が、本来 TofuNomics の経済機能が有効なワールドでのみ動作すべきところ、**全ワールドで動作してしまっていた**問題を修正します。

## 原因
`FoodConsumeListener.onPlayerItemConsume()` にワールド制限チェックが無く、どのワールドで食材を食べてもバフが付与されていました。プラグイン内の他リスナー（NPCListener, PayCommand など）は `ConfigManager.isEconomyEnabledInWorld()` でワールドを判定していますが、食べ物バフ付与処理だけこのガードを通っていませんでした。

## 修正内容
`FoodConsumeListener` に既存の `isEconomyEnabledInWorld()` ガードを追加し、経済機能が有効なワールド（`economy.enabled_worlds`）以外では食材を食べてもバフが付与されないようにしました。

- 入口（バフ付与時）で止めるため最もシンプルかつ確実
- 既存パターンを踏襲、新規メソッド・config項目の追加なし
- `economy.enabled_worlds` が空の場合は全ワールドで有効（後方互換）

## 検証
- [x] `mvn clean package` でビルド成功
- [ ] tofuNomics ワールドで食材を食べ → バフ発動を確認
- [ ] それ以外のワールドで食材を食べ → バフが付かないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)