### PR TITLE
fix: 採掘NPC売却GUIの価格0表示・売却拒否を修正

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1799,9 +1799,9 @@ npc_system:
     quartz: 2
     amethyst_shard: 4
     # 素手採掘でドロップする石材（序盤の収入源）
-    andesite: 0.3
-    diorite: 0.3
-    granite: 0.3
+    andesite: 1
+    diorite: 1
+    granite: 1
     # --- woodcutter: 板材・剥いだ原木・苗木・竹 ---
     jungle_planks: 0.12
     acacia_planks: 0.12
@@ -1898,18 +1898,18 @@ npc_system:
     glowstone: 4
     sea_lantern: 6
     # --- architect: 建材 ---
-    stone: 0.3
-    cobblestone: 0.1
+    stone: 1
+    cobblestone: 1
     smooth_stone_slab: 0.5
     chiseled_stone_bricks: 1.2
     cracked_stone_bricks: 0.9
     mossy_stone_bricks: 1.2
-    deepslate: 0.3
-    cobbled_deepslate: 0.2
+    deepslate: 1
+    cobbled_deepslate: 1
     polished_deepslate: 0.5
     deepslate_bricks: 0.8
     deepslate_tiles: 0.8
-    tuff: 0.2
+    tuff: 1
     calcite: 0.5
     dripstone_block: 0.5
     sandstone: 0.5


### PR DESCRIPTION
## 概要

採掘NPCの売却GUIで一部アイテム（石・丸石など）が「基本価格: 0」と表示される不具合を修正します。

## 根本原因

TofuNomicsの通貨は金塊（整数）ベースで、以下の処理が `Math.round()` で四捨五入します。

- 表示: `CurrencyConverter.formatCurrency()`（CurrencyConverter.java:39）
- 売却実行: `CurrencyConverter.convertBalanceToNuggets()`（CurrencyConverter.java:116-122）

そのため基本価格が **0.5未満のアイテム** は次の問題が発生していました。

1. GUIで「基本価格: 0」と表示される
2. 1個ずつ売却すると0金塊になり `TradingNPCManager.java:710-712` で「売却額が少なすぎます」と**売却拒否**される（複数個まとめると累積で売却可能）

## 修正内容

採掘で取れる0.5未満の石系ブロック8項目の `item_prices` を `1` に引き上げ、表示・売却の両方を解消します。

| アイテム | 変更前 | 変更後 |
|---|---|---|
| stone | 0.3 | 1 |
| cobblestone | 0.1 | 1 |
| andesite | 0.3 | 1 |
| diorite | 0.3 | 1 |
| granite | 0.3 | 1 |
| deepslate | 0.3 | 1 |
| cobbled_deepslate | 0.2 | 1 |
| tuff | 0.2 | 1 |

丸めロジック自体は整数通貨の仕様として意図通りのため、価格側を調整しました。

## ⚠️ サーバー反映について

本リポジトリの方針上、jar同梱のconfig.ymlは既存サーバーのconfig.ymlを上書きしません（NPC座標等の保護）。**稼働中サーバーへの反映には、サーバー上の `item_prices` 該当8行の手動編集 + `/tofunomics reload` が別途必要**です。

## 検証

- [x] `yaml.safe_load` でYAML構文チェック済み
- [ ] サーバー反映後、採掘NPC GUIで stone 等が「基本価格: 1」表示になることを確認
- [ ] stone を1個だけ売却して拒否されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)