### PR TITLE
feat: 職業NPCの購入も職業一致を必須にする

### DIFF
--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -2060,14 +2060,6 @@ public class ConfigManager {
     }
 
     /**
-     * 別職業での購入時の価格倍率を取得
-     * @return 価格倍率（デフォルト: 1.5 = 50%増）
-     */
-    public double getCrossJobPurchaseMultiplier() {
-        return config.getDouble("npc_system.trading_npcs.cross_job_purchase_multiplier", 1.5);
-    }
-    
-    /**
      * 取引所の設定一覧を取得
      */
     public List<Map<?, ?>> getTradingPostConfigs() {

--- a/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
@@ -163,12 +163,12 @@ public class TradingNPCManager {
         }
 
         /**
-         * 購入時の職業チェック（全職業許可）
+         * 購入時の職業チェック（売却と同様に職業一致が必須）
          * @param jobType プレイヤーの職業
-         * @return 常にtrue（購入は職業問わず可能）
+         * @return 購入可能な場合true
          */
         public boolean acceptsJobForPurchase(String jobType) {
-            return true; // 購入は全職業許可
+            return acceptsJob(jobType);
         }
 
         /**

--- a/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
@@ -176,24 +176,13 @@ public class TradingGUI implements Listener {
         try {
             String playerJob = jobManager.getPlayerJob(player.getUniqueId());
 
-            // 職業チェック（購入と売却で異なる制限）
+            // 職業チェック（購入・売却ともに職業一致が必須）
             boolean isMatchingJob = tradingPost.isMatchingJob(playerJob);
 
             if (!isMatchingJob) {
-                // 別職業または無職の場合、売却モードのみ制限
-                if (initialMode == TradingMode.SELL) {
-                    String acceptedJobsStr = String.join("、", tradingPost.getAcceptedJobTypes());
-
-                    player.sendMessage("§c売却はこの取引所の対応職業のみ可能です");
-                    if (playerJob == null) {
-                        player.sendMessage("§e対応職業: §f" + acceptedJobsStr);
-                        player.sendMessage("§7コマンド: §f/jobs join <職業名>");
-                    } else {
-                        player.sendMessage("§eお客様の職業: §f" + playerJob + "§e、対応職業: §f" + acceptedJobsStr);
-                    }
-                    return;
-                }
-                // 購入モードの場合は職業に関係なく続行（割増価格適用）
+                // 別職業または無職の場合、購入・売却ともに制限
+                sendJobMismatchMessage(player, tradingPost, playerJob, initialMode);
+                return;
             }
 
             String title = "§6" + tradingPost.getName() + " - アイテム取引";
@@ -223,7 +212,28 @@ public class TradingGUI implements Listener {
             player.sendMessage("§c管理者にお知らせください。詳細はサーバーログを確認してください。");
         }
     }
-    
+
+    /**
+     * 職業不一致時のエラーメッセージを送信する（購入・売却共通）
+     * @param player プレイヤー
+     * @param tradingPost 取引所
+     * @param playerJob プレイヤーの職業（無職の場合null）
+     * @param mode 操作モード（メッセージの文言切り替えに使用）
+     */
+    private void sendJobMismatchMessage(Player player, TradingNPCManager.TradingPost tradingPost,
+                                        String playerJob, TradingMode mode) {
+        String acceptedJobsStr = String.join("、", tradingPost.getAcceptedJobTypes());
+        String action = (mode == TradingMode.BUY) ? "購入" : "売却";
+
+        player.sendMessage("§c" + action + "はこの取引所の対応職業のみ可能です");
+        if (playerJob == null) {
+            player.sendMessage("§e対応職業: §f" + acceptedJobsStr);
+            player.sendMessage("§7コマンド: §f/jobs join <職業名>");
+        } else {
+            player.sendMessage("§eお客様の職業: §f" + playerJob + "§e、対応職業: §f" + acceptedJobsStr);
+        }
+    }
+
     private void setupTradingGUIItems(Inventory gui, Player player, TradingNPCManager.TradingPost tradingPost, TradingGUISession session) {
         gui.clear();
         
@@ -260,14 +270,8 @@ public class TradingGUI implements Listener {
             
             ItemStack displayItem;
             if (session.getTradingMode() == TradingMode.BUY) {
-                // 購入モード
-                // 別職業の場合は価格を割増
-                double purchasePrice = price;
-                boolean isCrossJob = !tradingPost.isMatchingJob(playerJob);
-                if (isCrossJob) {
-                    purchasePrice *= configManager.getCrossJobPurchaseMultiplier();
-                }
-                displayItem = createPurchaseItem(material, purchasePrice, playerJob, isCrossJob);
+                // 購入モード（対応職業のみ購入可能なため割増は適用しない）
+                displayItem = createPurchaseItem(material, price);
             } else {
                 // 売却モード
                 // 職業ボーナスは職業専用取引所でのみ適用（総合取引所では素の価格）
@@ -419,7 +423,7 @@ public class TradingGUI implements Listener {
         return item;
     }
     
-    private ItemStack createPurchaseItem(Material material, double price, String playerJob, boolean isCrossJob) {
+    private ItemStack createPurchaseItem(Material material, double price) {
         ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
 
@@ -428,9 +432,6 @@ public class TradingGUI implements Listener {
 
             List<String> lore = new ArrayList<>();
             lore.add("§f購入価格: §e" + currencyConverter.formatCurrency(price));
-            if (isCrossJob) {
-                lore.add("§e※別職業のため" + String.format("%.1f", configManager.getCrossJobPurchaseMultiplier()) + "倍価格");
-            }
             lore.add("");
             lore.add("§e左クリック: §f1個購入");
             lore.add("§e右クリック: §f16個購入");
@@ -716,6 +717,15 @@ public class TradingGUI implements Listener {
         
         // モード切り替えボタン処理 (スロット0)
         if (slot == 0) {
+            // 別職業・無職は購入・売却ともに不可のため、モード切替自体をブロック
+            String playerJob = jobManager.getPlayerJob(player.getUniqueId());
+            if (!tradingPost.isMatchingJob(playerJob)) {
+                TradingMode targetMode = (session.getTradingMode() == TradingMode.SELL)
+                    ? TradingMode.BUY : TradingMode.SELL;
+                sendJobMismatchMessage(player, tradingPost, playerJob, targetMode);
+                return;
+            }
+
             // モード切り替え
             if (session.getTradingMode() == TradingMode.SELL) {
                 session.setTradingMode(TradingMode.BUY);
@@ -950,21 +960,20 @@ public class TradingGUI implements Listener {
                 return;
         }
 
+        // プレイヤーの職業を取得
+        String playerJob = jobManager.getPlayerJob(player.getUniqueId());
+
+        // 職業一致チェック（購入も売却同様に対応職業のみ可能）
+        if (!tradingPost.acceptsJobForPurchase(playerJob)) {
+            sendJobMismatchMessage(player, tradingPost, playerJob, TradingMode.BUY);
+            return;
+        }
+
         // 購入価格を取得（緊急モードの価格倍率を適用）
         double unitPrice = tradingPost.getEffectivePurchasePrice(material);
         if (unitPrice <= 0) {
             player.sendMessage("§cこのアイテムは購入できません");
             return;
-        }
-
-        // プレイヤーの職業を取得
-        String playerJob = jobManager.getPlayerJob(player.getUniqueId());
-
-        // 別職業の場合は価格を割増
-        boolean isCrossJob = !tradingPost.isMatchingJob(playerJob);
-        if (isCrossJob) {
-            double multiplier = configManager.getCrossJobPurchaseMultiplier();
-            unitPrice *= multiplier;
         }
 
         // 合計金額を計算
@@ -1006,9 +1015,6 @@ public class TradingGUI implements Listener {
         // メッセージ
         String message = "§a" + material.name() + " を " + purchaseAmount + "個購入しました（" +
                           currencyConverter.formatCurrency(totalPrice) + "）";
-        if (isCrossJob) {
-            message += " §e※別職業のため" + String.format("%.1f", configManager.getCrossJobPurchaseMultiplier()) + "倍価格";
-        }
         player.sendMessage(message);
     }
     


### PR DESCRIPTION
## 概要
職業NPC（取引所）での**購入**を、**売却**と同様にプレイヤーの職業とNPCの対応職業が一致しないとできないように変更します。

## 背景・課題
- これまで売却のみ職業一致が必須で、購入は別職業でも価格1.5倍（`cross_job_purchase_multiplier`）で可能だった
- 要望: 購入も売却同様、職業が一致しないとできないようにしたい

## 変更内容
- `TradingPost.acceptsJobForPurchase()` を常にtrueから、売却と同じ職業チェックに変更
- 購入の各入口（モード選択GUI → `openTradingGUIWithMode`、GUI内モード切替ボタン、`handleItemPurchase`）で職業不一致をブロック
- 職業不一致メッセージを `sendJobMismatchMessage()` に共通化（購入/売却で文言切替）
- 不要になった別職業向け割増価格ロジック（計算・lore表示・完了メッセージ）を削除

## 影響範囲
- **職業専用NPC**: 対応職業のみ購入・売却可能（別職業/無職はブロック）
- **総合取引所（all）**: 全員が購入・売却可能（従来どおり影響なし）

## 検証
- `mvn clean package` 成功
- 全テスト 193件 成功（Failures: 0, Errors: 0）

### 手動確認（デプロイ後にお願いします）
- [ ] 対応職業: 職業専用NPCで購入・売却ともに可能
- [ ] 別職業/無職: 購入・売却ともにブロックされエラーメッセージが出る（モード選択ボタン・GUI内モード切替の両方）
- [ ] 総合取引所: 全員が購入・売却可能
- [ ] 購入完了メッセージに「○倍価格」表記が出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)