### PR TITLE
feat: プレイヤー間マーケット機能（売り出品＋買い注文）

### DIFF
--- a/docs/market-buyorder-handoff.md
+++ b/docs/market-buyorder-handoff.md
@@ -1,0 +1,294 @@
+# マーケット「買い注文（募集）」機能 実装 引き継ぎ書
+
+> 別セッションで「募集（買い注文 / Buy Order）」機能を実装するための完全な引き継ぎ書。
+> 作成日: 2026-06-11 / 作成: Claude Opus 4.8 セッション
+> 前提: 売り出品マーケット（S1〜S4）は実装・デプロイ済み。本機能はその**対になる買い注文**を追加する。
+> 関連: `docs/market-implementation-handoff.md`（売りマーケットの正本）, `docs/config-reference.md`
+
+---
+
+## 0. まず最初に確認すること
+
+- **ブランチ**: `feature/player-market`（このまま続行）。`main` 直接コミット禁止、PR でマージ。
+- **売りマーケットは完成済み**。直近コミット（新しい順）:
+  - `5470065` feat: 一覧GUIにカテゴリフィルタ
+  - `4f4a881` fix: sold_notify の %item%/%currency% 未置換修正
+  - `6d1c452` fix: 購入を現金（手持ち金塊）払いに変更
+  - `03cc03f` S4(コマンド＋配線) / `c3f7491` S3(GUI＋タスク) / `99ac0c8` S2 / `7cc1093` S1
+- デプロイ済み（lobby-1.21）。リロードはユーザー手動。`tofu-mc-deploy --skip-build` でデプロイ。
+- シェルは fish。bash 専用構文は `bash -c '...'` で囲む。
+
+---
+
+## 1. 確定仕様（ユーザー合意済み・2026-06-11）
+
+「**出品アイテムの募集**」= 買い注文。あるプレイヤーが「このアイテムをこの値段で買いたい」と募集を出し、
+別プレイヤーが手持ちから供給して成立させる。売り出品の鏡像。
+
+| 項目 | 決定 |
+|---|---|
+| 代金拘束 | **募集時に前払い（エスクロー）**。募集を出した時点で募集者の**現金（金塊）から price 全額を回収**し拘束する。 |
+| 手数料 | **売りと同じ消却型 5%**（`market.fee_rate` を共用）。供給者受取 = `floor(price × 0.95)`、差額は通貨総量から消却。 |
+| 供給UI | **GUI 一覧からクリック供給**。募集一覧GUIで募集をクリックすると、手持ちから該当アイテムを供給して成立。 |
+| オフライン対応 | 募集者がオフラインでも供給成立可。**供給されたアイテムは注文レコードに保存**し、募集者が後で「自分の募集」GUIから回収する（売りの expired 回収と同方式）。 |
+| 対象アイテム | **Material + 個数のみ**で募集（特定NBT/エンチャントは対象外）。供給者は同 Material を合計個数ぶん供給。 |
+
+### ライフサイクル（status）
+- `open`: 募集中。price 全額をエスクロー済み（募集者の現金から回収済み）。
+- `fulfilled`: 供給成立。供給アイテムを `item_data` に保存、供給者へ `floor(price×0.95)` を bank 入金。募集者は未回収。
+- `reclaimed`: 募集者が供給アイテムを回収済み。
+- `cancelled`: 募集者が open をキャンセル → **エスクロー全額（price）を募集者へ返金**（手数料なし。fulfillment 前なので消却も無し）。
+- `expired`: 期限切れ → **エスクロー全額を募集者の bank へ自動返金**（オフライン安全）。
+
+### 通貨保存則（重要・実装時に必ず確認）
+- 募集時: 募集者の現金から `price` 回収（経済から退場＝拘束）。
+- 成立時: 供給者 bank += `floor(price×0.95)`。差額 `price − floor(price×0.95)` は**消却**（再生成しない）。
+- キャンセル/期限切れ: 募集者へ `price` 返金（再生成）。差し引きゼロ。
+- → fee は**成立時のみ**発生。キャンセル/期限切れは全額返金。
+
+---
+
+## 2. 既存資産（売りマーケット）— 買い注文はこれらを再利用・踏襲する
+
+### 2-1. MarketManager（`market/MarketManager.java`）
+- コンストラクタ（**現金払い対応済み**）:
+  `MarketManager(Connection, PlayerDAO, MarketListingDAO, ConfigManager, CurrencyConverter, Logger)`
+- 現金API（`CurrencyConverter`、`economy/CurrencyConverter.java`）:
+  - `payWithCash(Player, double)→boolean`（所持チェック＋金塊削除を原子的に。不足で false）
+  - `receiveCash(Player, double, boolean skipSpaceCheck)→boolean`（現金付与＝返金に使う）
+  - `canAffordWithCash(Player, double)→boolean`
+  - 金額→金塊枚数換算は内部で実施（`convertBalanceToNuggets` 等）。
+- bank 入金: `PlayerDAO.getOrCreatePlayer(UUID)` → `player.addBankBalance(double)` → `playerDAO.updatePlayer(player)`。**UUID直指定でオフライン可**。
+- トランザクション作法: `synchronized(connection)` ＋ `setAutoCommit(false)` ＋ 楽観ロック（条件付きUPDATEの影響行数==1判定）＋ commit/rollback、finally で `setAutoCommit(true)`。
+- アイテム付与ヘルパー `giveItem(Player, String itemData)`: deserialize → `addItem`、入りきらない分は足元 `dropItem`（喪失防止）。**買い注文の回収でも同じ方式**。
+
+### 2-2. シリアライズ（`market/MarketItemSerializer.java`）
+- `serialize(ItemStack)→String`（Base64、失敗時 null） / `deserialize(String)→ItemStack`（不正で null）。供給アイテムの保存に流用。
+
+### 2-3. DAO パターン（`dao/MarketListingDAO.java` を雛形に）
+- コンストラクタで `Connection` 受領。`PreparedStatement`。`RETURN_GENERATED_KEYS` で id 取得。
+- 楽観ロック更新の例: `markAsSold(id, buyerUuid, soldAtMillis)` / `updateStatusConditional(id, expected, new)`（影響行数==1で成功）。
+- 一覧取得: `getActiveListings()` / `getListingsBySeller(uuid)` / 期限切れ一括 `expireActiveListings(nowMillis)→int`。
+- expires_at は **epoch millis（INTEGER）**。期限判定は数値比較。
+
+### 2-4. DB テーブル追加方法（`database/DatabaseManager.java`）
+- `createTables()` 内 `tableCreationQueries`（または `tableSQLs`）配列末尾に CREATE 文を**インライン追加**。
+- インデックスは `performMigrations()` 末尾に `CREATE INDEX IF NOT EXISTS ...` を追加。
+- `CREATE TABLE IF NOT EXISTS` なのでマイグレーション不要。
+- 売りの `market_listings` 追加箇所（`idx_market_status/seller/expires`）を grep して直後に倣う。
+
+### 2-5. GUI パターン（`market/gui/` 一式）
+- `MarketGUIListener`（`implements Listener`）: `InventoryClickEvent`/`InventoryCloseEvent` を集約、`ConcurrentHashMap<UUID, MarketGUISession>` でセッション管理、`session.getType()` で各GUIへ振り分け。**買い注文GUIもこのListenerに統合する**（型を追加）。
+  - `registerSession(uuid, session)` / `setGUIs(...)`（循環依存をセッター注入で解決）/ `closeAll()`。
+- `MarketGUISession`: `type`（enum）, `inventory`, `page`, `category`(`MarketCategory`), `slotListings`(Map<Integer,MarketListing>)。**買い注文用に `slotBuyOrders` か、汎用化が必要**（下記4-3参照）。
+- `MarketGUIUtil`: `createButton(Material,name,lore)` / `formatPrice(double)` / `prettifyMaterial(String)`。共用。
+- `MarketCategory`: Material 分類（ALL/MINING/FARMING/LOGGING/FISHING/CRAFTING/MATERIALS/OTHER）。`classify(Material)` / `matches(Material)`。買い注文一覧のカテゴリ分けにも流用可。
+- `MarketBrowseGUI`: レイアウト参考（0-7 カテゴリボタン、9-44 アイテム36件/ページ、48 前/49 情報/50 次/53 閉じる）。
+
+### 2-6. コマンド（`commands/MarketCommand.java`）
+- `implements CommandExecutor, TabCompleter`。`/market`（一覧）/`sell <価格>`/`mylistings`/`cancel <id>`/`reclaim <id>`/`reload`/`help`。
+- 権限: `tofunomics.market.use`(true) / `.sell`(true) / `.admin`(op)。
+- メッセージ送信: `MarketMessages.format(configManager, MarketResult, item, price)`（未使用プレースホルダは無視される。`item/price/currency/min/max/limit/amount` を一括で渡す方式）。
+- **買い注文は同じ `/market` にサブコマンド追加**（下記4-5）。
+
+### 2-7. 配線（`TofuNomics.java`）
+- フィールド群（`marketListingDAO/marketManager/marketBrowseGUI/myListingsGUI/marketGUIListener/marketExpirationTask`）の直後に買い注文用フィールドを追加。
+- `initializeDAOs()`: `marketBuyOrderDAO = new MarketBuyOrderDAO(databaseManager.getConnection());` 追加。
+- `initializeMarketSystem()`: BuyOrder 用 GUI 生成・`marketGUIListener.setGUIs(...)` 拡張・定期タスクに買い注文期限切れも追加。
+- `registerEventListeners()`: Listener は marketGUIListener 1個で足りる（型で分岐するため）。
+- `registerCommands()`: MarketCommand のコンストラクタ引数に BuyOrder GUI を追加。
+- `onDisable()`: 既存の `marketExpirationTask.cancel()` / `marketGUIListener.closeAll()` に乗る。
+
+### 2-8. config / messages
+- `ConfigManager`（約4260行〜）: market getter は `config.getDouble/getInt/getBoolean("market.xxx", default)` の直書き。`getMarketMessage(key, Object...)` が `messages.market.key` を `%k%` ペア置換。
+- `src/main/resources/config.yml`: トップレベル `market:` と `messages.market:` に**ピンポイント追記**（全体上書き厳禁）。jar 同梱 config が本番へ不足キーのみ自動補完される。
+
+---
+
+## 3. config 追記（`src/main/resources/config.yml`）
+
+```yaml
+market:
+  # 既存（売り）に加えて
+  max_buy_orders_per_player: 10    # 募集の同時保有上限
+  # fee_rate / listing_duration_days / min_price / max_price / expire_check_interval は売りと共用
+```
+
+`messages.market` に追記（書式は既存に倣う。`&` カラーコード、`%player% %item% %amount% %price% %currency% %min% %max% %limit%`）:
+```yaml
+    # 募集（買い注文）
+    requested: "&a%item% x%amount% の募集を &e%price% %currency%&a で登録しました（前払い）。"
+    fulfilled: "&a募集に応じ %item% x%amount% を供給しました。&e%amount_proceeds% %currency%&a を受け取りました。"
+    fulfilled_notify: "&aあなたの募集（%item% x%amount%）が成立しました。アイテムは /market myrequests から回収できます。"
+    request_cancelled: "&a募集をキャンセルし、前払い分を返金しました。"
+    request_reclaimed: "&a成立した募集からアイテムを回収しました。"
+    request_expired_refund: "&e募集が期限切れになり、前払い分を返金しました。"
+    request_limit: "&c募集数の上限（%limit%）に達しています。"
+    no_matching_item: "&c供給するアイテム（%item% x%amount%）を所持していません。"
+    request_not_available: "&cこの募集は既に成立済みか、存在しません。"
+    request_not_owner: "&cこれはあなたの募集ではありません。"
+```
+> 注意: `fulfilled` の受取額プレースホルダ名は既存 `%amount%` と衝突しないよう `%amount_proceeds%` 等にするか、`MarketMessages` 側で整理する。要は「個数」と「受取金額」を別プレースホルダにすること。
+
+---
+
+## 4. 実装設計
+
+### 4-1. DB スキーマ（`DatabaseManager` にインライン追加）
+```sql
+CREATE TABLE IF NOT EXISTS market_buy_orders (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    requester_uuid TEXT NOT NULL,
+    requester_name TEXT NOT NULL,
+    material TEXT NOT NULL,            -- 募集する Material 名
+    amount INTEGER NOT NULL,          -- 募集個数
+    price REAL NOT NULL,              -- 前払いエスクロー総額
+    status TEXT NOT NULL DEFAULT 'open',  -- open/fulfilled/reclaimed/cancelled/expired
+    supplier_uuid TEXT,              -- 供給者（成立時）
+    item_data TEXT,                  -- 供給されたアイテム（Base64、成立時に保存、回収用）
+    listed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at INTEGER,              -- epoch millis、NULL=無期限
+    fulfilled_at TIMESTAMP
+);
+-- performMigrations() 末尾
+CREATE INDEX IF NOT EXISTS idx_buyorder_status    ON market_buy_orders(status);
+CREATE INDEX IF NOT EXISTS idx_buyorder_requester ON market_buy_orders(requester_uuid, status);
+CREATE INDEX IF NOT EXISTS idx_buyorder_expires   ON market_buy_orders(status, expires_at);
+```
+
+### 4-2. 新規クラス
+| ファイル | 役割 |
+|---|---|
+| `models/MarketBuyOrder.java` | エンティティ + status定数（OPEN/FULFILLED/RECLAIMED/CANCELLED/EXPIRED）+ getter/setter。コンストラクタ `(requesterUuid, requesterName, material, amount, price, Long expiresAtMillis)`。 |
+| `dao/MarketBuyOrderDAO.java` | insert/getById/getOpenOrders/getOrdersByRequester/countOpenByRequester/getExpiredOpen/expireOpenOrders/markAsFulfilled（楽観ロック・supplier/item_data/fulfilled_at設定）/updateStatusConditional |
+| `market/gui/BuyOrderBrowseGUI.java` | 募集一覧（open、カテゴリ＋ページング、クリックで供給） |
+| `market/gui/MyBuyOrdersGUI.java` | 自分の募集管理（open→キャンセル、fulfilled→アイテム回収） |
+| `commands/MarketCommand.java`（既存に追記） | buy/requests/myrequests/cancelrequest/reclaimrequest サブコマンド |
+
+`MarketManager` に買い注文メソッドを追加（新規 Manager を作らず集約。connection/playerDAO/currencyConverter/configManager を既に保持）。
+**`MarketResult` に値を追加**: `REQUESTED("requested")`, `FULFILLED("fulfilled")`, `ORDER_CANCELLED("request_cancelled")`, `ORDER_RECLAIMED("request_reclaimed")`, `NO_MATCHING_ITEM("no_matching_item")`, `ORDER_NOT_AVAILABLE("request_not_available")`, `ORDER_NOT_OWNER("request_not_owner")`, `ORDER_LIMIT("request_limit")`。`isSuccess()` に REQUESTED/FULFILLED/ORDER_CANCELLED/ORDER_RECLAIMED を含める。
+
+### 4-3. MarketGUISession の拡張
+現状 `slotListings: Map<Integer, MarketListing>` と `Type{BROWSE, MY_LISTINGS}`。買い注文用に:
+- `Type` に `BUY_BROWSE`, `MY_BUY_ORDERS` を追加。
+- スロット→オブジェクトのマップを売り/買いで分けるか汎用化する。**推奨**: `slotBuyOrders: Map<Integer, MarketBuyOrder>` を追加し、GUI 種別に応じて使い分け（`getBuyOrderAtSlot(slot)` / `putSlotBuyOrder`）。`clearSlotListings()` で両方クリア。
+- `MarketGUIListener.dispatchClick` の switch に2分岐追加。
+
+### 4-4. MarketManager 追加メソッド（設計）
+
+**募集登録（Bukkit ラッパー）** `createBuyOrder(Player requester, Material material, int amount, double price)`:
+```
+1. enabled / isValidPrice(price) / amount>0 を検証 → 不正なら INVALID_*
+2. countOpenByRequester < max_buy_orders_per_player → 超過 ORDER_LIMIT
+   （countは synchronized(connection) 内で）
+3. ★現金を先に回収★ payWithCash(requester, price) 失敗 → INSUFFICIENT_FUNDS
+4. INSERT (status=open, expires_at=now+days)  ※executeCreateBuyOrder 内で
+5. DB 失敗時は receiveCash で返金して ERROR
+6. 成功 REQUESTED
+```
+順序: **現金回収 → INSERT、INSERT 失敗時は返金**（売りの purchase と同じ安全順序）。
+
+**供給（Bukkit ラッパー）** `fulfillBuyOrder(Player supplier, int orderId)`:
+```
+1. order = getById; open でなければ ORDER_NOT_AVAILABLE
+2. 自己供給チェック（自分の募集には供給不可。allow_self_purchase を流用 or 常に不可）
+3. 供給者が material を amount 個所持しているか（インベントリ集計）→ 無ければ NO_MATCHING_ITEM
+4. ★手持ちから amount 個を除去し、ItemStack(material, amount) を serialize★（除去はTradingGUIの手動removeパターン参照）
+5. executeFulfillTransaction(supplierUuid, orderId, itemData, now):
+     synchronized(connection)+autocommit(false)
+     - markAsFulfilled(orderId, supplierUuid, itemData, now)  ※status=open限定の楽観ロック。影響行数!=1で ALREADY/NOT_AVAILABLE
+     - 供給者 bank += floor(price*0.95)
+     - commit
+6. DB 失敗/楽観ロック失敗 → 除去したアイテムを供給者へ返却（giveItem）して結果コード返す
+7. 成功時: 募集者がオンラインなら fulfilled_notify 通知。supplier へ FULFILLED（受取額含む）
+```
+※エスクロー消却の会計: price は募集時に回収済み。ここで floor(price*0.95) だけ再生成。差額は自動的に消却される（明示的な burn 処理は不要）。
+
+**キャンセル** `cancelBuyOrder(Player requester, int orderId)`:
+```
+- order取得、所有者チェック（違えば ORDER_NOT_OWNER）、open でなければ ORDER_NOT_AVAILABLE
+- updateStatusConditional(open→cancelled) 楽観ロック
+- 成功時 ★エスクロー返金★ receiveCash(requester, price, true)（オンライン前提＝キャンセルは本人操作）
+- ORDER_CANCELLED
+```
+
+**回収** `reclaimBuyOrder(Player requester, int orderId)`:
+```
+- order取得、所有者チェック、fulfilled でなければ ORDER_NOT_AVAILABLE
+- updateStatusConditional(fulfilled→reclaimed) 楽観ロック
+- 成功時 giveItem(requester, order.getItemData())
+- ORDER_RECLAIMED
+```
+
+**期限切れ（定期タスク）** `expireBuyOrders()→int`:
+```
+synchronized(connection):
+  open かつ expires_at<=now の注文を取得 → 各々 status=expired にしつつ
+  ★募集者 bank へ price を返金★（getOrCreatePlayer→addBankBalance→updatePlayer）
+  （単純な一括UPDATEだと返金漏れるので、対象を取得してループで返金＋status更新する）
+return 件数
+```
+> 注意: 売りの `expireActiveListings` は単純UPDATEで良いが、買い注文は**返金を伴う**ため取得→ループ処理にする。各注文は楽観ロック（open限定UPDATE）で二重返金を防止。
+> `MarketExpirationTask` に `marketManager.expireBuyOrders()` の呼び出しを追加（既存タスクに相乗り or 新タスク。既存タスクに1行追加が簡単）。
+
+### 4-5. コマンド追加（`/market` サブコマンド）
+| コマンド | 動作 | 権限 |
+|---|---|---|
+| `/market buy <material> <個数> <価格>` | 募集を登録（前払い） | `tofunomics.market.sell`（出品系）または新設 `.market.buy` |
+| `/market requests` | 募集一覧GUI（BuyOrderBrowseGUI）を開く | use |
+| `/market myrequests` | 自分の募集GUI（MyBuyOrdersGUI） | use |
+| `/market cancelrequest <id>` | open 募集をキャンセル＋返金 | use |
+| `/market reclaimrequest <id>` | fulfilled 募集のアイテム回収 | use |
+- `material` は `Material.matchMaterial(arg.toUpperCase())` でパース。null なら INVALID_ITEM 相当のメッセージ。
+- TabCompleter: 第1引数に buy/requests/myrequests/cancelrequest/reclaimrequest を追加。`cancelrequest`/`reclaimrequest` は自分の該当status注文ID補完。`buy` の第2引数は Material 候補（任意）。
+- plugin.yml の usage 文字列を更新（権限を増やすなら permissions も追記）。
+
+### 4-6. GUI 設計
+- `BuyOrderBrowseGUI`: `getOpenOrders()` を描画。各注文アイテム= `new ItemStack(Material, amount)`（募集対象。NBT無しなので matchMaterial で生成）に lore（募集者・希望個数・支払価格・「クリックで供給」）。カテゴリ＋ページングは MarketBrowseGUI を踏襲。クリック→ `fulfillBuyOrder`。
+- `MyBuyOrdersGUI`: `getOrdersByRequester(uuid)`。open→クリックでキャンセル、fulfilled→クリックで回収、それ以外は表示のみ。MyListingsGUI を踏襲。
+- メッセージは結果コード→`getMarketMessage(result.getMessageKey(), ...)`。プレースホルダ（item/amount/price/currency/受取額/limit）を呼び出し側で埋める。
+
+---
+
+## 5. セッション分割（推奨・各回コンパイル可能）
+
+- **B1: DB層** — `models/MarketBuyOrder` → `dao/MarketBuyOrderDAO` → `DatabaseManager` にDDL＋index。`MarketBuyOrderDAOTest`（CRUD・open取得・countOpen・expired取得・markAsFulfilled楽観ロック）green。
+- **B2: ロジック層** — `MarketResult` 値追加 → `MarketManager` に createBuyOrder/fulfill/cancel/reclaim/expire のコア＋ラッパー → `config.yml` の market追記。`MarketManagerTest` に買い注文ケース追加（手数料floor・二重供給の楽観ロック・期限切れ返金・所有者チェック）。
+- **B3: GUI＋タスク** — `MarketGUISession`拡張 → `MarketGUIListener`分岐追加 → `BuyOrderBrowseGUI`/`MyBuyOrdersGUI` → `MarketExpirationTask` に expireBuyOrders 追加。
+- **B4: コマンド＋配線** — `MarketCommand` サブコマンド追加 → `TofuNomics.java` 配線 → `plugin.yml` usage/権限。`messages.market` 追記。
+- **B5: ビルド＋デプロイ** — `mvn clean package`（テストgreen）→ `tofu-mc-deploy` → リロード案内 → E2E。
+
+各単位で `mvn -q compile`、テストは `mvn test -Dtest='Market*'`。
+
+---
+
+## 6. E2E 検証
+1. A が `/market buy DIAMOND 10 100` → 手持ち現金から100消費、募集登録。`/market requests` に表示。
+2. A ログアウト → B が `/market requests` から募集をクリック → B の手持ちダイヤ10個が消え、B の bank に `floor(100×0.95)=95` 加算（5消却）。
+3. A 再ログイン → `/market myrequests` → 成立した募集をクリックでダイヤ10個回収。
+4. キャンセル: A が open 募集を `/market cancelrequest <id>` → 前払い100が現金で返金。
+5. 期限切れ: `listing_duration_days` を短く → expired 化 → A の bank に100返金。
+6. エッジ: 供給アイテム不足（NO_MATCHING_ITEM）、現金不足で募集不可、募集上限、自己供給拒否、二重供給防止。
+
+---
+
+## 7. プロジェクト規約（厳守）
+- 応答・コメント・コミットメッセージは**日本語**。コミットプレフィックス `feat/fix/docs/refactor/test/config`。
+- コミット末尾に `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`。
+- ビルド前 `mvn clean`。カバレッジ70%維持。作業は `feature/player-market`、`main` 直接コミット禁止。
+- PR作成時・config変更時は `~/bin/worklog TofuNomics "..."`（フルパス）。
+- **config.yml 全体上書き厳禁**（NPC座標等のサーバー固有設定を保護）。サーバー reload はユーザー手動依頼。
+- デプロイは `tofu-mc-deploy`（deployスキル）。リロードは plugman unload/load をユーザーが手動実行。
+
+---
+
+## 8. 注意点・落とし穴
+- **通貨保存則を必ずテスト**: 募集→キャンセルで純増減ゼロ、募集→供給で floor分だけ供給者に渡り差額消却。
+- **エスクロー返金の二重実行防止**: キャンセル/期限切れは必ず楽観ロック（open限定UPDATEの影響行数==1）を経てから返金する。先に返金して後でUPDATE失敗、の順にしない。
+- **供給時のアイテム除去とDBの順序**: 「手持ち除去→serialize→DBトランザクション、失敗時はアイテム返却」。売りの現金払い purchase と同じ安全順序。
+- 期限切れ買い注文は**単純一括UPDATE不可**（返金が必要）。取得→ループ→注文ごとに楽観ロックUPDATE＋返金。
+- `%amount%`（個数）と受取金額のプレースホルダ名を分ける（衝突回避）。
+- 共有 Connection への非同期書き込み（PlayerJoinHandler）と競合するため、DB操作は全て `synchronized(connection)`。
+- MockBukkit は依存に無い。ItemStack 往復・インベントリ操作はユニット不可 → コア（DB＋bank）のみ単体テスト、現金/インベントリは E2E 委譲（売りと同方針）。
+
+> 新セッションは本書 → `docs/market-implementation-handoff.md`（既存APIの正本）の順に読み、B1 から着手すること。

--- a/docs/market-implementation-handoff.md
+++ b/docs/market-implementation-handoff.md
@@ -1,0 +1,333 @@
+# プレイヤー間マーケット機能 実装 引き継ぎ書
+
+> このドキュメントは、別セッションでマーケット機能の実装を引き継ぐための完全な引き継ぎ書です。
+> 作成日: 2026-06-11 / 作成: Claude Opus 4.8 セッション
+> 関連: `docs/market-feature-findings.md`（調査メモ）, `docs/config-reference.md`（config仕様の market セクション）
+
+---
+
+## ★ 進捗（2026-06-11 追記）: S1・S2 完了 → 次は S3
+
+> **このセクションが S1/S2 については「正本」**。下の「## 4. 実装設計」は当初プランで、実装と一部食い違う（差分は本セクションに明記）。S3 以降の設計指針としては引き続き「## 4」「## 5」を参照してよい。
+
+### 完了状況
+- ブランチ `feature/player-market`（`main` から作成済み・このまま続行）。
+- **S1（DB層）コミット `7cc1093`** / **S2（ロジック層）コミット `99ac0c8`**。
+- マーケット関連テスト **計31件 green**（DAO 10・Serializer 5・Manager 16）。全体コンパイル・pre-commit の YAML 検証も通過。
+- 未コミットの `.claude/settings.json`・`docs/` はコミットに含めていない（従来方針どおり）。
+
+### 当初プランとの差分（重要・実装に合わせること）
+1. **`expires_at` は epoch millis（INTEGER）**。当初案の TIMESTAMP+CURRENT_TIMESTAMP 比較は、SQLite の文字列比較フォーマット依存を避けるため不採用。モデルは `Long expiresAtMillis`（NULL=無期限）。期限判定は数値比較。
+2. **DB テーブル追加はインライン方式**。`DatabaseManager.createTables()` 内の `tableCreationQueries` 配列末尾に `market_listings` の CREATE 文を追加済み。インデックス3本（`idx_market_status` / `idx_market_seller` / `idx_market_expires`）は `performMigrations()` 末尾に追加済み。当初案の `createMarketListingsTableSQL()` メソッド分割は実コードに存在せず不採用。
+3. **テストは SQLite インメモリ（`jdbc:sqlite::memory:`）＋ JUnit4（`org.junit`）＋ Mockito**。新規テストは本番 DDL を流用するため SQLite を使用（`PlayerDAOTest` は H2 だが踏襲しない）。**MockBukkit は依存に無い** → ItemStack の往復シリアライズはユニット不可、E2E 委譲。
+4. `ConfigManager` は **約4260行**、getter は `config.getDouble/getInt/getBoolean("path", default)` の直書き。`getMessage(key, Object... replacements)` が `%key%` ペア置換。
+5. config.yml は約3485行、`messages:` は約2051行。market 設定は**トップレベル `market:`** と **`messages.market:`**（15メッセージ）を追加済み。
+
+### S1/S2 で実際に作られたもの（API 一覧・S3 はこれを使う）
+- `models/MarketListing`: フィールド `id, sellerUuid(UUID), sellerName, itemData(Base64), displayName, material, amount, price(double), status, buyerUuid(UUID), listedAt(Timestamp), expiresAtMillis(Long), soldAt(Timestamp)`。status 定数 `STATUS_ACTIVE/SOLD/EXPIRED/RECLAIMED`。コンストラクタ `(sellerUuid, sellerName, itemData, displayName, material, amount, price, Long expiresAtMillis)`。
+- `market/MarketItemSerializer`: static `serialize(ItemStack)→String`（失敗時 null） / `deserialize(String)→ItemStack`（null/空/不正で null）。
+- `dao/MarketListingDAO`: `insertListing(listing)→int` / `getById(int)` / `getActiveListings()` / `getListingsBySeller(UUID)` / `countActiveBySeller(UUID)` / `getExpiredActiveListings(long nowMillis)` / `expireActiveListings(long nowMillis)→int` / `markAsSold(id, buyerUuid, long soldAtMillis)→boolean`（楽観ロック） / `updateStatusConditional(id, expectedStatus, newStatus)→boolean`（楽観ロック）。
+- `market/MarketResult`（enum）: 各値が `messages.market.*` キーに対応（`getMessageKey()`）。`isSuccess()` あり。値: LISTED/PURCHASED/CANCELLED/RECLAIMED/INVALID_ITEM/INVALID_PRICE/CURRENCY_NOT_ALLOWED/LISTING_LIMIT/NOT_AVAILABLE/ALREADY_SOLD/INSUFFICIENT_FUNDS/INVENTORY_FULL/NOT_OWNER/MARKET_DISABLED/ERROR。
+- `market/PurchaseOutcome`: `getResult()/isSuccess()/getItemData()/getSellerUuid()/getSellerProceeds()`。`failure(result)` / `success(itemData, sellerUuid, proceeds)`。
+- `market/MarketManager`: コンストラクタ `(Connection, PlayerDAO, MarketListingDAO, ConfigManager, Logger)`。
+  - **Bukkit ラッパー（コマンド/GUI から呼ぶ）**: `createListing(Player, double price)→MarketResult` / `purchaseListing(Player, int listingId)→MarketResult` / `cancelListing(Player, int)→MarketResult` / `reclaimListing(Player, int)→MarketResult`。
+  - **テスト可能コア**: `isValidPrice(double)` / `calculateSellerProceeds(double)→long` / `executeCreateListing(sellerUuid, sellerName, itemData, displayName, material, amount, price, nowMillis)→MarketResult` / `executePurchaseTransaction(buyerUuid, listingId, boolean hasSpace, nowMillis)→PurchaseOutcome` / `executeReclaim(sellerUuid, listingId, expectedStatus, boolean hasSpace)→MarketResult`。
+  - 購入・回収は `synchronized(connection)`＋手動トランザクション。アイテム付与・出品者通知（`sold_notify`、プレースホルダ `%amount%`）は commit 後。アイテムは `addItem`、入りきらない分は足元に `dropItem`（喪失防止）。
+- `ConfigManager` getter（9個）: `isMarketEnabled` / `getMarketFeeRate` / `getMarketMaxListingsPerPlayer` / `getMarketListingDurationDays` / `getMarketMinPrice` / `getMarketMaxPrice` / `isMarketAllowSelfPurchase` / `getMarketExpireCheckInterval` / `getMarketMessage(key, Object... replacements)`。
+
+### S3 でやること（GUI＋定期タスク）
+- `market/gui/MarketBrowseGUI`: `listingDAO.getActiveListings()` を描画（item_data を deserialize して表示、価格・出品者名）。購入クリック → `manager.purchaseListing(player, id)`。ページング。
+- `market/gui/MyListingsGUI`: `listingDAO.getListingsBySeller(uuid)`。active クリック → `cancelListing`、expired クリック → `reclaimListing`。
+- `market/gui/MarketGUIListener`: `InventoryClickEvent`/`InventoryCloseEvent`、`ConcurrentHashMap` でセッション（開いている GUI と listingId/ページ）管理。
+- `market/MarketExpirationTask`: `BukkitRunnable.runTaskTimer(plugin, 0L, intervalTicks)`（`getMarketExpireCheckInterval()` 秒 ×20）。中で期限切れ一括処理。**`MarketManager` に `synchronized(connection)` で `listingDAO.expireActiveListings(System.currentTimeMillis())` を呼ぶ薄いメソッド（例 `expireListings()→int`）を追加して、それをタスクから呼ぶ**（現状 Manager には未実装なので S3 で追加）。
+- 雛形にする既存 GUI: `npc/gui/TradingGUI.java`, `npc/gui/BankGUI.java`（実在を `ls src/main/java/org/tofu/tofunomics/npc/gui/` で確認してから読む）。
+- メッセージ送信は GUI/コマンド側で `configManager.getMarketMessage(result.getMessageKey(), プレースホルダ...)`。プレースホルダ実値（`%item% %price% %currency% %amount% %min% %max% %limit%`）は呼び出し側で埋める。
+- **配線（`TofuNomics.java` の Manager/DAO 生成・コマンド登録・リスナー登録・タスク起動、`plugin.yml`、`MarketCommand`、`MarketMessages`）は S4**。S3 は GUI とタスクのクラス実装まで（コンパイルが通る単位で）。
+
+### S3 開始時の最初の一歩
+1. `git log --oneline -3` で `99ac0c8`(S2)・`7cc1093`(S1) を確認。ブランチ `feature/player-market`。
+2. `ls src/main/java/org/tofu/tofunomics/npc/gui/` → `TradingGUI`/`BankGUI` を読み、GUI の枠（Inventory 生成・Holder・クリックハンドリング）の流儀を把握。
+3. `MarketManager` に `expireListings()` を追加 → `MarketExpirationTask` → GUI 群の順で実装。各単位で `mvn -q compile` を通す。
+
+---
+
+## 0. まず最初に確認すること
+
+- **現在のブランチ**: `feature/player-market`（`main` から分岐済み・作成済み）。`develop` ブランチは存在しない（このプロジェクトは `main` ベース運用、feature→main へPRマージ）。
+- **作業はこのブランチで続行**してよい。`main` への直接コミットは Stop hook（`~/.claude/scripts/no-direct-commit.sh`）が警告する＝正常動作。
+- **過去の market 実装（24ファイル）は git gc で完全消失**（stash・dangling commit にも残っていない）。**ゼロから新規実装**する。仕様だけが docs に残っている。
+- 未コミットの変更として `.claude/settings.json` の変更がある（ユーザーが設定ミスを修正したもの。実装とは無関係。コミットに含めない方が無難）。
+
+---
+
+## 1. ユーザーの要望（原文の意図）
+
+「常にプレイヤーがいる状態じゃないとプレイヤー同士の取引ができないので、**プレイヤーがいなくても取引ができるトレード機能**を実装したい。実装が膨大になるので計画を立て、必要ならタスクごとにセッションを分割してよい」
+
+→ **公開マーケット型**（出品者がオフラインでも他プレイヤーが購入できる）として実装することでユーザーと合意済み。
+
+---
+
+## 2. 確定仕様（ユーザー合意済み）
+
+- 形態: **公開マーケット型**。出品者オフラインでも購入可。代金は出品者の `bank_balance` へ入金。
+- 出品: コマンド `/market sell <価格>`。**手に持っているアイテム（メインハンドのスタック全体）**を出品。価格は total（スタック全体の値段）。
+- 一覧・購入: **GUI**。
+- 価格は出品者が自由設定。**手数料 5%（消却＝どこにも入金せず通貨総量から消える）**。出品者受取 = `Math.floor(price × (1 − fee_rate))`。
+- 期限切れ（既定7日）は**アイテム喪失ゼロの回収方式**。expired になってもアイテムデータはDBに残り、出品者が手動回収するまで保持。
+
+---
+
+## 3. 技術前提（実コードで確認済み・重要）
+
+### 3-1. ItemStack シリアライズ方式 ★確認済み
+`PlayerInventoryManager.java`（214-249行）の方式を流用する。**YAML ではなく `BukkitObjectOutputStream/InputStream` + Base64**：
+
+```java
+// シリアライズ（単一 ItemStack 用に流用）
+ByteArrayOutputStream out = new ByteArrayOutputStream();
+BukkitObjectOutputStream bukkitOut = new BukkitObjectOutputStream(out);
+bukkitOut.writeObject(item);          // 単一アイテム（PlayerInventoryManagerは配列をwriteInt+ループ）
+bukkitOut.close();
+String base64 = Base64.getEncoder().encodeToString(out.toByteArray());
+
+// デシリアライズ
+ByteArrayInputStream in = new ByteArrayInputStream(Base64.getDecoder().decode(base64));
+BukkitObjectInputStream bukkitIn = new BukkitObjectInputStream(in);
+ItemStack item = (ItemStack) bukkitIn.readObject();
+bukkitIn.close();
+```
+- import: `org.bukkit.util.io.BukkitObjectOutputStream` / `org.bukkit.util.io.BukkitObjectInputStream`
+- 例外: `IOException` / `ClassNotFoundException` を catch
+- → これを `market/MarketItemSerializer.java` として `serialize(ItemStack)` / `deserialize(String)` の static メソッドに切り出す。
+
+### 3-2. データベース層 ★確認済み
+- アクティブDB層は `database/DatabaseManager.java`（**単一の共有 Connection**、`tofunomics.db` ハードコード）。`HikariDatabaseManager` は未使用。
+- `getConnection()` は50行付近。`createTables()` は75行：
+  ```java
+  private void createTables() throws SQLException {
+      String[] tableSQLs = {
+          createPlayersTableSQL(),
+          ...
+          createPlayerInventoriesTableSQL()   // ← 配列の最後
+      };
+      for (String sql : tableSQLs) {
+          try (PreparedStatement statement = connection.prepareStatement(sql)) {
+              statement.execute();
+          }
+      }
+      performMigrations();
+  }
+  ```
+- **テーブル追加手順**: ①`createMarketListingsTableSQL()` という private メソッドを新設しSQL文字列を返す ②`tableSQLs` 配列の末尾に `createMarketListingsTableSQL()` を追加。
+- **インデックス作成箇所は未確認**（grep が拒否された）。`createPlayerInventoriesTableSQL()` の実装と既存インデックス（`idx_*`）の作り方を最初に確認すること（`grep -n "idx_\|CREATE INDEX" src/main/java/org/tofu/tofunomics/database/DatabaseManager.java`）。インデックスを CREATE INDEX 文として tableSQLs に含めるか、別メソッドかを既存パターンに合わせる。
+- 新規テーブルなので**マイグレーション不要**（`CREATE TABLE IF NOT EXISTS`）。
+
+### 3-3. 残高操作 ★確認済み
+- `bank_balance` は **double 型（REAL）**。価格入力は整数で受け付けるが、内部計算は double。手数料の端数は `Math.floor`。
+- `PlayerDAO` の bank_balance 操作メソッド（`addBankBalance` / `removeBankBalance` 等）を使用。**UUID 直指定でオフラインプレイヤーにも適用可能**。
+- `PlayerDAO.transferBalance`（220行付近）が `setAutoCommit(false)` 手動トランザクションの参考。**実装前にこのメソッドを必ず読むこと**（コミット/ロールバックの作法、メソッドシグネチャ確認のため）。
+
+### 3-4. DAOパターン ★要確認
+- DAOはコンストラクタで `Connection` を受け取る。`PreparedStatement` でSQLインジェクション対策。`ResultSet` → モデルのマッピング。
+- 既存DAO（`PlayerDAO.java`, `dao/HousingRentalDAO.java`）を雛形として読むこと。
+
+### 3-5. Risk B（重要な並行性の注意） ★確認済み
+- `PlayerJoinHandler` がプレイヤー入場時に `runTaskAsynchronously` で**共有 Connection に非同期書き込み**する（insertPlayer/updateLastLogin/updatePlayerName）。
+- マーケットの購入処理は `setAutoCommit(false)` の手動トランザクションを使うため、この非同期書き込みと**同一 Connection で競合しうる**。
+- **対策**: `MarketManager.purchaseListing()`（および出品/回収のトランザクション）を `synchronized(connection)` ブロックで囲む。
+
+### 3-6. config 自動補完の仕組み ★確認済み
+- `ConfigManager.updateConfigWithDefaults()`（onEnable で実行）が **jar 同梱 `src/main/resources/config.yml` を読み、本番 config に不足キーを追加**（追加のみ・削除しない）。
+- → `src/main/resources/config.yml` に `market:` と `messages.market:` を入れてビルド・デプロイすれば、本番へ自動補完される。**本番 config の手動編集・全体上書きは厳禁**（NPC座標等のサーバー固有設定が消える）。
+- jar 名: `TofuNomics-1.0-SNAPSHOT.jar`。デプロイ先: `/opt/minecraft/servers/lobby-1.21/plugins/TofuNomics-1.0-SNAPSHOT.jar`。reload はユーザー手動。
+
+---
+
+## 4. 実装設計
+
+### 4-1. DBスキーマ（`DatabaseManager` に追加）
+```sql
+CREATE TABLE IF NOT EXISTS market_listings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    seller_uuid TEXT NOT NULL,
+    seller_name TEXT NOT NULL,
+    item_data TEXT NOT NULL,                      -- Base64(BukkitObjectStream)
+    display_name TEXT,                            -- GUI表示用
+    material TEXT NOT NULL,                        -- フィルタ・表示用 Material名
+    amount INTEGER NOT NULL,
+    price REAL NOT NULL,                           -- 出品価格(total)
+    status TEXT NOT NULL DEFAULT 'active',         -- active/sold/expired/reclaimed
+    buyer_uuid TEXT,
+    listed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP,                          -- NULL = 無期限(listing_duration_days=0)
+    sold_at TIMESTAMP,
+    FOREIGN KEY (seller_uuid) REFERENCES players(uuid)
+);
+-- インデックス（既存パターンに合わせて配置）
+CREATE INDEX IF NOT EXISTS idx_market_status  ON market_listings(status);
+CREATE INDEX IF NOT EXISTS idx_market_seller  ON market_listings(seller_uuid, status);
+CREATE INDEX IF NOT EXISTS idx_market_expires ON market_listings(status, expires_at);
+```
+期限は**リアルタイム（CURRENT_TIMESTAMP + 日数）基準**（housing の tick 基準ではない。オフライン中も経過する現実時間が公開マーケットに適切）。
+
+### 4-2. 新規クラス（`market/` パッケージ新設）
+| ファイルパス | 役割 |
+|---|---|
+| `models/MarketListing.java` | エンティティ + status定数(active/sold/expired/reclaimed) + getter/setter |
+| `dao/MarketListingDAO.java` | CRUD、active一覧取得、seller別取得、expired検出、status条件付きUPDATE、countActiveBySeller |
+| `market/MarketItemSerializer.java` | ItemStack ⇔ Base64（3-1の方式、static） |
+| `market/MarketManager.java` | 出品/購入/キャンセル/回収、手数料計算、トランザクション制御、バリデーション |
+| `market/MarketExpirationTask.java` | 定期タスク（`BukkitRunnable.runTaskTimer`、expired化） |
+| `market/MarketMessages.java` | `messages.market.*` 読み込み + プレースホルダ置換ヘルパー |
+| `market/gui/MarketBrowseGUI.java` | マーケット一覧GUI（全active、ページング、購入クリック） |
+| `market/gui/MyListingsGUI.java` | 自分の出品管理GUI（active/expired、キャンセル・回収） |
+| `market/gui/MarketGUIListener.java` | InventoryClickEvent/InventoryCloseEvent、ConcurrentHashMapセッション管理 |
+| `commands/MarketCommand.java` | `/market`（CommandExecutor + TabCompleter） |
+
+GUI実装は既存の `npc/gui/TradingGUI.java`, `npc/gui/BankGUI.java` を雛形にすること。
+
+### 4-3. 既存クラスへの変更
+- `database/DatabaseManager.java` — `createMarketListingsTableSQL()` 追加 + `tableSQLs` 配列に追加 + インデックス
+- `config/ConfigManager.java` — market getter群（`isMarketEnabled` / `getMarketFeeRate` / `getMarketMaxListingsPerPlayer` / `getMarketListingDurationDays` / `getMarketMinPrice` / `getMarketMaxPrice` / `isMarketAllowSelfPurchase` / `getMarketExpireCheckInterval` / `getMarketMessage(key)`）。既存 getDouble/getInt/getBoolean ラッパーを利用。
+- `TofuNomics.java` — `initializeManagers()` で Manager/DAO 生成、`registerCommands()` で `getCommand("market").setExecutor(...)`、`registerEventListeners()` で `MarketGUIListener` 登録、`onEnable()` 末尾で `MarketExpirationTask` を `runTaskTimer(this, 0L, intervalTicks)` 起動（`expire_check_interval` 秒 ×20 = ticks）、`onDisable()` でタスクキャンセル。
+- `src/main/resources/plugin.yml` — `market` コマンド + パーミッション（`tofunomics.market.use` default:true / `.market.sell` default:true / `.market.admin` default:op / `.market.*`）。
+- `src/main/resources/config.yml` — `market:` セクション（下記）+ `messages.market:`（14メッセージ）。
+
+### 4-4. config 既定値（`src/main/resources/config.yml` に追記）
+```yaml
+market:
+  enabled: true
+  fee_rate: 0.05
+  max_listings_per_player: 10
+  listing_duration_days: 7        # 0で無期限
+  min_price: 1
+  max_price: 1000000
+  allow_self_purchase: false
+  expire_check_interval: 3600     # 秒
+```
+`messages.market`（14メッセージのキー）: `listed` / `purchased` / `sold_notify` / `cancelled` / `reclaimed` / `invalid_item` / `invalid_price` / `currency_not_allowed` / `listing_limit` / `not_available` / `already_sold` / `insufficient_funds` / `inventory_full` / `not_owner` / `error`
+（既存 messages の書式・プレースホルダ %player% %amount% %currency% %item% %price% 等に倣う）
+
+### 4-5. 購入処理のトランザクション設計（`MarketManager.purchaseListing(Player buyer, int listingId)`）
+```
+synchronized (connection) {              // Risk B 対策
+  try {
+    connection.setAutoCommit(false);
+    1. SELECT ... WHERE id=? AND status='active'（再取得・再確認）→ 無ければ already_sold
+    2. 自己購入チェック（allow_self_purchase=false かつ seller==buyer なら拒否）
+    3. 購入者 bank_balance >= price 確認 → 不足なら insufficient_funds
+    4. 購入者インベントリ空き確認（firstEmpty() != -1）→ 満杯なら inventory_full（購入させない）
+    5. UPDATE market_listings SET status='sold', buyer_uuid=?, sold_at=? WHERE id=? AND status='active'
+       → 影響行数 ≠ 1 なら rollback（already_sold）※二重購入防止の楽観ロック（最重要）
+    6. 購入者 removeBankBalance(price)
+    7. 出品者 addBankBalance(Math.floor(price * (1 - fee_rate)))  // UUID直指定・オフライン可
+    8. connection.commit()
+    9. commit成功後にアイテム付与（deserialize → addItem、失敗時は world.dropItem で喪失防止）
+    10. 出品者がオンラインなら sold_notify 送信
+  } catch (SQLException e) {
+    connection.rollback(); return ERROR;
+  } finally {
+    connection.setAutoCommit(true);
+  }
+}
+```
+
+### 4-6. 出品処理（`MarketManager.createListing(Player seller, double price)`）
+順序が重要（喪失防止）:
+```
+1. メインハンドのアイテム取得 → AIR/null なら invalid_item
+2. 価格バリデーション（min_price <= price <= max_price、整数）→ 不正なら invalid_price
+3. 出品数上限（countActiveBySeller < max_listings_per_player）→ 超過なら listing_limit
+4. serialize(item) → Base64
+5. expires_at 計算（duration==0 ? null : now + days）
+6. INSERT market_listings (status='active')
+7. ★DB保存成功を確認してから★ seller の手持ちアイテムを除去（setItemInMainHand(null)）
+8. listed メッセージ
+```
+※「DB保存成功 → 手持ち除去」の順を厳守（逆だと保存失敗時にアイテム消失）。
+
+### 4-7. 期限切れ・回収
+- `MarketExpirationTask`（`expire_check_interval` 秒ごと）:
+  `UPDATE market_listings SET status='expired' WHERE status='active' AND expires_at IS NOT NULL AND expires_at <= CURRENT_TIMESTAMP`
+- 出品者は `/market mylistings`（MyListingsGUI）から expired/active をクリックで回収/キャンセル:
+  `reclaimListing(seller, id)`: 自分の出品取得 → インベントリ空き確認（満杯なら inventory_full・出品維持）→ デシリアライズして付与 → `UPDATE status='reclaimed'` → reclaimed/cancelled メッセージ。
+
+### 4-8. コマンド体系
+| コマンド | 動作 | 権限 |
+|---|---|---|
+| `/market` | MarketBrowseGUI を開く | `tofunomics.market.use`(true) |
+| `/market sell <価格>` | 手持ちを出品 | `tofunomics.market.sell`(true) |
+| `/market mylistings` | MyListingsGUI を開く | use |
+| `/market cancel <id>` | active出品をキャンセル回収 | use |
+| `/market reclaim <id>` | expired出品を回収 | use |
+| `/market reload` | config再読込 | `tofunomics.market.admin`(op) |
+| `/market help` | ヘルプ | use |
+TabCompleter: 第1引数にサブコマンド、`cancel`/`reclaim` は自分の listing ID 候補。
+
+---
+
+## 5. セッション分割（実装順・各回コンパイル/テスト可能）
+
+- **S0: フック修正 → 不要と判明**（`no-direct-commit.sh` は正常な Stop hook だった。実装しない）。
+- **S1: DB層**（このセッションで途中まで調査済み）
+  - `models/MarketListing.java` → `market/MarketItemSerializer.java` → `dao/MarketListingDAO.java` → `DatabaseManager` にDDL追加
+  - 完了条件: `MarketItemSerializerTest` / `MarketListingDAOTest` が green
+- **S2: ロジック層**: `MarketManager` / `ConfigManager` getter / `config.yml` の `market:` → `MarketManagerTest`
+- **S3: GUI + 定期タスク**: `MarketBrowseGUI` / `MyListingsGUI` / `MarketGUIListener` / `MarketExpirationTask`
+- **S4: コマンド + 統合**: `MarketCommand` / `MarketMessages` / `plugin.yml` / `TofuNomics.java` 配線 / `messages.market`
+- **S5: テスト + ビルド**: ユニットテスト拡充（カバレッジ70%）→ `mvn clean package` → デプロイ案内
+
+タスクは TaskCreate で S1〜S5 登録済み（新セッションでは TaskList で確認）。
+
+---
+
+## 6. テスト方針（カバレッジ70%目標）
+- `src/test/java/org/tofu/tofunomics/` の既存テストパターン（JUnit + Mockito、インメモリSQLite `jdbc:sqlite::memory:`）を最初に確認して流用。
+- `MarketItemSerializerTest`: 往復（通常/エンチャント/カスタム名/null）。
+- `MarketListingDAOTest`: CRUD、expired検出クエリ、countActive。
+- `MarketManagerTest`: **二重購入防止（条件付きUPDATEの影響行数）**、残高不足、出品上限、自己購入拒否、手数料floor、インベントリ満杯。
+- `MarketExpirationTaskTest`: expires_at 境界値。
+
+---
+
+## 7. 検証（End-to-End）
+1. `mvn clean package` でコンパイル（各セッション末）。
+2. `mvn test` green（特に二重購入防止・手数料端数）。
+3. サーバーで: A が `/market sell 100` → 手持ちから消え出品 → A ログアウト → B が `/market` で購入 → B にアイテム、A の `bank_balance` に `floor(100×0.95)=95` 加算（手数料5消却）。
+4. 期限切れ: `listing_duration_days` を短く → expired 化 → A が回収でアイテムが戻る（喪失ゼロ）。
+5. エッジ: 残高不足・インベントリ満杯・自己購入拒否・出品上限の各メッセージ表示。
+
+---
+
+## 8. プロジェクト規約（厳守）
+- 応答・コメント・コミットメッセージは**日本語**。
+- コミットプレフィックス: `feat` / `fix` / `docs` / `refactor` / `test` / `config`。
+- コミット末尾に `Co-Authored-By: Claude <モデル名> <noreply@anthropic.com>`。
+- ビルド前に `mvn clean`。カバレッジ70%維持。
+- **作業は `feature/player-market` で。`main` 直接コミット禁止**。PR を通じてマージ。
+- PR作成時・config変更時は worklog 記録: `~/bin/worklog TofuNomics "..."`（フルパスで実行）。
+- **config.yml 全体上書き厳禁**（サーバー固有のNPC座標・銀行/取引所位置を保護）。サーバー reload はユーザー手動依頼。
+- サーバー再起動が必要な場合は「別ターミナルでサーバーを停止してください」とユーザーに依頼。
+
+---
+
+## 9. 既知の環境メモ
+- シェルは `fish`。Bash ツールで bash 専用構文（`for ...; do ... done` 等）はパースエラーになる。`bash -c '...'` で囲むか fish 互換にする。
+- `~/.claude/scripts/no-direct-commit.sh` は **正常な Stop hook**（main/master で未コミット変更時に exit 2 で feature ブランチ作成を促す）。壊れていない。
+- このセッション（opus）ではツール出力の truncate/混線が散発した。長い出力や複数コマンドの `;` 連結を避け、**単一コマンド・小さい範囲**でツールを呼ぶと安定する。
+
+---
+
+## 10. 引き継ぎ時点の状態（チェックリスト）
+- [x] feature ブランチ `feature/player-market` 作成・切替済み
+- [x] プランファイル `/Users/kuriharaataru/.claude/plans/validated-booping-deer.md` 作成済み
+- [x] タスク S1〜S5 登録済み
+- [x] 既存シリアライズ方式の特定（BukkitObjectStream + Base64）
+- [x] `DatabaseManager.createTables()` の追加方法の特定
+- [ ] **インデックス作成箇所の確認**（最初にやる）
+- [ ] `PlayerDAO.transferBalance` / 既存DAO・既存GUI の精読
+- [ ] S1 のコード実装（未着手）
+- [ ] 以降 S2〜S5
+
+> 新セッションは本書 → `docs/market-feature-findings.md` → `docs/config-reference.md` の順に読み、S1 のコード確認（インデックス箇所・既存DAO・既存GUI）から再開すること。

--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -116,6 +116,14 @@ public final class TofuNomics extends JavaPlugin {
     // ルール確認システム
     private org.tofu.tofunomics.rules.RulesManager rulesManager;
 
+    // プレイヤー間マーケットシステム
+    private org.tofu.tofunomics.dao.MarketListingDAO marketListingDAO;
+    private org.tofu.tofunomics.market.MarketManager marketManager;
+    private org.tofu.tofunomics.market.gui.MarketBrowseGUI marketBrowseGUI;
+    private org.tofu.tofunomics.market.gui.MyListingsGUI myListingsGUI;
+    private org.tofu.tofunomics.market.gui.MarketGUIListener marketGUIListener;
+    private org.tofu.tofunomics.market.MarketExpirationTask marketExpirationTask;
+
     @Override
     public void onEnable() {
         instance = this;
@@ -180,6 +188,9 @@ public final class TofuNomics extends JavaPlugin {
         // 時計アイテムシステムの初期化
         initializeClockItemSystem();
 
+        // プレイヤー間マーケットシステムの初期化
+        initializeMarketSystem();
+
         // イベントリスナーの登録
         registerEventListeners();
         
@@ -236,6 +247,18 @@ public final class TofuNomics extends JavaPlugin {
             clockItemManager.stopActionBarTask();
         }
 
+        // マーケットシステムのクリーンアップ
+        if (marketExpirationTask != null) {
+            try {
+                marketExpirationTask.cancel();
+            } catch (Exception ignored) {
+                // 未スケジュール等は無視
+            }
+        }
+        if (marketGUIListener != null) {
+            marketGUIListener.closeAll();
+        }
+
         // データベース接続を閉じる
         if (databaseManager != null) {
             databaseManager.disconnect();
@@ -279,7 +302,8 @@ public final class TofuNomics extends JavaPlugin {
             playerJobDAO = new PlayerJobDAO(databaseManager.getConnection());
             jobChangeDAO = new JobChangeDAO(databaseManager.getConnection());
             jobHistoryDAO = new JobHistoryDAO(databaseManager.getConnection());
-            
+            marketListingDAO = new org.tofu.tofunomics.dao.MarketListingDAO(databaseManager.getConnection());
+
             getLogger().info("データアクセス層（DAO）を初期化しました");
         }
     }
@@ -318,6 +342,44 @@ public final class TofuNomics extends JavaPlugin {
             getLogger().info("マネージャーを初期化しました");
         } catch (Exception e) {
             getLogger().severe("マネージャー初期化中にエラーが発生しました: " + e.getMessage());
+        }
+    }
+
+    /**
+     * プレイヤー間マーケットシステムを初期化する。
+     * Manager・GUI・リスナー生成と、期限切れ定期タスクの起動を行う。
+     */
+    private void initializeMarketSystem() {
+        try {
+            if (databaseManager == null || !databaseManager.isConnected() || marketListingDAO == null) {
+                getLogger().warning("マーケットシステムの初期化をスキップしました（DB未接続）");
+                return;
+            }
+
+            marketManager = new org.tofu.tofunomics.market.MarketManager(
+                databaseManager.getConnection(),
+                playerDAO,
+                marketListingDAO,
+                configManager,
+                getLogger()
+            );
+
+            // リスナーを先に生成し、GUI へ注入してから GUI 参照を逆注入する（循環依存の解決）
+            marketGUIListener = new org.tofu.tofunomics.market.gui.MarketGUIListener(this);
+            marketBrowseGUI = new org.tofu.tofunomics.market.gui.MarketBrowseGUI(
+                this, configManager, marketManager, marketListingDAO, marketGUIListener);
+            myListingsGUI = new org.tofu.tofunomics.market.gui.MyListingsGUI(
+                this, configManager, marketManager, marketListingDAO, marketGUIListener);
+            marketGUIListener.setGUIs(marketBrowseGUI, myListingsGUI);
+
+            // 期限切れ定期タスクの起動（expire_check_interval 秒 × 20 = ticks）
+            long intervalTicks = Math.max(1L, (long) configManager.getMarketExpireCheckInterval() * 20L);
+            marketExpirationTask = new org.tofu.tofunomics.market.MarketExpirationTask(marketManager, getLogger());
+            marketExpirationTask.runTaskTimer(this, intervalTicks, intervalTicks);
+
+            getLogger().info("プレイヤー間マーケットシステムを初期化しました");
+        } catch (Exception e) {
+            getLogger().severe("マーケットシステム初期化中にエラーが発生しました: " + e.getMessage());
         }
     }
 
@@ -627,6 +689,12 @@ public final class TofuNomics extends JavaPlugin {
                 getLogger().info("ルール確認システムリスナーを登録しました");
             }
 
+            // マーケットGUIリスナーの登録
+            if (marketGUIListener != null) {
+                getServer().getPluginManager().registerEvents(marketGUIListener, this);
+                getLogger().info("マーケットGUIリスナーを登録しました");
+            }
+
             getLogger().info("全てのイベントリスナーを登録しました");
         } catch (Exception e) {
             getLogger().severe("イベントリスナー登録中にエラーが発生しました: " + e.getMessage());
@@ -706,10 +774,19 @@ public final class TofuNomics extends JavaPlugin {
             getCommand("rules").setExecutor(rulesCommand);
             
             // 中心都市マップ配布コマンド
-            org.tofu.tofunomics.commands.CityMapCommand cityMapCommand = 
+            org.tofu.tofunomics.commands.CityMapCommand cityMapCommand =
                 new org.tofu.tofunomics.commands.CityMapCommand(configManager);
             getCommand("citymap").setExecutor(cityMapCommand);
-            
+
+            // プレイヤー間マーケットコマンド
+            if (marketManager != null) {
+                org.tofu.tofunomics.commands.MarketCommand marketCommand =
+                    new org.tofu.tofunomics.commands.MarketCommand(
+                        configManager, marketManager, marketListingDAO, marketBrowseGUI, myListingsGUI);
+                getCommand("market").setExecutor(marketCommand);
+                getCommand("market").setTabCompleter(marketCommand);
+            }
+
             getLogger().info("コマンドハンドラーを登録しました");
         } catch (Exception e) {
             getLogger().severe("コマンド登録中にエラーが発生しました: " + e.getMessage());

--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -361,6 +361,7 @@ public final class TofuNomics extends JavaPlugin {
                 playerDAO,
                 marketListingDAO,
                 configManager,
+                currencyConverter,
                 getLogger()
             );
 

--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -118,6 +118,7 @@ public final class TofuNomics extends JavaPlugin {
 
     // プレイヤー間マーケットシステム
     private org.tofu.tofunomics.dao.MarketListingDAO marketListingDAO;
+    private org.tofu.tofunomics.dao.MarketBuyOrderDAO marketBuyOrderDAO;
     private org.tofu.tofunomics.market.MarketManager marketManager;
     private org.tofu.tofunomics.market.gui.MarketBrowseGUI marketBrowseGUI;
     private org.tofu.tofunomics.market.gui.MyListingsGUI myListingsGUI;
@@ -303,6 +304,7 @@ public final class TofuNomics extends JavaPlugin {
             jobChangeDAO = new JobChangeDAO(databaseManager.getConnection());
             jobHistoryDAO = new JobHistoryDAO(databaseManager.getConnection());
             marketListingDAO = new org.tofu.tofunomics.dao.MarketListingDAO(databaseManager.getConnection());
+            marketBuyOrderDAO = new org.tofu.tofunomics.dao.MarketBuyOrderDAO(databaseManager.getConnection());
 
             getLogger().info("データアクセス層（DAO）を初期化しました");
         }
@@ -360,6 +362,7 @@ public final class TofuNomics extends JavaPlugin {
                 databaseManager.getConnection(),
                 playerDAO,
                 marketListingDAO,
+                marketBuyOrderDAO,
                 configManager,
                 currencyConverter,
                 getLogger()

--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -122,6 +122,8 @@ public final class TofuNomics extends JavaPlugin {
     private org.tofu.tofunomics.market.MarketManager marketManager;
     private org.tofu.tofunomics.market.gui.MarketBrowseGUI marketBrowseGUI;
     private org.tofu.tofunomics.market.gui.MyListingsGUI myListingsGUI;
+    private org.tofu.tofunomics.market.gui.BuyOrderBrowseGUI buyOrderBrowseGUI;
+    private org.tofu.tofunomics.market.gui.MyBuyOrdersGUI myBuyOrdersGUI;
     private org.tofu.tofunomics.market.gui.MarketGUIListener marketGUIListener;
     private org.tofu.tofunomics.market.MarketExpirationTask marketExpirationTask;
 
@@ -375,6 +377,13 @@ public final class TofuNomics extends JavaPlugin {
             myListingsGUI = new org.tofu.tofunomics.market.gui.MyListingsGUI(
                 this, configManager, marketManager, marketListingDAO, marketGUIListener);
             marketGUIListener.setGUIs(marketBrowseGUI, myListingsGUI);
+
+            // 買い注文（募集）GUI を生成して注入
+            buyOrderBrowseGUI = new org.tofu.tofunomics.market.gui.BuyOrderBrowseGUI(
+                this, configManager, marketManager, marketBuyOrderDAO, marketGUIListener);
+            myBuyOrdersGUI = new org.tofu.tofunomics.market.gui.MyBuyOrdersGUI(
+                this, configManager, marketManager, marketBuyOrderDAO, marketGUIListener);
+            marketGUIListener.setBuyOrderGUIs(buyOrderBrowseGUI, myBuyOrdersGUI);
 
             // 期限切れ定期タスクの起動（expire_check_interval 秒 × 20 = ticks）
             long intervalTicks = Math.max(1L, (long) configManager.getMarketExpireCheckInterval() * 20L);
@@ -786,7 +795,8 @@ public final class TofuNomics extends JavaPlugin {
             if (marketManager != null) {
                 org.tofu.tofunomics.commands.MarketCommand marketCommand =
                     new org.tofu.tofunomics.commands.MarketCommand(
-                        configManager, marketManager, marketListingDAO, marketBrowseGUI, myListingsGUI);
+                        configManager, marketManager, marketListingDAO, marketBuyOrderDAO,
+                        marketBrowseGUI, myListingsGUI, buyOrderBrowseGUI, myBuyOrdersGUI);
                 getCommand("market").setExecutor(marketCommand);
                 getCommand("market").setTabCompleter(marketCommand);
             }

--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -528,7 +528,10 @@ public final class TofuNomics extends JavaPlugin {
             
             // クラフト制限設定の自動初期化
             configManager.ensureCraftRestrictionMessagesExist();
-            
+
+            // プレイヤー間マーケット（売り・募集）メッセージの自動初期化
+            configManager.ensureMarketMessagesExist();
+
             // 設定を保存
             saveConfig();
 

--- a/src/main/java/org/tofu/tofunomics/commands/MarketCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/MarketCommand.java
@@ -1,0 +1,237 @@
+package org.tofu.tofunomics.commands;
+
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.MarketListingDAO;
+import org.tofu.tofunomics.market.MarketManager;
+import org.tofu.tofunomics.market.MarketMessages;
+import org.tofu.tofunomics.market.MarketResult;
+import org.tofu.tofunomics.market.gui.MarketBrowseGUI;
+import org.tofu.tofunomics.market.gui.MarketGUIUtil;
+import org.tofu.tofunomics.market.gui.MyListingsGUI;
+import org.tofu.tofunomics.models.MarketListing;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * プレイヤー間マーケットのコマンド。
+ *
+ * <pre>
+ * /market                 マーケット一覧GUIを開く
+ * /market sell &lt;価格&gt;      手持ちのアイテムを出品する
+ * /market mylistings      自分の出品管理GUIを開く
+ * /market cancel &lt;id&gt;     出品中の出品をキャンセルしてアイテムを回収する
+ * /market reclaim &lt;id&gt;    期限切れの出品からアイテムを回収する
+ * /market reload          設定を再読み込みする（管理者）
+ * /market help            ヘルプを表示する
+ * </pre>
+ */
+public class MarketCommand implements CommandExecutor, TabCompleter {
+
+    private static final String PERM_USE = "tofunomics.market.use";
+    private static final String PERM_SELL = "tofunomics.market.sell";
+    private static final String PERM_ADMIN = "tofunomics.market.admin";
+
+    private final ConfigManager configManager;
+    private final MarketManager marketManager;
+    private final MarketListingDAO listingDAO;
+    private final MarketBrowseGUI browseGUI;
+    private final MyListingsGUI myListingsGUI;
+
+    public MarketCommand(ConfigManager configManager, MarketManager marketManager,
+                         MarketListingDAO listingDAO, MarketBrowseGUI browseGUI, MyListingsGUI myListingsGUI) {
+        this.configManager = configManager;
+        this.marketManager = marketManager;
+        this.listingDAO = listingDAO;
+        this.browseGUI = browseGUI;
+        this.myListingsGUI = myListingsGUI;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!configManager.isMarketEnabled()) {
+            sender.sendMessage(configManager.getMarketMessage("error"));
+            return true;
+        }
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("§cこのコマンドはプレイヤーのみ実行できます。");
+            return true;
+        }
+        Player player = (Player) sender;
+
+        if (args.length == 0) {
+            return handleBrowse(player);
+        }
+
+        switch (args[0].toLowerCase()) {
+            case "sell":
+                return handleSell(player, args);
+            case "mylistings":
+            case "my":
+                return handleMyListings(player);
+            case "cancel":
+                return handleReclaim(player, args, true);
+            case "reclaim":
+                return handleReclaim(player, args, false);
+            case "reload":
+                return handleReload(player);
+            case "help":
+                sendUsage(player);
+                return true;
+            default:
+                sendUsage(player);
+                return true;
+        }
+    }
+
+    private boolean handleBrowse(Player player) {
+        if (!player.hasPermission(PERM_USE)) {
+            player.sendMessage(configManager.getMessage("no_permission"));
+            return true;
+        }
+        browseGUI.open(player);
+        return true;
+    }
+
+    private boolean handleMyListings(Player player) {
+        if (!player.hasPermission(PERM_USE)) {
+            player.sendMessage(configManager.getMessage("no_permission"));
+            return true;
+        }
+        myListingsGUI.open(player);
+        return true;
+    }
+
+    private boolean handleSell(Player player, String[] args) {
+        if (!player.hasPermission(PERM_SELL)) {
+            player.sendMessage(configManager.getMessage("no_permission"));
+            return true;
+        }
+        if (args.length < 2) {
+            player.sendMessage("§e使い方: §f/market sell <価格>");
+            return true;
+        }
+
+        double price;
+        try {
+            price = Double.parseDouble(args[1]);
+        } catch (NumberFormatException e) {
+            player.sendMessage(MarketMessages.format(configManager, MarketResult.INVALID_PRICE, "", 0));
+            return true;
+        }
+
+        // 出品成功後はアイテムが手元から消えるため、メッセージ用の名前を先に取得しておく
+        ItemStack inHand = player.getInventory().getItemInMainHand();
+        String itemName = (inHand != null && inHand.getType() != Material.AIR)
+                ? MarketGUIUtil.prettifyMaterial(inHand.getType().name())
+                : "";
+
+        MarketResult result = marketManager.createListing(player, price);
+        player.sendMessage(MarketMessages.format(configManager, result, itemName, price));
+        return true;
+    }
+
+    private boolean handleReclaim(Player player, String[] args, boolean cancel) {
+        if (!player.hasPermission(PERM_USE)) {
+            player.sendMessage(configManager.getMessage("no_permission"));
+            return true;
+        }
+        if (args.length < 2) {
+            player.sendMessage("§e使い方: §f/market " + (cancel ? "cancel" : "reclaim") + " <ID>");
+            return true;
+        }
+
+        int listingId;
+        try {
+            listingId = Integer.parseInt(args[1]);
+        } catch (NumberFormatException e) {
+            player.sendMessage("§cIDは数値で指定してください。");
+            return true;
+        }
+
+        MarketResult result = cancel
+                ? marketManager.cancelListing(player, listingId)
+                : marketManager.reclaimListing(player, listingId);
+        player.sendMessage(MarketMessages.format(configManager, result, "", 0));
+        return true;
+    }
+
+    private boolean handleReload(Player player) {
+        if (!player.hasPermission(PERM_ADMIN)) {
+            player.sendMessage(configManager.getMessage("no_permission"));
+            return true;
+        }
+        configManager.reloadConfig();
+        player.sendMessage("§aマーケット設定を再読み込みしました。");
+        return true;
+    }
+
+    private void sendUsage(Player player) {
+        player.sendMessage("§6=== マーケットコマンド ===");
+        player.sendMessage("§e/market §7- 出品一覧を開く");
+        player.sendMessage("§e/market sell <価格> §7- 手持ちアイテムを出品");
+        player.sendMessage("§e/market mylistings §7- 自分の出品を管理");
+        player.sendMessage("§e/market cancel <ID> §7- 出品をキャンセルして回収");
+        player.sendMessage("§e/market reclaim <ID> §7- 期限切れの出品を回収");
+        if (player.hasPermission(PERM_ADMIN)) {
+            player.sendMessage("§e/market reload §7- 設定を再読み込み（管理者）");
+        }
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> completions = new ArrayList<>();
+
+        if (args.length == 1) {
+            List<String> subs = new ArrayList<>(Arrays.asList("sell", "mylistings", "cancel", "reclaim", "help"));
+            if (sender.hasPermission(PERM_ADMIN)) {
+                subs.add("reload");
+            }
+            String prefix = args[0].toLowerCase();
+            for (String sub : subs) {
+                if (sub.startsWith(prefix)) {
+                    completions.add(sub);
+                }
+            }
+            return completions;
+        }
+
+        if (args.length == 2 && sender instanceof Player) {
+            String sub = args[0].toLowerCase();
+            if (sub.equals("cancel") || sub.equals("reclaim")) {
+                completions.addAll(suggestListingIds((Player) sender, sub.equals("cancel")));
+            }
+        }
+
+        return completions;
+    }
+
+    /**
+     * 自分の出品のうち、操作可能な status の ID を補完候補として返す。
+     *
+     * @param activeOnly true なら active（cancel 用）、false なら expired（reclaim 用）
+     */
+    private List<String> suggestListingIds(Player player, boolean activeOnly) {
+        List<String> ids = new ArrayList<>();
+        try {
+            for (MarketListing listing : listingDAO.getListingsBySeller(player.getUniqueId())) {
+                boolean match = activeOnly ? listing.isActive() : listing.isExpired();
+                if (match) {
+                    ids.add(String.valueOf(listing.getId()));
+                }
+            }
+        } catch (SQLException ignored) {
+            // 補完失敗時は候補なしで返す
+        }
+        return ids;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/commands/MarketCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/MarketCommand.java
@@ -8,13 +8,17 @@ import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.MarketBuyOrderDAO;
 import org.tofu.tofunomics.dao.MarketListingDAO;
 import org.tofu.tofunomics.market.MarketManager;
 import org.tofu.tofunomics.market.MarketMessages;
 import org.tofu.tofunomics.market.MarketResult;
+import org.tofu.tofunomics.market.gui.BuyOrderBrowseGUI;
 import org.tofu.tofunomics.market.gui.MarketBrowseGUI;
 import org.tofu.tofunomics.market.gui.MarketGUIUtil;
+import org.tofu.tofunomics.market.gui.MyBuyOrdersGUI;
 import org.tofu.tofunomics.market.gui.MyListingsGUI;
+import org.tofu.tofunomics.models.MarketBuyOrder;
 import org.tofu.tofunomics.models.MarketListing;
 
 import java.sql.SQLException;
@@ -26,34 +30,48 @@ import java.util.List;
  * プレイヤー間マーケットのコマンド。
  *
  * <pre>
- * /market                 マーケット一覧GUIを開く
- * /market sell &lt;価格&gt;      手持ちのアイテムを出品する
- * /market mylistings      自分の出品管理GUIを開く
- * /market cancel &lt;id&gt;     出品中の出品をキャンセルしてアイテムを回収する
- * /market reclaim &lt;id&gt;    期限切れの出品からアイテムを回収する
- * /market reload          設定を再読み込みする（管理者）
- * /market help            ヘルプを表示する
+ * /market                       マーケット一覧GUIを開く
+ * /market sell &lt;価格&gt;            手持ちのアイテムを出品する
+ * /market mylistings            自分の出品管理GUIを開く
+ * /market cancel &lt;id&gt;           出品中の出品をキャンセルしてアイテムを回収する
+ * /market reclaim &lt;id&gt;          期限切れの出品からアイテムを回収する
+ * /market buy &lt;material&gt; &lt;個数&gt; &lt;価格&gt;  募集（買い注文）を登録する（前払い）
+ * /market requests              募集一覧GUIを開く
+ * /market myrequests            自分の募集管理GUIを開く
+ * /market cancelrequest &lt;id&gt;    募集をキャンセルして前払いを返金する
+ * /market reclaimrequest &lt;id&gt;   成立した募集から供給アイテムを回収する
+ * /market reload                設定を再読み込みする（管理者）
+ * /market help                  ヘルプを表示する
  * </pre>
  */
 public class MarketCommand implements CommandExecutor, TabCompleter {
 
     private static final String PERM_USE = "tofunomics.market.use";
     private static final String PERM_SELL = "tofunomics.market.sell";
+    private static final String PERM_BUY = "tofunomics.market.buy";
     private static final String PERM_ADMIN = "tofunomics.market.admin";
 
     private final ConfigManager configManager;
     private final MarketManager marketManager;
     private final MarketListingDAO listingDAO;
+    private final MarketBuyOrderDAO buyOrderDAO;
     private final MarketBrowseGUI browseGUI;
     private final MyListingsGUI myListingsGUI;
+    private final BuyOrderBrowseGUI buyOrderBrowseGUI;
+    private final MyBuyOrdersGUI myBuyOrdersGUI;
 
     public MarketCommand(ConfigManager configManager, MarketManager marketManager,
-                         MarketListingDAO listingDAO, MarketBrowseGUI browseGUI, MyListingsGUI myListingsGUI) {
+                         MarketListingDAO listingDAO, MarketBuyOrderDAO buyOrderDAO,
+                         MarketBrowseGUI browseGUI, MyListingsGUI myListingsGUI,
+                         BuyOrderBrowseGUI buyOrderBrowseGUI, MyBuyOrdersGUI myBuyOrdersGUI) {
         this.configManager = configManager;
         this.marketManager = marketManager;
         this.listingDAO = listingDAO;
+        this.buyOrderDAO = buyOrderDAO;
         this.browseGUI = browseGUI;
         this.myListingsGUI = myListingsGUI;
+        this.buyOrderBrowseGUI = buyOrderBrowseGUI;
+        this.myBuyOrdersGUI = myBuyOrdersGUI;
     }
 
     @Override
@@ -82,6 +100,16 @@ public class MarketCommand implements CommandExecutor, TabCompleter {
                 return handleReclaim(player, args, true);
             case "reclaim":
                 return handleReclaim(player, args, false);
+            case "buy":
+                return handleBuy(player, args);
+            case "requests":
+                return handleRequests(player);
+            case "myrequests":
+                return handleMyRequests(player);
+            case "cancelrequest":
+                return handleRequestAction(player, args, true);
+            case "reclaimrequest":
+                return handleRequestAction(player, args, false);
             case "reload":
                 return handleReload(player);
             case "help":
@@ -165,6 +193,119 @@ public class MarketCommand implements CommandExecutor, TabCompleter {
         return true;
     }
 
+    // ====================================================================
+    // 買い注文（募集）サブコマンド
+    // ====================================================================
+
+    private boolean handleRequests(Player player) {
+        if (!player.hasPermission(PERM_USE)) {
+            player.sendMessage(configManager.getMessage("no_permission"));
+            return true;
+        }
+        buyOrderBrowseGUI.open(player);
+        return true;
+    }
+
+    private boolean handleMyRequests(Player player) {
+        if (!player.hasPermission(PERM_USE)) {
+            player.sendMessage(configManager.getMessage("no_permission"));
+            return true;
+        }
+        myBuyOrdersGUI.open(player);
+        return true;
+    }
+
+    private boolean handleBuy(Player player, String[] args) {
+        if (!player.hasPermission(PERM_BUY)) {
+            player.sendMessage(configManager.getMessage("no_permission"));
+            return true;
+        }
+        if (args.length < 4) {
+            player.sendMessage("§e使い方: §f/market buy <material> <個数> <価格>");
+            return true;
+        }
+
+        Material material = Material.matchMaterial(args[1].toUpperCase());
+        if (material == null || material == Material.AIR) {
+            player.sendMessage(configManager.getMarketMessage("invalid_item"));
+            return true;
+        }
+
+        int amount;
+        double price;
+        try {
+            amount = Integer.parseInt(args[2]);
+            price = Double.parseDouble(args[3]);
+        } catch (NumberFormatException e) {
+            player.sendMessage("§c個数と価格は数値で指定してください。");
+            return true;
+        }
+        if (amount <= 0) {
+            player.sendMessage(configManager.getMarketMessage("invalid_item"));
+            return true;
+        }
+
+        MarketResult result = marketManager.createBuyOrder(player, material, amount, price);
+        sendBuyOrderMessage(player, result, MarketGUIUtil.prettifyMaterial(material.name()), amount, price);
+        return true;
+    }
+
+    private boolean handleRequestAction(Player player, String[] args, boolean cancel) {
+        if (!player.hasPermission(PERM_USE)) {
+            player.sendMessage(configManager.getMessage("no_permission"));
+            return true;
+        }
+        if (args.length < 2) {
+            player.sendMessage("§e使い方: §f/market " + (cancel ? "cancelrequest" : "reclaimrequest") + " <ID>");
+            return true;
+        }
+
+        int orderId;
+        try {
+            orderId = Integer.parseInt(args[1]);
+        } catch (NumberFormatException e) {
+            player.sendMessage("§cIDは数値で指定してください。");
+            return true;
+        }
+
+        // メッセージのプレースホルダ用に注文情報を先に取得（無くても続行）
+        String item = "";
+        int amount = 0;
+        double price = 0;
+        try {
+            MarketBuyOrder order = buyOrderDAO.getById(orderId);
+            if (order != null) {
+                item = MarketGUIUtil.prettifyMaterial(order.getMaterial());
+                amount = order.getAmount();
+                price = order.getPrice();
+            }
+        } catch (SQLException ignored) {
+            // 取得失敗時はプレースホルダ空のまま続行
+        }
+
+        MarketResult result = cancel
+                ? marketManager.cancelBuyOrder(player, orderId)
+                : marketManager.reclaimBuyOrder(player, orderId);
+        sendBuyOrderMessage(player, result, item, amount, price);
+        return true;
+    }
+
+    /**
+     * 買い注文（募集）系の結果メッセージを、関連プレースホルダを埋めて送信する。
+     * 未使用のプレースホルダはメッセージ側で無視される。
+     */
+    private void sendBuyOrderMessage(Player player, MarketResult result, String item, int amount, double price) {
+        player.sendMessage(configManager.getMarketMessage(result.getMessageKey(),
+                "item", item != null ? item : "",
+                "amount", String.valueOf(amount),
+                "price", MarketGUIUtil.formatPrice(price),
+                "proceeds", String.valueOf(marketManager.calculateSellerProceeds(price)),
+                "currency", configManager.getCurrencyName(),
+                "min", String.valueOf((long) configManager.getMarketMinPrice()),
+                "max", String.valueOf((long) configManager.getMarketMaxPrice()),
+                "limit", String.valueOf(configManager.getMarketMaxBuyOrdersPerPlayer())));
+    }
+
     private boolean handleReload(Player player) {
         if (!player.hasPermission(PERM_ADMIN)) {
             player.sendMessage(configManager.getMessage("no_permission"));
@@ -177,11 +318,18 @@ public class MarketCommand implements CommandExecutor, TabCompleter {
 
     private void sendUsage(Player player) {
         player.sendMessage("§6=== マーケットコマンド ===");
+        player.sendMessage("§b▼ 売り");
         player.sendMessage("§e/market §7- 出品一覧を開く");
         player.sendMessage("§e/market sell <価格> §7- 手持ちアイテムを出品");
         player.sendMessage("§e/market mylistings §7- 自分の出品を管理");
         player.sendMessage("§e/market cancel <ID> §7- 出品をキャンセルして回収");
         player.sendMessage("§e/market reclaim <ID> §7- 期限切れの出品を回収");
+        player.sendMessage("§b▼ 募集（買い注文）");
+        player.sendMessage("§e/market buy <material> <個数> <価格> §7- 募集を登録（前払い）");
+        player.sendMessage("§e/market requests §7- 募集一覧を開く");
+        player.sendMessage("§e/market myrequests §7- 自分の募集を管理");
+        player.sendMessage("§e/market cancelrequest <ID> §7- 募集をキャンセルして返金");
+        player.sendMessage("§e/market reclaimrequest <ID> §7- 成立した募集のアイテムを回収");
         if (player.hasPermission(PERM_ADMIN)) {
             player.sendMessage("§e/market reload §7- 設定を再読み込み（管理者）");
         }
@@ -192,7 +340,9 @@ public class MarketCommand implements CommandExecutor, TabCompleter {
         List<String> completions = new ArrayList<>();
 
         if (args.length == 1) {
-            List<String> subs = new ArrayList<>(Arrays.asList("sell", "mylistings", "cancel", "reclaim", "help"));
+            List<String> subs = new ArrayList<>(Arrays.asList(
+                    "sell", "mylistings", "cancel", "reclaim",
+                    "buy", "requests", "myrequests", "cancelrequest", "reclaimrequest", "help"));
             if (sender.hasPermission(PERM_ADMIN)) {
                 subs.add("reload");
             }
@@ -206,13 +356,42 @@ public class MarketCommand implements CommandExecutor, TabCompleter {
         }
 
         if (args.length == 2 && sender instanceof Player) {
+            Player player = (Player) sender;
             String sub = args[0].toLowerCase();
             if (sub.equals("cancel") || sub.equals("reclaim")) {
-                completions.addAll(suggestListingIds((Player) sender, sub.equals("cancel")));
+                completions.addAll(suggestListingIds(player, sub.equals("cancel")));
+            } else if (sub.equals("cancelrequest") || sub.equals("reclaimrequest")) {
+                completions.addAll(suggestBuyOrderIds(player, sub.equals("cancelrequest")));
+            } else if (sub.equals("buy")) {
+                // 第2引数（material）は手持ちアイテムの Material 名を候補として提示
+                ItemStack inHand = player.getInventory().getItemInMainHand();
+                if (inHand != null && inHand.getType() != Material.AIR) {
+                    completions.add(inHand.getType().name());
+                }
             }
         }
 
         return completions;
+    }
+
+    /**
+     * 自分の募集のうち、操作可能な status の ID を補完候補として返す。
+     *
+     * @param openOnly true なら open（cancelrequest 用）、false なら fulfilled（reclaimrequest 用）
+     */
+    private List<String> suggestBuyOrderIds(Player player, boolean openOnly) {
+        List<String> ids = new ArrayList<>();
+        try {
+            for (MarketBuyOrder order : buyOrderDAO.getOrdersByRequester(player.getUniqueId())) {
+                boolean match = openOnly ? order.isOpen() : order.isFulfilled();
+                if (match) {
+                    ids.add(String.valueOf(order.getId()));
+                }
+            }
+        } catch (SQLException ignored) {
+            // 補完失敗時は候補なしで返す
+        }
+        return ids;
     }
 
     /**

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -337,7 +337,48 @@ public class ConfigManager {
     public double getMaxDeposit() {
         return config.getDouble("economy.withdraw_deposit.max_deposit", 10000.0);
     }
-    
+
+    // ========== プレイヤー間マーケット設定 ==========
+
+    public boolean isMarketEnabled() {
+        return config.getBoolean("market.enabled", true);
+    }
+
+    public double getMarketFeeRate() {
+        return config.getDouble("market.fee_rate", 0.05);
+    }
+
+    public int getMarketMaxListingsPerPlayer() {
+        return config.getInt("market.max_listings_per_player", 10);
+    }
+
+    public int getMarketListingDurationDays() {
+        return config.getInt("market.listing_duration_days", 7);
+    }
+
+    public double getMarketMinPrice() {
+        return config.getDouble("market.min_price", 1);
+    }
+
+    public double getMarketMaxPrice() {
+        return config.getDouble("market.max_price", 1000000);
+    }
+
+    public boolean isMarketAllowSelfPurchase() {
+        return config.getBoolean("market.allow_self_purchase", false);
+    }
+
+    public int getMarketExpireCheckInterval() {
+        return config.getInt("market.expire_check_interval", 3600);
+    }
+
+    /**
+     * messages.market 配下のメッセージを取得（プレースホルダ置換対応）
+     */
+    public String getMarketMessage(String key, Object... replacements) {
+        return getMessage("market." + key, replacements);
+    }
+
     // 職業設定
     public int getMaxJobsPerPlayer() {
         return config.getInt("jobs.general.max_jobs_per_player", 1);

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -372,6 +372,10 @@ public class ConfigManager {
         return config.getInt("market.expire_check_interval", 3600);
     }
 
+    public int getMarketMaxBuyOrdersPerPlayer() {
+        return config.getInt("market.max_buy_orders_per_player", 10);
+    }
+
     /**
      * messages.market 配下のメッセージを取得（プレースホルダ置換対応）
      */

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -2504,6 +2504,47 @@ public class ConfigManager {
     }
     
     /**
+     * プレイヤー間マーケット（売り・募集）のメッセージの存在を確認し、不足分を自動追加する。
+     *
+     * jar 同梱の config.yml は既存のサーバー config.yml を上書きしないため、新規メッセージキーは
+     * このメソッドで起動時に補完する（既存キーは {@code config.contains} で skip される）。
+     */
+    public void ensureMarketMessagesExist() {
+        try {
+            // 売り（出品・購入）
+            ensureMessagePath("messages.market.listed", "&a%item% を &e%price% %currency%&a で出品しました。");
+            ensureMessagePath("messages.market.purchased", "&a%item% を &e%price% %currency%&a で購入しました。");
+            ensureMessagePath("messages.market.sold_notify", "&a出品した %item% が売れました！手数料を引いた &e%amount% %currency%&a を受け取りました。");
+            ensureMessagePath("messages.market.cancelled", "&a出品をキャンセルし、アイテムを回収しました。");
+            ensureMessagePath("messages.market.reclaimed", "&a期限切れの出品からアイテムを回収しました。");
+            ensureMessagePath("messages.market.invalid_item", "&c出品するアイテムを手に持ってください。");
+            ensureMessagePath("messages.market.invalid_price", "&c価格は &e%min%&c 〜 &e%max%&c の整数で指定してください。");
+            ensureMessagePath("messages.market.currency_not_allowed", "&c通貨アイテムは出品できません。");
+            ensureMessagePath("messages.market.listing_limit", "&c出品数の上限（%limit%）に達しています。");
+            ensureMessagePath("messages.market.not_available", "&cこの出品は購入できません。");
+            ensureMessagePath("messages.market.already_sold", "&cこの出品は既に売り切れました。");
+            ensureMessagePath("messages.market.insufficient_funds", "&c残高が不足しています。");
+            ensureMessagePath("messages.market.inventory_full", "&cインベントリに空きがありません。アイテムを整理してください。");
+            ensureMessagePath("messages.market.not_owner", "&cこれはあなたの出品ではありません。");
+            ensureMessagePath("messages.market.error", "&c処理中にエラーが発生しました。もう一度お試しください。");
+
+            // 募集（買い注文）
+            ensureMessagePath("messages.market.requested", "&a%item% x%amount% の募集を &e%price% %currency%&a で登録しました（前払い）。");
+            ensureMessagePath("messages.market.fulfilled", "&a募集に応じ %item% x%amount% を供給しました。&e%proceeds% %currency%&a を受け取りました。");
+            ensureMessagePath("messages.market.fulfilled_notify", "&aあなたの募集（%item% x%amount%）が成立しました。アイテムは /market myrequests から回収できます。");
+            ensureMessagePath("messages.market.request_cancelled", "&a募集をキャンセルし、前払い分を返金しました。");
+            ensureMessagePath("messages.market.request_reclaimed", "&a成立した募集からアイテムを回収しました。");
+            ensureMessagePath("messages.market.request_expired_refund", "&e募集が期限切れになり、前払い分を返金しました。");
+            ensureMessagePath("messages.market.request_limit", "&c募集数の上限（%limit%）に達しています。");
+            ensureMessagePath("messages.market.no_matching_item", "&c供給するアイテム（%item% x%amount%）を所持していません。");
+            ensureMessagePath("messages.market.request_not_available", "&cこの募集は既に成立済みか、存在しません。");
+            ensureMessagePath("messages.market.request_not_owner", "&cこれはあなたの募集ではありません。");
+        } catch (Exception e) {
+            plugin.getLogger().warning("マーケットメッセージの初期化に失敗しました: " + e.getMessage());
+        }
+    }
+
+    /**
      * NPCメッセージの存在を確認し、不足している場合は自動追加
      */
     public void ensureNPCMessagesExist() {

--- a/src/main/java/org/tofu/tofunomics/dao/MarketBuyOrderDAO.java
+++ b/src/main/java/org/tofu/tofunomics/dao/MarketBuyOrderDAO.java
@@ -1,0 +1,221 @@
+package org.tofu.tofunomics.dao;
+
+import org.tofu.tofunomics.models.MarketBuyOrder;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * プレイヤー間マーケット買い注文（募集）のデータアクセスオブジェクト
+ *
+ * 売り出品の {@link MarketListingDAO} の鏡像。
+ * expires_at は epoch millis（INTEGER）で保持し、期限判定は数値比較で行う。
+ */
+public class MarketBuyOrderDAO {
+    private final Connection connection;
+
+    public MarketBuyOrderDAO(Connection connection) {
+        this.connection = connection;
+    }
+
+    /**
+     * 募集を新規作成し、生成された id を返す。
+     * listed_at は DB 側の DEFAULT CURRENT_TIMESTAMP に委ねる。
+     */
+    public int insertBuyOrder(MarketBuyOrder order) throws SQLException {
+        String query = "INSERT INTO market_buy_orders " +
+                "(requester_uuid, requester_name, material, amount, price, status, expires_at) " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?)";
+
+        try (PreparedStatement statement = connection.prepareStatement(query, Statement.RETURN_GENERATED_KEYS)) {
+            statement.setString(1, order.getRequesterUuid().toString());
+            statement.setString(2, order.getRequesterName());
+            statement.setString(3, order.getMaterial());
+            statement.setInt(4, order.getAmount());
+            statement.setDouble(5, order.getPrice());
+            statement.setString(6, order.getStatus() != null ? order.getStatus() : MarketBuyOrder.STATUS_OPEN);
+            if (order.getExpiresAtMillis() != null) {
+                statement.setLong(7, order.getExpiresAtMillis());
+            } else {
+                statement.setNull(7, Types.BIGINT);
+            }
+
+            statement.executeUpdate();
+
+            try (ResultSet generatedKeys = statement.getGeneratedKeys()) {
+                if (generatedKeys.next()) {
+                    int id = generatedKeys.getInt(1);
+                    order.setId(id);
+                    return id;
+                }
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * id で募集を取得
+     */
+    public MarketBuyOrder getById(int id) throws SQLException {
+        String query = "SELECT * FROM market_buy_orders WHERE id = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setInt(1, id);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    return mapResultSet(rs);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 募集中（open）の全募集を新しい順で取得（GUI 一覧用）
+     */
+    public List<MarketBuyOrder> getOpenOrders() throws SQLException {
+        String query = "SELECT * FROM market_buy_orders WHERE status = ? ORDER BY listed_at DESC, id DESC";
+        List<MarketBuyOrder> orders = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, MarketBuyOrder.STATUS_OPEN);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    orders.add(mapResultSet(rs));
+                }
+            }
+        }
+        return orders;
+    }
+
+    /**
+     * 指定募集者の全募集（status 問わず）を新しい順で取得（myrequests 用）
+     */
+    public List<MarketBuyOrder> getOrdersByRequester(UUID requesterUuid) throws SQLException {
+        String query = "SELECT * FROM market_buy_orders WHERE requester_uuid = ? ORDER BY listed_at DESC, id DESC";
+        List<MarketBuyOrder> orders = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, requesterUuid.toString());
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    orders.add(mapResultSet(rs));
+                }
+            }
+        }
+        return orders;
+    }
+
+    /**
+     * 指定募集者の open 募集数をカウント（募集上限チェック用）
+     */
+    public int countOpenByRequester(UUID requesterUuid) throws SQLException {
+        String query = "SELECT COUNT(*) FROM market_buy_orders WHERE requester_uuid = ? AND status = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, requesterUuid.toString());
+            statement.setString(2, MarketBuyOrder.STATUS_OPEN);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getInt(1);
+                }
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * 期限切れの open 募集を取得（期限切れ返金処理用）。
+     * 買い注文の期限切れは返金を伴うため、一括 UPDATE ではなく取得 → ループ処理にする。
+     * @param nowMillis 現在時刻（epoch millis）
+     */
+    public List<MarketBuyOrder> getExpiredOpenOrders(long nowMillis) throws SQLException {
+        String query = "SELECT * FROM market_buy_orders " +
+                "WHERE status = ? AND expires_at IS NOT NULL AND expires_at <= ?";
+        List<MarketBuyOrder> orders = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, MarketBuyOrder.STATUS_OPEN);
+            statement.setLong(2, nowMillis);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    orders.add(mapResultSet(rs));
+                }
+            }
+        }
+        return orders;
+    }
+
+    /**
+     * 募集を供給成立（fulfilled）にする（楽観ロック）。
+     * status='open' の行のみを対象とし、影響行数が 1 のときだけ成功とする。
+     * これにより、同一募集への同時供給（二重供給）を防止する。
+     *
+     * @param id 募集 id
+     * @param supplierUuid 供給者 UUID
+     * @param itemData 供給されたアイテム（Base64）
+     * @param fulfilledAtMillis 成立時刻（epoch millis）
+     * @return 成立処理に成功した場合 true（影響行数 == 1）
+     */
+    public boolean markAsFulfilled(int id, UUID supplierUuid, String itemData, long fulfilledAtMillis) throws SQLException {
+        String query = "UPDATE market_buy_orders SET status = ?, supplier_uuid = ?, item_data = ?, fulfilled_at = ? " +
+                "WHERE id = ? AND status = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, MarketBuyOrder.STATUS_FULFILLED);
+            statement.setString(2, supplierUuid.toString());
+            statement.setString(3, itemData);
+            statement.setTimestamp(4, new Timestamp(fulfilledAtMillis));
+            statement.setInt(5, id);
+            statement.setString(6, MarketBuyOrder.STATUS_OPEN);
+            return statement.executeUpdate() == 1;
+        }
+    }
+
+    /**
+     * 募集のステータスを条件付きで更新する（楽観ロック）。
+     * 現在のステータスが expectedStatus の行のみを newStatus に更新し、
+     * 影響行数が 1 のときだけ成功とする。
+     *
+     * cancel（open → cancelled）/ reclaim（fulfilled → reclaimed）/
+     * expire（open → expired）に用いる。
+     *
+     * @return 更新に成功した場合 true（影響行数 == 1）
+     */
+    public boolean updateStatusConditional(int id, String expectedStatus, String newStatus) throws SQLException {
+        String query = "UPDATE market_buy_orders SET status = ? WHERE id = ? AND status = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, newStatus);
+            statement.setInt(2, id);
+            statement.setString(3, expectedStatus);
+            return statement.executeUpdate() == 1;
+        }
+    }
+
+    /**
+     * ResultSet から MarketBuyOrder にマッピング
+     */
+    private MarketBuyOrder mapResultSet(ResultSet rs) throws SQLException {
+        MarketBuyOrder order = new MarketBuyOrder();
+        order.setId(rs.getInt("id"));
+        order.setRequesterUuid(UUID.fromString(rs.getString("requester_uuid")));
+        order.setRequesterName(rs.getString("requester_name"));
+        order.setMaterial(rs.getString("material"));
+        order.setAmount(rs.getInt("amount"));
+        order.setPrice(rs.getDouble("price"));
+        order.setStatus(rs.getString("status"));
+
+        String supplierUuid = rs.getString("supplier_uuid");
+        if (supplierUuid != null) {
+            order.setSupplierUuid(UUID.fromString(supplierUuid));
+        }
+
+        order.setItemData(rs.getString("item_data"));
+        order.setListedAt(rs.getTimestamp("listed_at"));
+
+        long expiresAt = rs.getLong("expires_at");
+        if (!rs.wasNull()) {
+            order.setExpiresAtMillis(expiresAt);
+        }
+
+        order.setFulfilledAt(rs.getTimestamp("fulfilled_at"));
+
+        return order;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/dao/MarketListingDAO.java
+++ b/src/main/java/org/tofu/tofunomics/dao/MarketListingDAO.java
@@ -1,0 +1,233 @@
+package org.tofu.tofunomics.dao;
+
+import org.tofu.tofunomics.models.MarketListing;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * プレイヤー間マーケット出品のデータアクセスオブジェクト
+ *
+ * expires_at は epoch millis（INTEGER）で保持し、期限判定は数値比較で行う
+ * （CURRENT_TIMESTAMP との文字列比較によるフォーマット依存を避けるため）。
+ */
+public class MarketListingDAO {
+    private final Connection connection;
+
+    public MarketListingDAO(Connection connection) {
+        this.connection = connection;
+    }
+
+    /**
+     * 出品を新規作成し、生成された id を返す。
+     * listed_at は DB 側の DEFAULT CURRENT_TIMESTAMP に委ねる。
+     */
+    public int insertListing(MarketListing listing) throws SQLException {
+        String query = "INSERT INTO market_listings " +
+                "(seller_uuid, seller_name, item_data, display_name, material, amount, price, status, expires_at) " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+        try (PreparedStatement statement = connection.prepareStatement(query, Statement.RETURN_GENERATED_KEYS)) {
+            statement.setString(1, listing.getSellerUuid().toString());
+            statement.setString(2, listing.getSellerName());
+            statement.setString(3, listing.getItemData());
+            statement.setString(4, listing.getDisplayName());
+            statement.setString(5, listing.getMaterial());
+            statement.setInt(6, listing.getAmount());
+            statement.setDouble(7, listing.getPrice());
+            statement.setString(8, listing.getStatus() != null ? listing.getStatus() : MarketListing.STATUS_ACTIVE);
+            if (listing.getExpiresAtMillis() != null) {
+                statement.setLong(9, listing.getExpiresAtMillis());
+            } else {
+                statement.setNull(9, Types.BIGINT);
+            }
+
+            statement.executeUpdate();
+
+            try (ResultSet generatedKeys = statement.getGeneratedKeys()) {
+                if (generatedKeys.next()) {
+                    int id = generatedKeys.getInt(1);
+                    listing.setId(id);
+                    return id;
+                }
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * id で出品を取得
+     */
+    public MarketListing getById(int id) throws SQLException {
+        String query = "SELECT * FROM market_listings WHERE id = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setInt(1, id);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    return mapResultSet(rs);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 出品中（active）の全出品を新しい順で取得（GUI 一覧用）
+     */
+    public List<MarketListing> getActiveListings() throws SQLException {
+        String query = "SELECT * FROM market_listings WHERE status = ? ORDER BY listed_at DESC, id DESC";
+        List<MarketListing> listings = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, MarketListing.STATUS_ACTIVE);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    listings.add(mapResultSet(rs));
+                }
+            }
+        }
+        return listings;
+    }
+
+    /**
+     * 指定出品者の全出品（status 問わず）を新しい順で取得（mylistings 用）
+     */
+    public List<MarketListing> getListingsBySeller(UUID sellerUuid) throws SQLException {
+        String query = "SELECT * FROM market_listings WHERE seller_uuid = ? ORDER BY listed_at DESC, id DESC";
+        List<MarketListing> listings = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, sellerUuid.toString());
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    listings.add(mapResultSet(rs));
+                }
+            }
+        }
+        return listings;
+    }
+
+    /**
+     * 指定出品者の active 出品数をカウント（出品上限チェック用）
+     */
+    public int countActiveBySeller(UUID sellerUuid) throws SQLException {
+        String query = "SELECT COUNT(*) FROM market_listings WHERE seller_uuid = ? AND status = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, sellerUuid.toString());
+            statement.setString(2, MarketListing.STATUS_ACTIVE);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getInt(1);
+                }
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * 期限切れの active 出品を取得（参照・テスト用）。
+     * @param nowMillis 現在時刻（epoch millis）
+     */
+    public List<MarketListing> getExpiredActiveListings(long nowMillis) throws SQLException {
+        String query = "SELECT * FROM market_listings " +
+                "WHERE status = ? AND expires_at IS NOT NULL AND expires_at <= ?";
+        List<MarketListing> listings = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, MarketListing.STATUS_ACTIVE);
+            statement.setLong(2, nowMillis);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    listings.add(mapResultSet(rs));
+                }
+            }
+        }
+        return listings;
+    }
+
+    /**
+     * 期限切れの active 出品を一括で expired 化する。
+     * @param nowMillis 現在時刻（epoch millis）
+     * @return 期限切れ化した件数
+     */
+    public int expireActiveListings(long nowMillis) throws SQLException {
+        String query = "UPDATE market_listings SET status = ? " +
+                "WHERE status = ? AND expires_at IS NOT NULL AND expires_at <= ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, MarketListing.STATUS_EXPIRED);
+            statement.setString(2, MarketListing.STATUS_ACTIVE);
+            statement.setLong(3, nowMillis);
+            return statement.executeUpdate();
+        }
+    }
+
+    /**
+     * 出品を売却済みにする（楽観ロック）。
+     * status='active' の行のみを対象とし、影響行数が 1 のときだけ成功とする。
+     * これにより、同一出品への同時購入（二重購入）を防止する。
+     *
+     * @return 売却処理に成功した場合 true（影響行数 == 1）
+     */
+    public boolean markAsSold(int id, UUID buyerUuid, long soldAtMillis) throws SQLException {
+        String query = "UPDATE market_listings SET status = ?, buyer_uuid = ?, sold_at = ? " +
+                "WHERE id = ? AND status = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, MarketListing.STATUS_SOLD);
+            statement.setString(2, buyerUuid.toString());
+            statement.setTimestamp(3, new Timestamp(soldAtMillis));
+            statement.setInt(4, id);
+            statement.setString(5, MarketListing.STATUS_ACTIVE);
+            return statement.executeUpdate() == 1;
+        }
+    }
+
+    /**
+     * 出品のステータスを条件付きで更新する（楽観ロック）。
+     * 現在のステータスが expectedStatus の行のみを newStatus に更新し、
+     * 影響行数が 1 のときだけ成功とする。
+     *
+     * cancel（active → reclaimed）/ reclaim（expired → reclaimed）に用いる。
+     *
+     * @return 更新に成功した場合 true（影響行数 == 1）
+     */
+    public boolean updateStatusConditional(int id, String expectedStatus, String newStatus) throws SQLException {
+        String query = "UPDATE market_listings SET status = ? WHERE id = ? AND status = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, newStatus);
+            statement.setInt(2, id);
+            statement.setString(3, expectedStatus);
+            return statement.executeUpdate() == 1;
+        }
+    }
+
+    /**
+     * ResultSet から MarketListing にマッピング
+     */
+    private MarketListing mapResultSet(ResultSet rs) throws SQLException {
+        MarketListing listing = new MarketListing();
+        listing.setId(rs.getInt("id"));
+        listing.setSellerUuid(UUID.fromString(rs.getString("seller_uuid")));
+        listing.setSellerName(rs.getString("seller_name"));
+        listing.setItemData(rs.getString("item_data"));
+        listing.setDisplayName(rs.getString("display_name"));
+        listing.setMaterial(rs.getString("material"));
+        listing.setAmount(rs.getInt("amount"));
+        listing.setPrice(rs.getDouble("price"));
+        listing.setStatus(rs.getString("status"));
+
+        String buyerUuid = rs.getString("buyer_uuid");
+        if (buyerUuid != null) {
+            listing.setBuyerUuid(UUID.fromString(buyerUuid));
+        }
+
+        listing.setListedAt(rs.getTimestamp("listed_at"));
+
+        long expiresAt = rs.getLong("expires_at");
+        if (!rs.wasNull()) {
+            listing.setExpiresAtMillis(expiresAt);
+        }
+
+        listing.setSoldAt(rs.getTimestamp("sold_at"));
+
+        return listing;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/database/DatabaseManager.java
+++ b/src/main/java/org/tofu/tofunomics/database/DatabaseManager.java
@@ -227,6 +227,24 @@ public class DatabaseManager {
             "    offhand_data TEXT," +
             "    last_saved TIMESTAMP DEFAULT CURRENT_TIMESTAMP," +
             "    FOREIGN KEY (player_uuid) REFERENCES players(uuid) ON DELETE CASCADE" +
+            ");",
+
+            // プレイヤー間マーケット出品テーブル
+            "CREATE TABLE IF NOT EXISTS market_listings (" +
+            "    id INTEGER PRIMARY KEY AUTOINCREMENT," +
+            "    seller_uuid TEXT NOT NULL," +
+            "    seller_name TEXT NOT NULL," +
+            "    item_data TEXT NOT NULL," +
+            "    display_name TEXT," +
+            "    material TEXT NOT NULL," +
+            "    amount INTEGER NOT NULL," +
+            "    price REAL NOT NULL," +
+            "    status TEXT NOT NULL DEFAULT 'active'," +
+            "    buyer_uuid TEXT," +
+            "    listed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+            "    expires_at INTEGER," +
+            "    sold_at TIMESTAMP," +
+            "    FOREIGN KEY (seller_uuid) REFERENCES players(uuid) ON DELETE CASCADE" +
             ");"
         };
 
@@ -364,6 +382,11 @@ public class DatabaseManager {
             // 期限切れ検索高速化用インデックス（存在しなければ作成）
             statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_housing_rentals_end_tick ON housing_rentals(end_tick)");
             statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_housing_rentals_status_end_tick ON housing_rentals(status, end_tick)");
+
+            // マーケット出品検索高速化用インデックス（存在しなければ作成）
+            statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_market_status ON market_listings(status)");
+            statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_market_seller ON market_listings(seller_uuid, status)");
+            statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_market_expires ON market_listings(status, expires_at)");
         } catch (SQLException e) {
             logger.warning("マイグレーション処理に失敗しました: " + e.getMessage());
         }

--- a/src/main/java/org/tofu/tofunomics/database/DatabaseManager.java
+++ b/src/main/java/org/tofu/tofunomics/database/DatabaseManager.java
@@ -245,6 +245,23 @@ public class DatabaseManager {
             "    expires_at INTEGER," +
             "    sold_at TIMESTAMP," +
             "    FOREIGN KEY (seller_uuid) REFERENCES players(uuid) ON DELETE CASCADE" +
+            ");",
+
+            // プレイヤー間マーケット買い注文（募集）テーブル
+            "CREATE TABLE IF NOT EXISTS market_buy_orders (" +
+            "    id INTEGER PRIMARY KEY AUTOINCREMENT," +
+            "    requester_uuid TEXT NOT NULL," +
+            "    requester_name TEXT NOT NULL," +
+            "    material TEXT NOT NULL," +
+            "    amount INTEGER NOT NULL," +
+            "    price REAL NOT NULL," +
+            "    status TEXT NOT NULL DEFAULT 'open'," +
+            "    supplier_uuid TEXT," +
+            "    item_data TEXT," +
+            "    listed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+            "    expires_at INTEGER," +
+            "    fulfilled_at TIMESTAMP," +
+            "    FOREIGN KEY (requester_uuid) REFERENCES players(uuid) ON DELETE CASCADE" +
             ");"
         };
 
@@ -387,6 +404,11 @@ public class DatabaseManager {
             statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_market_status ON market_listings(status)");
             statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_market_seller ON market_listings(seller_uuid, status)");
             statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_market_expires ON market_listings(status, expires_at)");
+
+            // マーケット買い注文（募集）検索高速化用インデックス（存在しなければ作成）
+            statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_buyorder_status ON market_buy_orders(status)");
+            statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_buyorder_requester ON market_buy_orders(requester_uuid, status)");
+            statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_buyorder_expires ON market_buy_orders(status, expires_at)");
         } catch (SQLException e) {
             logger.warning("マイグレーション処理に失敗しました: " + e.getMessage());
         }

--- a/src/main/java/org/tofu/tofunomics/market/FulfillOutcome.java
+++ b/src/main/java/org/tofu/tofunomics/market/FulfillOutcome.java
@@ -1,0 +1,53 @@
+package org.tofu.tofunomics.market;
+
+import java.util.UUID;
+
+/**
+ * 買い注文（募集）への供給決済（DB トランザクション）の結果を表す。
+ *
+ * {@code MarketManager.executeFulfillTransaction} が返し、ラッパー
+ * {@code fulfillBuyOrder} が供給者への結果表示・募集者への通知に付帯情報
+ * （requesterUuid/supplierProceeds）を用いる。
+ */
+public class FulfillOutcome {
+
+    private final MarketResult result;
+    private final UUID requesterUuid;     // 募集者（成立時の通知用）
+    private final long supplierProceeds;  // 供給者の受取額（手数料控除後・floor）
+
+    private FulfillOutcome(MarketResult result, UUID requesterUuid, long supplierProceeds) {
+        this.result = result;
+        this.requesterUuid = requesterUuid;
+        this.supplierProceeds = supplierProceeds;
+    }
+
+    /**
+     * 失敗結果（付帯情報なし）
+     */
+    public static FulfillOutcome failure(MarketResult result) {
+        return new FulfillOutcome(result, null, 0L);
+    }
+
+    /**
+     * 供給成立結果
+     */
+    public static FulfillOutcome success(UUID requesterUuid, long supplierProceeds) {
+        return new FulfillOutcome(MarketResult.FULFILLED, requesterUuid, supplierProceeds);
+    }
+
+    public MarketResult getResult() {
+        return result;
+    }
+
+    public boolean isSuccess() {
+        return result == MarketResult.FULFILLED;
+    }
+
+    public UUID getRequesterUuid() {
+        return requesterUuid;
+    }
+
+    public long getSupplierProceeds() {
+        return supplierProceeds;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/MarketExpirationTask.java
+++ b/src/main/java/org/tofu/tofunomics/market/MarketExpirationTask.java
@@ -1,0 +1,36 @@
+package org.tofu.tofunomics.market;
+
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.logging.Logger;
+
+/**
+ * 期限切れ出品を定期的に expired 化するタスク。
+ *
+ * {@code MarketExpirationTask#runTaskTimer(plugin, 0L, intervalTicks)} で起動する。
+ * 実処理は {@link MarketManager#expireListings()} に委譲し、内部で
+ * {@code synchronized(connection)} により共有 Connection の競合を防いでいる。
+ */
+public class MarketExpirationTask extends BukkitRunnable {
+
+    private final MarketManager marketManager;
+    private final Logger logger;
+
+    public MarketExpirationTask(MarketManager marketManager, Logger logger) {
+        this.marketManager = marketManager;
+        this.logger = logger;
+    }
+
+    @Override
+    public void run() {
+        try {
+            int expired = marketManager.expireListings();
+            if (expired > 0) {
+                logger.info("マーケット: 期限切れ出品を " + expired + " 件 expired 化しました。");
+            }
+        } catch (Exception e) {
+            // タスクが例外で停止しないように握りつぶしてログのみ
+            logger.warning("マーケット期限切れタスクの実行中にエラーが発生しました: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/MarketExpirationTask.java
+++ b/src/main/java/org/tofu/tofunomics/market/MarketExpirationTask.java
@@ -28,6 +28,12 @@ public class MarketExpirationTask extends BukkitRunnable {
             if (expired > 0) {
                 logger.info("マーケット: 期限切れ出品を " + expired + " 件 expired 化しました。");
             }
+
+            // 買い注文（募集）の期限切れ：前払い分を募集者の bank へ返金しつつ expired 化
+            int refunded = marketManager.expireBuyOrders();
+            if (refunded > 0) {
+                logger.info("マーケット: 期限切れ募集を " + refunded + " 件 返金・expired 化しました。");
+            }
         } catch (Exception e) {
             // タスクが例外で停止しないように握りつぶしてログのみ
             logger.warning("マーケット期限切れタスクの実行中にエラーが発生しました: " + e.getMessage());

--- a/src/main/java/org/tofu/tofunomics/market/MarketItemSerializer.java
+++ b/src/main/java/org/tofu/tofunomics/market/MarketItemSerializer.java
@@ -1,0 +1,66 @@
+package org.tofu.tofunomics.market;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.io.BukkitObjectInputStream;
+import org.bukkit.util.io.BukkitObjectOutputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+/**
+ * 単一の ItemStack を Base64 文字列に相互変換するユーティリティ。
+ *
+ * {@code PlayerInventoryManager} の単一アイテム変換と同一方式
+ * （{@code BukkitObjectOutputStream}/{@code BukkitObjectInputStream} + Base64）。
+ * YAML ではなくバイナリシリアライズを用いることで、エンチャント・カスタム名・
+ * NBT を含む完全な ItemStack を保持できる。
+ */
+public final class MarketItemSerializer {
+
+    private MarketItemSerializer() {
+    }
+
+    /**
+     * ItemStack を Base64 文字列に変換する。
+     *
+     * @param item 変換対象（null 不可）
+     * @return Base64 文字列。失敗時は null
+     */
+    public static String serialize(ItemStack item) {
+        if (item == null) {
+            return null;
+        }
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             BukkitObjectOutputStream dataOutput = new BukkitObjectOutputStream(outputStream)) {
+
+            dataOutput.writeObject(item);
+            dataOutput.flush();
+            return Base64.getEncoder().encodeToString(outputStream.toByteArray());
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Base64 文字列を ItemStack に変換する。
+     *
+     * @param data Base64 文字列
+     * @return 復元した ItemStack。null/空文字列/不正データの場合は null
+     */
+    public static ItemStack deserialize(String data) {
+        if (data == null || data.isEmpty()) {
+            return null;
+        }
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64.getDecoder().decode(data));
+             BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream)) {
+
+            return (ItemStack) dataInput.readObject();
+        } catch (IOException | ClassNotFoundException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/MarketManager.java
+++ b/src/main/java/org/tofu/tofunomics/market/MarketManager.java
@@ -219,6 +219,23 @@ public class MarketManager {
         }
     }
 
+    /**
+     * 期限切れの active 出品を一括で expired 化する（定期タスクから呼ぶ薄いラッパー）。
+     * 共有 Connection への非同期書き込みとの競合を防ぐため {@code synchronized(connection)} で囲む。
+     *
+     * @return 期限切れ化した件数（失敗時は 0）
+     */
+    public int expireListings() {
+        synchronized (connection) {
+            try {
+                return listingDAO.expireActiveListings(System.currentTimeMillis());
+            } catch (SQLException e) {
+                logger.log(Level.WARNING, "期限切れ出品の一括処理に失敗しました", e);
+                return 0;
+            }
+        }
+    }
+
     // ========================================================================
     // Bukkit 依存のラッパー（コマンド/GUI から呼ぶ）
     // ========================================================================

--- a/src/main/java/org/tofu/tofunomics/market/MarketManager.java
+++ b/src/main/java/org/tofu/tofunomics/market/MarketManager.java
@@ -8,6 +8,7 @@ import org.bukkit.inventory.ItemStack;
 import org.tofu.tofunomics.config.ConfigManager;
 import org.tofu.tofunomics.dao.MarketListingDAO;
 import org.tofu.tofunomics.dao.PlayerDAO;
+import org.tofu.tofunomics.economy.CurrencyConverter;
 import org.tofu.tofunomics.models.MarketListing;
 
 import java.sql.Connection;
@@ -34,14 +35,16 @@ public class MarketManager {
     private final PlayerDAO playerDAO;
     private final MarketListingDAO listingDAO;
     private final ConfigManager configManager;
+    private final CurrencyConverter currencyConverter;
     private final Logger logger;
 
     public MarketManager(Connection connection, PlayerDAO playerDAO, MarketListingDAO listingDAO,
-                         ConfigManager configManager, Logger logger) {
+                         ConfigManager configManager, CurrencyConverter currencyConverter, Logger logger) {
         this.connection = connection;
         this.playerDAO = playerDAO;
         this.listingDAO = listingDAO;
         this.configManager = configManager;
+        this.currencyConverter = currencyConverter;
         this.logger = logger;
     }
 
@@ -112,12 +115,12 @@ public class MarketManager {
     }
 
     /**
-     * 購入決済コア（Bukkit 非依存）。手動トランザクションで楽観ロック・残高移動・手数料を処理する。
+     * 購入決済コア（Bukkit 非依存）。手動トランザクションで楽観ロック・出品者への入金・手数料を処理する。
      *
-     * @param buyerHasInventorySpace 購入者インベントリに空きがあるか（呼び出し側が判定して渡す）
+     * 購入者の支払い（現金回収）は Bukkit 依存のため呼び出し側（{@link #purchaseListing}）が行う。
+     * 本コアは「楽観ロックで sold 化 → 出品者の bank_balance へ手数料控除後を入金」のみを担当する。
      */
-    public PurchaseOutcome executePurchaseTransaction(UUID buyerUuid, int listingId,
-                                                      boolean buyerHasInventorySpace, long nowMillis) {
+    public PurchaseOutcome executePurchaseTransaction(UUID buyerUuid, int listingId, long nowMillis) {
         synchronized (connection) {
             try {
                 connection.setAutoCommit(false);
@@ -136,29 +139,13 @@ public class MarketManager {
                     return PurchaseOutcome.failure(MarketResult.NOT_AVAILABLE);
                 }
 
-                // 残高チェック
-                org.tofu.tofunomics.models.Player buyer = playerDAO.getPlayer(buyerUuid);
-                if (buyer == null || buyer.getBankBalance() < listing.getPrice()) {
-                    connection.rollback();
-                    return PurchaseOutcome.failure(MarketResult.INSUFFICIENT_FUNDS);
-                }
-
-                // インベントリ空きチェック（満杯なら購入させない＝アイテム喪失防止）
-                if (!buyerHasInventorySpace) {
-                    connection.rollback();
-                    return PurchaseOutcome.failure(MarketResult.INVENTORY_FULL);
-                }
-
                 // 楽観ロック：active の行のみ sold 化。影響行数 1 以外は二重購入として中止
                 if (!listingDAO.markAsSold(listingId, buyerUuid, nowMillis)) {
                     connection.rollback();
                     return PurchaseOutcome.failure(MarketResult.ALREADY_SOLD);
                 }
 
-                // 購入者から代金を引き、出品者へ手数料控除後を入金
-                buyer.removeBankBalance(listing.getPrice());
-                playerDAO.updatePlayer(buyer);
-
+                // 出品者へ手数料控除後を入金（オフライン可・UUID 直指定）
                 long proceeds = calculateSellerProceeds(listing.getPrice());
                 org.tofu.tofunomics.models.Player seller = playerDAO.getOrCreatePlayer(sellerUuid);
                 seller.addBankBalance(proceeds);
@@ -274,21 +261,52 @@ public class MarketManager {
     }
 
     /**
-     * 出品を購入する。決済成功後にアイテムを付与し、出品者がオンラインなら通知する。
+     * 出品を購入する。購入者は手持ちの現金（金塊）で支払い、出品者は bank_balance で受け取る。
+     *
+     * 喪失防止のため、先に現金を回収（チェック＋削除を原子的に実行）してから DB 決済を行い、
+     * 決済が失敗した場合は現金を返金する。付与アイテムは {@link #giveItem} が入りきらない分を
+     * 足元へドロップするため、インベントリ満杯でも喪失しない。
      */
     public MarketResult purchaseListing(Player buyer, int listingId) {
         if (!configManager.isMarketEnabled()) {
             return MarketResult.MARKET_DISABLED;
         }
 
-        boolean hasSpace = buyer.getInventory().firstEmpty() != -1;
-        PurchaseOutcome outcome = executePurchaseTransaction(
-                buyer.getUniqueId(), listingId, hasSpace, System.currentTimeMillis());
-
-        if (outcome.isSuccess()) {
-            giveItem(buyer, outcome.getItemData());
-            notifySellerSold(outcome);
+        // 価格・自己購入の事前確認（現金を回収する前に弾く）
+        MarketListing listing;
+        try {
+            listing = listingDAO.getById(listingId);
+        } catch (SQLException e) {
+            logger.log(Level.WARNING, "マーケット出品の取得に失敗しました", e);
+            return MarketResult.ERROR;
         }
+        if (listing == null || !listing.isActive()) {
+            return MarketResult.ALREADY_SOLD;
+        }
+        if (!configManager.isMarketAllowSelfPurchase()
+                && listing.getSellerUuid().equals(buyer.getUniqueId())) {
+            return MarketResult.NOT_AVAILABLE;
+        }
+
+        double price = listing.getPrice();
+
+        // 現金を先に回収（所持チェックと削除を原子的に行う）。不足なら資金不足
+        if (!currencyConverter.payWithCash(buyer, price)) {
+            return MarketResult.INSUFFICIENT_FUNDS;
+        }
+
+        // DB 決済（楽観ロック＋出品者入金）
+        PurchaseOutcome outcome = executePurchaseTransaction(
+                buyer.getUniqueId(), listingId, System.currentTimeMillis());
+
+        if (!outcome.isSuccess()) {
+            // 売却失敗 → 回収した現金を返金（スペースチェックは不要＝直前に同額を取り除いている）
+            currencyConverter.receiveCash(buyer, price, true);
+            return outcome.getResult();
+        }
+
+        giveItem(buyer, outcome.getItemData());
+        notifySellerSold(outcome);
         return outcome.getResult();
     }
 

--- a/src/main/java/org/tofu/tofunomics/market/MarketManager.java
+++ b/src/main/java/org/tofu/tofunomics/market/MarketManager.java
@@ -1,0 +1,355 @@
+package org.tofu.tofunomics.market;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.MarketListingDAO;
+import org.tofu.tofunomics.dao.PlayerDAO;
+import org.tofu.tofunomics.models.MarketListing;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * プレイヤー間マーケットのビジネスロジック層。
+ *
+ * 出品・購入・キャンセル・回収の各操作を提供する。Bukkit（Player/ItemStack/インベントリ）
+ * 依存の薄いラッパーと、ユニットテスト可能な DB 決済コアを分離している。
+ *
+ * 購入・回収の DB トランザクションは {@code synchronized(connection)} で囲み、
+ * 共有 Connection への非同期書き込み（PlayerJoinHandler 等）との競合を防ぐ（Risk B 対策）。
+ */
+public class MarketManager {
+
+    private static final long MILLIS_PER_DAY = 86_400_000L;
+
+    private final Connection connection;
+    private final PlayerDAO playerDAO;
+    private final MarketListingDAO listingDAO;
+    private final ConfigManager configManager;
+    private final Logger logger;
+
+    public MarketManager(Connection connection, PlayerDAO playerDAO, MarketListingDAO listingDAO,
+                         ConfigManager configManager, Logger logger) {
+        this.connection = connection;
+        this.playerDAO = playerDAO;
+        this.listingDAO = listingDAO;
+        this.configManager = configManager;
+        this.logger = logger;
+    }
+
+    // ========================================================================
+    // テスト可能なコアロジック（Bukkit 非依存）
+    // ========================================================================
+
+    /**
+     * 出品価格が妥当か（整数かつ min_price 〜 max_price の範囲内）。
+     */
+    public boolean isValidPrice(double price) {
+        if (price != Math.floor(price) || Double.isInfinite(price)) {
+            return false;
+        }
+        return price >= configManager.getMarketMinPrice() && price <= configManager.getMarketMaxPrice();
+    }
+
+    /**
+     * 出品者の受取額（手数料控除後・端数切り捨て）を計算する。
+     */
+    public long calculateSellerProceeds(double price) {
+        return (long) Math.floor(price * (1.0 - configManager.getMarketFeeRate()));
+    }
+
+    /**
+     * 失効時刻（epoch millis）を計算する。listing_duration_days が 0 以下なら無期限（null）。
+     */
+    private Long calculateExpiresAtMillis(long nowMillis) {
+        int days = configManager.getMarketListingDurationDays();
+        if (days <= 0) {
+            return null;
+        }
+        return nowMillis + days * MILLIS_PER_DAY;
+    }
+
+    /**
+     * 出品の DB 登録コア（Bukkit 非依存）。
+     * バリデーション → 出品上限 → INSERT を行う。アイテムのシリアライズ・手持ち除去は呼び出し側。
+     */
+    public MarketResult executeCreateListing(UUID sellerUuid, String sellerName, String itemData,
+                                             String displayName, String material, int amount,
+                                             double price, long nowMillis) {
+        if (!configManager.isMarketEnabled()) {
+            return MarketResult.MARKET_DISABLED;
+        }
+        if (itemData == null) {
+            return MarketResult.INVALID_ITEM;
+        }
+        if (!isValidPrice(price)) {
+            return MarketResult.INVALID_PRICE;
+        }
+
+        synchronized (connection) {
+            try {
+                if (listingDAO.countActiveBySeller(sellerUuid) >= configManager.getMarketMaxListingsPerPlayer()) {
+                    return MarketResult.LISTING_LIMIT;
+                }
+                Long expiresAt = calculateExpiresAtMillis(nowMillis);
+                MarketListing listing = new MarketListing(
+                        sellerUuid, sellerName, itemData, displayName, material, amount, price, expiresAt);
+                int id = listingDAO.insertListing(listing);
+                return id > 0 ? MarketResult.LISTED : MarketResult.ERROR;
+            } catch (SQLException e) {
+                logger.log(Level.WARNING, "マーケット出品の登録に失敗しました", e);
+                return MarketResult.ERROR;
+            }
+        }
+    }
+
+    /**
+     * 購入決済コア（Bukkit 非依存）。手動トランザクションで楽観ロック・残高移動・手数料を処理する。
+     *
+     * @param buyerHasInventorySpace 購入者インベントリに空きがあるか（呼び出し側が判定して渡す）
+     */
+    public PurchaseOutcome executePurchaseTransaction(UUID buyerUuid, int listingId,
+                                                      boolean buyerHasInventorySpace, long nowMillis) {
+        synchronized (connection) {
+            try {
+                connection.setAutoCommit(false);
+
+                MarketListing listing = listingDAO.getById(listingId);
+                if (listing == null || !listing.isActive()) {
+                    connection.rollback();
+                    return PurchaseOutcome.failure(MarketResult.ALREADY_SOLD);
+                }
+
+                UUID sellerUuid = listing.getSellerUuid();
+
+                // 自己購入チェック
+                if (!configManager.isMarketAllowSelfPurchase() && sellerUuid.equals(buyerUuid)) {
+                    connection.rollback();
+                    return PurchaseOutcome.failure(MarketResult.NOT_AVAILABLE);
+                }
+
+                // 残高チェック
+                org.tofu.tofunomics.models.Player buyer = playerDAO.getPlayer(buyerUuid);
+                if (buyer == null || buyer.getBankBalance() < listing.getPrice()) {
+                    connection.rollback();
+                    return PurchaseOutcome.failure(MarketResult.INSUFFICIENT_FUNDS);
+                }
+
+                // インベントリ空きチェック（満杯なら購入させない＝アイテム喪失防止）
+                if (!buyerHasInventorySpace) {
+                    connection.rollback();
+                    return PurchaseOutcome.failure(MarketResult.INVENTORY_FULL);
+                }
+
+                // 楽観ロック：active の行のみ sold 化。影響行数 1 以外は二重購入として中止
+                if (!listingDAO.markAsSold(listingId, buyerUuid, nowMillis)) {
+                    connection.rollback();
+                    return PurchaseOutcome.failure(MarketResult.ALREADY_SOLD);
+                }
+
+                // 購入者から代金を引き、出品者へ手数料控除後を入金
+                buyer.removeBankBalance(listing.getPrice());
+                playerDAO.updatePlayer(buyer);
+
+                long proceeds = calculateSellerProceeds(listing.getPrice());
+                org.tofu.tofunomics.models.Player seller = playerDAO.getOrCreatePlayer(sellerUuid);
+                seller.addBankBalance(proceeds);
+                playerDAO.updatePlayer(seller);
+
+                connection.commit();
+                return PurchaseOutcome.success(listing.getItemData(), sellerUuid, proceeds);
+            } catch (SQLException e) {
+                logger.log(Level.WARNING, "マーケット購入の決済に失敗しました", e);
+                try {
+                    connection.rollback();
+                } catch (SQLException rollbackEx) {
+                    logger.log(Level.SEVERE, "ロールバックに失敗しました", rollbackEx);
+                }
+                return PurchaseOutcome.failure(MarketResult.ERROR);
+            } finally {
+                try {
+                    connection.setAutoCommit(true);
+                } catch (SQLException e) {
+                    logger.log(Level.SEVERE, "setAutoCommit(true) に失敗しました", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * キャンセル/回収のステータス遷移コア（Bukkit 非依存）。
+     * 所有権・期待ステータス・インベントリ空きを検証し、楽観ロックで status を reclaimed に遷移させる。
+     *
+     * @param expectedStatus active（キャンセル）または expired（回収）
+     */
+    public MarketResult executeReclaim(UUID sellerUuid, int listingId, String expectedStatus,
+                                       boolean hasInventorySpace) {
+        synchronized (connection) {
+            try {
+                MarketListing listing = listingDAO.getById(listingId);
+                if (listing == null) {
+                    return MarketResult.NOT_AVAILABLE;
+                }
+                if (!listing.getSellerUuid().equals(sellerUuid)) {
+                    return MarketResult.NOT_OWNER;
+                }
+                if (!expectedStatus.equals(listing.getStatus())) {
+                    return MarketResult.NOT_AVAILABLE;
+                }
+                if (!hasInventorySpace) {
+                    return MarketResult.INVENTORY_FULL;
+                }
+                if (!listingDAO.updateStatusConditional(listingId, expectedStatus, MarketListing.STATUS_RECLAIMED)) {
+                    return MarketResult.NOT_AVAILABLE;
+                }
+                return MarketListing.STATUS_ACTIVE.equals(expectedStatus)
+                        ? MarketResult.CANCELLED : MarketResult.RECLAIMED;
+            } catch (SQLException e) {
+                logger.log(Level.WARNING, "マーケット出品の回収に失敗しました", e);
+                return MarketResult.ERROR;
+            }
+        }
+    }
+
+    // ========================================================================
+    // Bukkit 依存のラッパー（コマンド/GUI から呼ぶ）
+    // ========================================================================
+
+    /**
+     * メインハンドのアイテムを出品する。DB 登録成功後に手持ちから除去する（喪失防止のため順序厳守）。
+     */
+    public MarketResult createListing(Player seller, double price) {
+        if (!configManager.isMarketEnabled()) {
+            return MarketResult.MARKET_DISABLED;
+        }
+
+        ItemStack item = seller.getInventory().getItemInMainHand();
+        if (item == null || item.getType() == Material.AIR || item.getAmount() <= 0) {
+            return MarketResult.INVALID_ITEM;
+        }
+
+        String itemData = MarketItemSerializer.serialize(item);
+        if (itemData == null) {
+            return MarketResult.ERROR;
+        }
+
+        String displayName = resolveDisplayName(item);
+        String material = item.getType().name();
+        int amount = item.getAmount();
+
+        MarketResult result = executeCreateListing(
+                seller.getUniqueId(), seller.getName(), itemData, displayName, material, amount,
+                price, System.currentTimeMillis());
+
+        if (result == MarketResult.LISTED) {
+            // DB 保存成功を確認してから手持ちを除去する
+            seller.getInventory().setItemInMainHand(null);
+        }
+        return result;
+    }
+
+    /**
+     * 出品を購入する。決済成功後にアイテムを付与し、出品者がオンラインなら通知する。
+     */
+    public MarketResult purchaseListing(Player buyer, int listingId) {
+        if (!configManager.isMarketEnabled()) {
+            return MarketResult.MARKET_DISABLED;
+        }
+
+        boolean hasSpace = buyer.getInventory().firstEmpty() != -1;
+        PurchaseOutcome outcome = executePurchaseTransaction(
+                buyer.getUniqueId(), listingId, hasSpace, System.currentTimeMillis());
+
+        if (outcome.isSuccess()) {
+            giveItem(buyer, outcome.getItemData());
+            notifySellerSold(outcome);
+        }
+        return outcome.getResult();
+    }
+
+    /**
+     * active 出品をキャンセルし、アイテムを回収する。
+     */
+    public MarketResult cancelListing(Player seller, int listingId) {
+        return reclaimInternal(seller, listingId, MarketListing.STATUS_ACTIVE);
+    }
+
+    /**
+     * expired 出品からアイテムを回収する。
+     */
+    public MarketResult reclaimListing(Player seller, int listingId) {
+        return reclaimInternal(seller, listingId, MarketListing.STATUS_EXPIRED);
+    }
+
+    private MarketResult reclaimInternal(Player seller, int listingId, String expectedStatus) {
+        MarketListing listing;
+        try {
+            listing = listingDAO.getById(listingId);
+        } catch (SQLException e) {
+            logger.log(Level.WARNING, "マーケット出品の取得に失敗しました", e);
+            return MarketResult.ERROR;
+        }
+        if (listing == null) {
+            return MarketResult.NOT_AVAILABLE;
+        }
+
+        boolean hasSpace = seller.getInventory().firstEmpty() != -1;
+        MarketResult result = executeReclaim(seller.getUniqueId(), listingId, expectedStatus, hasSpace);
+
+        if (result == MarketResult.CANCELLED || result == MarketResult.RECLAIMED) {
+            giveItem(seller, listing.getItemData());
+        }
+        return result;
+    }
+
+    // ========================================================================
+    // ヘルパー
+    // ========================================================================
+
+    /**
+     * アイテムを付与する。インベントリに入りきらない分はプレイヤー足元にドロップする（喪失防止）。
+     */
+    private void giveItem(Player player, String itemData) {
+        ItemStack item = MarketItemSerializer.deserialize(itemData);
+        if (item == null) {
+            logger.warning("マーケットアイテムのデシリアライズに失敗しました（listingのitem_dataが不正）");
+            return;
+        }
+        Map<Integer, ItemStack> leftover = player.getInventory().addItem(item);
+        if (!leftover.isEmpty()) {
+            Location loc = player.getLocation();
+            for (ItemStack drop : leftover.values()) {
+                player.getWorld().dropItem(loc, drop);
+            }
+        }
+    }
+
+    /**
+     * 出品者がオンラインなら売却を通知する。
+     */
+    private void notifySellerSold(PurchaseOutcome outcome) {
+        Player seller = Bukkit.getPlayer(outcome.getSellerUuid());
+        if (seller != null && seller.isOnline()) {
+            seller.sendMessage(configManager.getMarketMessage("sold_notify",
+                    "amount", outcome.getSellerProceeds()));
+        }
+    }
+
+    /**
+     * GUI 表示用の名前を解決する（カスタム名があればそれ、無ければ Material 名）。
+     */
+    private String resolveDisplayName(ItemStack item) {
+        if (item.hasItemMeta() && item.getItemMeta() != null && item.getItemMeta().hasDisplayName()) {
+            return item.getItemMeta().getDisplayName();
+        }
+        return item.getType().name();
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/MarketManager.java
+++ b/src/main/java/org/tofu/tofunomics/market/MarketManager.java
@@ -6,13 +6,16 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.MarketBuyOrderDAO;
 import org.tofu.tofunomics.dao.MarketListingDAO;
 import org.tofu.tofunomics.dao.PlayerDAO;
 import org.tofu.tofunomics.economy.CurrencyConverter;
+import org.tofu.tofunomics.models.MarketBuyOrder;
 import org.tofu.tofunomics.models.MarketListing;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -34,15 +37,18 @@ public class MarketManager {
     private final Connection connection;
     private final PlayerDAO playerDAO;
     private final MarketListingDAO listingDAO;
+    private final MarketBuyOrderDAO buyOrderDAO;
     private final ConfigManager configManager;
     private final CurrencyConverter currencyConverter;
     private final Logger logger;
 
     public MarketManager(Connection connection, PlayerDAO playerDAO, MarketListingDAO listingDAO,
-                         ConfigManager configManager, CurrencyConverter currencyConverter, Logger logger) {
+                         MarketBuyOrderDAO buyOrderDAO, ConfigManager configManager,
+                         CurrencyConverter currencyConverter, Logger logger) {
         this.connection = connection;
         this.playerDAO = playerDAO;
         this.listingDAO = listingDAO;
+        this.buyOrderDAO = buyOrderDAO;
         this.configManager = configManager;
         this.currencyConverter = currencyConverter;
         this.logger = logger;
@@ -224,6 +230,201 @@ public class MarketManager {
     }
 
     // ========================================================================
+    // 買い注文（募集）コアロジック（Bukkit 非依存）
+    // ========================================================================
+
+    /**
+     * 募集の DB 登録コア（Bukkit 非依存）。
+     * バリデーション → 募集上限 → INSERT を行う。前払い現金の回収は呼び出し側（ラッパー）。
+     *
+     * 通貨保存則上、現金回収はこの INSERT より前に行い、INSERT 失敗時は呼び出し側が返金する。
+     */
+    public MarketResult executeCreateBuyOrder(UUID requesterUuid, String requesterName, String material,
+                                              int amount, double price, long nowMillis) {
+        if (!configManager.isMarketEnabled()) {
+            return MarketResult.MARKET_DISABLED;
+        }
+        if (material == null || amount <= 0) {
+            return MarketResult.INVALID_ITEM;
+        }
+        if (!isValidPrice(price)) {
+            return MarketResult.INVALID_PRICE;
+        }
+
+        synchronized (connection) {
+            try {
+                if (buyOrderDAO.countOpenByRequester(requesterUuid) >= configManager.getMarketMaxBuyOrdersPerPlayer()) {
+                    return MarketResult.ORDER_LIMIT;
+                }
+                Long expiresAt = calculateExpiresAtMillis(nowMillis);
+                MarketBuyOrder order = new MarketBuyOrder(
+                        requesterUuid, requesterName, material, amount, price, expiresAt);
+                int id = buyOrderDAO.insertBuyOrder(order);
+                return id > 0 ? MarketResult.REQUESTED : MarketResult.ERROR;
+            } catch (SQLException e) {
+                logger.log(Level.WARNING, "買い注文の登録に失敗しました", e);
+                return MarketResult.ERROR;
+            }
+        }
+    }
+
+    /**
+     * 供給決済コア（Bukkit 非依存）。手動トランザクションで楽観ロック・供給者への入金・手数料を処理する。
+     *
+     * 供給者の手持ちからのアイテム除去・シリアライズは呼び出し側（{@link #fulfillBuyOrder}）が行い、
+     * 本コアは「楽観ロックで fulfilled 化（supplier/item_data 設定）→ 供給者の bank_balance へ
+     * 手数料控除後を入金」のみを担当する。差額は再生成しないため自動的に消却される。
+     */
+    public FulfillOutcome executeFulfillTransaction(UUID supplierUuid, int orderId, String itemData, long nowMillis) {
+        synchronized (connection) {
+            try {
+                connection.setAutoCommit(false);
+
+                MarketBuyOrder order = buyOrderDAO.getById(orderId);
+                if (order == null || !order.isOpen()) {
+                    connection.rollback();
+                    return FulfillOutcome.failure(MarketResult.ORDER_NOT_AVAILABLE);
+                }
+
+                // 楽観ロック：open の行のみ fulfilled 化。影響行数 1 以外は二重供給として中止
+                if (!buyOrderDAO.markAsFulfilled(orderId, supplierUuid, itemData, nowMillis)) {
+                    connection.rollback();
+                    return FulfillOutcome.failure(MarketResult.ORDER_NOT_AVAILABLE);
+                }
+
+                // 供給者へ手数料控除後を入金（オフライン可・UUID 直指定）。差額は消却。
+                long proceeds = calculateSellerProceeds(order.getPrice());
+                org.tofu.tofunomics.models.Player supplier = playerDAO.getOrCreatePlayer(supplierUuid);
+                supplier.addBankBalance(proceeds);
+                playerDAO.updatePlayer(supplier);
+
+                connection.commit();
+                return FulfillOutcome.success(order.getRequesterUuid(), proceeds);
+            } catch (SQLException e) {
+                logger.log(Level.WARNING, "買い注文の供給決済に失敗しました", e);
+                try {
+                    connection.rollback();
+                } catch (SQLException rollbackEx) {
+                    logger.log(Level.SEVERE, "ロールバックに失敗しました", rollbackEx);
+                }
+                return FulfillOutcome.failure(MarketResult.ERROR);
+            } finally {
+                try {
+                    connection.setAutoCommit(true);
+                } catch (SQLException e) {
+                    logger.log(Level.SEVERE, "setAutoCommit(true) に失敗しました", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * 募集キャンセルのステータス遷移コア（Bukkit 非依存）。
+     * 所有権・open 状態を検証し、楽観ロックで status を cancelled に遷移させる。
+     * 前払い分の返金（現金）は呼び出し側（{@link #cancelBuyOrder}）が遷移成功後に行う。
+     */
+    public MarketResult executeCancelBuyOrder(UUID requesterUuid, int orderId) {
+        synchronized (connection) {
+            try {
+                MarketBuyOrder order = buyOrderDAO.getById(orderId);
+                if (order == null) {
+                    return MarketResult.ORDER_NOT_AVAILABLE;
+                }
+                if (!order.getRequesterUuid().equals(requesterUuid)) {
+                    return MarketResult.ORDER_NOT_OWNER;
+                }
+                if (!order.isOpen()) {
+                    return MarketResult.ORDER_NOT_AVAILABLE;
+                }
+                if (!buyOrderDAO.updateStatusConditional(orderId, MarketBuyOrder.STATUS_OPEN, MarketBuyOrder.STATUS_CANCELLED)) {
+                    return MarketResult.ORDER_NOT_AVAILABLE;
+                }
+                return MarketResult.ORDER_CANCELLED;
+            } catch (SQLException e) {
+                logger.log(Level.WARNING, "買い注文のキャンセルに失敗しました", e);
+                return MarketResult.ERROR;
+            }
+        }
+    }
+
+    /**
+     * 成立した募集のアイテム回収のステータス遷移コア（Bukkit 非依存）。
+     * 所有権・fulfilled 状態・インベントリ空きを検証し、楽観ロックで status を reclaimed に遷移させる。
+     * アイテム付与は呼び出し側（{@link #reclaimBuyOrder}）が遷移成功後に行う。
+     */
+    public MarketResult executeReclaimBuyOrder(UUID requesterUuid, int orderId, boolean hasInventorySpace) {
+        synchronized (connection) {
+            try {
+                MarketBuyOrder order = buyOrderDAO.getById(orderId);
+                if (order == null) {
+                    return MarketResult.ORDER_NOT_AVAILABLE;
+                }
+                if (!order.getRequesterUuid().equals(requesterUuid)) {
+                    return MarketResult.ORDER_NOT_OWNER;
+                }
+                if (!order.isFulfilled()) {
+                    return MarketResult.ORDER_NOT_AVAILABLE;
+                }
+                if (!hasInventorySpace) {
+                    return MarketResult.INVENTORY_FULL;
+                }
+                if (!buyOrderDAO.updateStatusConditional(orderId, MarketBuyOrder.STATUS_FULFILLED, MarketBuyOrder.STATUS_RECLAIMED)) {
+                    return MarketResult.ORDER_NOT_AVAILABLE;
+                }
+                return MarketResult.ORDER_RECLAIMED;
+            } catch (SQLException e) {
+                logger.log(Level.WARNING, "買い注文のアイテム回収に失敗しました", e);
+                return MarketResult.ERROR;
+            }
+        }
+    }
+
+    /**
+     * 期限切れの open 募集を expired 化し、前払い分を募集者の bank へ返金する（定期タスクから呼ぶ）。
+     *
+     * 売りの一括 UPDATE と異なり返金を伴うため、取得 → ループで注文ごとに楽観ロック UPDATE ＋
+     * 返金を行う。全体を 1 トランザクションで囲み、途中失敗時はロールバックして二重返金を防ぐ。
+     *
+     * @return 期限切れ返金した件数（失敗時は 0）
+     */
+    public int expireBuyOrders() {
+        synchronized (connection) {
+            try {
+                connection.setAutoCommit(false);
+                long now = System.currentTimeMillis();
+                List<MarketBuyOrder> expired = buyOrderDAO.getExpiredOpenOrders(now);
+                int count = 0;
+                for (MarketBuyOrder order : expired) {
+                    // 楽観ロック：open 限定 UPDATE。成功した注文のみ返金（二重返金防止）
+                    if (buyOrderDAO.updateStatusConditional(order.getId(),
+                            MarketBuyOrder.STATUS_OPEN, MarketBuyOrder.STATUS_EXPIRED)) {
+                        org.tofu.tofunomics.models.Player requester = playerDAO.getOrCreatePlayer(order.getRequesterUuid());
+                        requester.addBankBalance(order.getPrice());
+                        playerDAO.updatePlayer(requester);
+                        count++;
+                    }
+                }
+                connection.commit();
+                return count;
+            } catch (SQLException e) {
+                logger.log(Level.WARNING, "期限切れ買い注文の返金処理に失敗しました", e);
+                try {
+                    connection.rollback();
+                } catch (SQLException rollbackEx) {
+                    logger.log(Level.SEVERE, "ロールバックに失敗しました", rollbackEx);
+                }
+                return 0;
+            } finally {
+                try {
+                    connection.setAutoCommit(true);
+                } catch (SQLException e) {
+                    logger.log(Level.SEVERE, "setAutoCommit(true) に失敗しました", e);
+                }
+            }
+        }
+    }
+
+    // ========================================================================
     // Bukkit 依存のラッパー（コマンド/GUI から呼ぶ）
     // ========================================================================
 
@@ -346,6 +547,164 @@ public class MarketManager {
     }
 
     // ========================================================================
+    // 買い注文（募集）Bukkit 依存ラッパー
+    // ========================================================================
+
+    /**
+     * 買い注文（募集）を登録する。前払いの現金（金塊）を先に回収し、DB 登録失敗時は返金する。
+     *
+     * 安全順序：募集上限の事前確認 → 現金回収 → INSERT。INSERT が失敗した場合は現金を返金する。
+     */
+    public MarketResult createBuyOrder(Player requester, Material material, int amount, double price) {
+        if (!configManager.isMarketEnabled()) {
+            return MarketResult.MARKET_DISABLED;
+        }
+        if (material == null || material == Material.AIR || amount <= 0) {
+            return MarketResult.INVALID_ITEM;
+        }
+        if (!isValidPrice(price)) {
+            return MarketResult.INVALID_PRICE;
+        }
+
+        // 現金を回収する前に募集上限を確認する（無駄な回収→返金の往復を避ける）
+        synchronized (connection) {
+            try {
+                if (buyOrderDAO.countOpenByRequester(requester.getUniqueId())
+                        >= configManager.getMarketMaxBuyOrdersPerPlayer()) {
+                    return MarketResult.ORDER_LIMIT;
+                }
+            } catch (SQLException e) {
+                logger.log(Level.WARNING, "募集数の確認に失敗しました", e);
+                return MarketResult.ERROR;
+            }
+        }
+
+        // 前払いの現金を先に回収（所持チェックと削除を原子的に行う）。不足なら資金不足
+        if (!currencyConverter.payWithCash(requester, price)) {
+            return MarketResult.INSUFFICIENT_FUNDS;
+        }
+
+        MarketResult result = executeCreateBuyOrder(
+                requester.getUniqueId(), requester.getName(), material.name(), amount,
+                price, System.currentTimeMillis());
+
+        if (result != MarketResult.REQUESTED) {
+            // 登録失敗 → 回収した前払いを返金（スペースチェックは不要＝直前に同額を取り除いている）
+            currencyConverter.receiveCash(requester, price, true);
+        }
+        return result;
+    }
+
+    /**
+     * 募集に供給して成立させる。手持ちから対象 Material を amount 個除去し、
+     * DB 決済（楽観ロック＋供給者入金）を行う。決済失敗時は除去したアイテムを返却する。
+     */
+    public MarketResult fulfillBuyOrder(Player supplier, int orderId) {
+        if (!configManager.isMarketEnabled()) {
+            return MarketResult.MARKET_DISABLED;
+        }
+
+        MarketBuyOrder order;
+        try {
+            order = buyOrderDAO.getById(orderId);
+        } catch (SQLException e) {
+            logger.log(Level.WARNING, "買い注文の取得に失敗しました", e);
+            return MarketResult.ERROR;
+        }
+        if (order == null || !order.isOpen()) {
+            return MarketResult.ORDER_NOT_AVAILABLE;
+        }
+        // 自己供給チェック（自分の募集には供給不可）
+        if (!configManager.isMarketAllowSelfPurchase()
+                && order.getRequesterUuid().equals(supplier.getUniqueId())) {
+            return MarketResult.ORDER_NOT_AVAILABLE;
+        }
+
+        Material material = Material.matchMaterial(order.getMaterial());
+        if (material == null) {
+            logger.warning("買い注文の Material 名が不正です: " + order.getMaterial());
+            return MarketResult.ERROR;
+        }
+        int amount = order.getAmount();
+
+        // 手持ちに供給可能な個数があるか
+        if (countMaterial(supplier, material) < amount) {
+            return MarketResult.NO_MATCHING_ITEM;
+        }
+
+        // 手持ちから除去し、供給アイテムをシリアライズ（除去 → serialize → DB の安全順序）
+        removeMaterial(supplier, material, amount);
+        ItemStack supplied = new ItemStack(material, amount);
+        String itemData = MarketItemSerializer.serialize(supplied);
+        if (itemData == null) {
+            // シリアライズ失敗 → 除去したアイテムを返却して中止
+            giveItemStack(supplier, supplied);
+            return MarketResult.ERROR;
+        }
+
+        FulfillOutcome outcome = executeFulfillTransaction(
+                supplier.getUniqueId(), orderId, itemData, System.currentTimeMillis());
+
+        if (!outcome.isSuccess()) {
+            // 決済失敗 → 除去したアイテムを返却
+            giveItem(supplier, itemData);
+            return outcome.getResult();
+        }
+
+        notifyRequesterFulfilled(outcome.getRequesterUuid(),
+                org.tofu.tofunomics.market.gui.MarketGUIUtil.prettifyMaterial(order.getMaterial()), amount);
+        return outcome.getResult();
+    }
+
+    /**
+     * open の募集をキャンセルし、前払い分を現金で返金する。
+     */
+    public MarketResult cancelBuyOrder(Player requester, int orderId) {
+        MarketBuyOrder order;
+        try {
+            order = buyOrderDAO.getById(orderId);
+        } catch (SQLException e) {
+            logger.log(Level.WARNING, "買い注文の取得に失敗しました", e);
+            return MarketResult.ERROR;
+        }
+        if (order == null) {
+            return MarketResult.ORDER_NOT_AVAILABLE;
+        }
+
+        MarketResult result = executeCancelBuyOrder(requester.getUniqueId(), orderId);
+
+        if (result == MarketResult.ORDER_CANCELLED) {
+            // 状態遷移成功後に前払いを返金（本人操作＝オンライン前提）
+            currencyConverter.receiveCash(requester, order.getPrice(), true);
+        }
+        return result;
+    }
+
+    /**
+     * fulfilled の募集から供給アイテムを回収する。
+     */
+    public MarketResult reclaimBuyOrder(Player requester, int orderId) {
+        MarketBuyOrder order;
+        try {
+            order = buyOrderDAO.getById(orderId);
+        } catch (SQLException e) {
+            logger.log(Level.WARNING, "買い注文の取得に失敗しました", e);
+            return MarketResult.ERROR;
+        }
+        if (order == null) {
+            return MarketResult.ORDER_NOT_AVAILABLE;
+        }
+
+        boolean hasSpace = requester.getInventory().firstEmpty() != -1;
+        MarketResult result = executeReclaimBuyOrder(requester.getUniqueId(), orderId, hasSpace);
+
+        if (result == MarketResult.ORDER_RECLAIMED) {
+            giveItem(requester, order.getItemData());
+        }
+        return result;
+    }
+
+    // ========================================================================
     // ヘルパー
     // ========================================================================
 
@@ -379,6 +738,69 @@ public class MarketManager {
                     "item", itemName,
                     "amount", String.valueOf(outcome.getSellerProceeds()),
                     "currency", configManager.getCurrencyName()));
+        }
+    }
+
+    /**
+     * 単一の ItemStack を付与する。入りきらない分は足元へドロップする（喪失防止）。
+     */
+    private void giveItemStack(Player player, ItemStack item) {
+        Map<Integer, ItemStack> leftover = player.getInventory().addItem(item);
+        if (!leftover.isEmpty()) {
+            Location loc = player.getLocation();
+            for (ItemStack drop : leftover.values()) {
+                player.getWorld().dropItem(loc, drop);
+            }
+        }
+    }
+
+    /**
+     * インベントリ内の指定 Material の合計個数を数える（NBT 無視・Material のみで集計）。
+     */
+    private int countMaterial(Player player, Material material) {
+        int total = 0;
+        for (ItemStack stack : player.getInventory().getContents()) {
+            if (stack != null && stack.getType() == material) {
+                total += stack.getAmount();
+            }
+        }
+        return total;
+    }
+
+    /**
+     * インベントリから指定 Material を合計 amount 個だけ除去する。
+     * 呼び出し前に {@link #countMaterial} で所持数を確認していることを前提とする。
+     */
+    private void removeMaterial(Player player, Material material, int amount) {
+        int remaining = amount;
+        ItemStack[] contents = player.getInventory().getContents();
+        for (int i = 0; i < contents.length && remaining > 0; i++) {
+            ItemStack stack = contents[i];
+            if (stack == null || stack.getType() != material) {
+                continue;
+            }
+            int take = Math.min(remaining, stack.getAmount());
+            stack.setAmount(stack.getAmount() - take);
+            remaining -= take;
+            if (stack.getAmount() <= 0) {
+                contents[i] = null;
+            }
+        }
+        player.getInventory().setContents(contents);
+    }
+
+    /**
+     * 募集者がオンラインなら供給成立を通知する。
+     *
+     * @param itemName 供給されたアイテムの表示名（%item% 用）
+     * @param amount   供給個数（%amount% 用）
+     */
+    private void notifyRequesterFulfilled(UUID requesterUuid, String itemName, int amount) {
+        Player requester = Bukkit.getPlayer(requesterUuid);
+        if (requester != null && requester.isOnline()) {
+            requester.sendMessage(configManager.getMarketMessage("fulfilled_notify",
+                    "item", itemName,
+                    "amount", String.valueOf(amount)));
         }
     }
 

--- a/src/main/java/org/tofu/tofunomics/market/MarketManager.java
+++ b/src/main/java/org/tofu/tofunomics/market/MarketManager.java
@@ -306,7 +306,7 @@ public class MarketManager {
         }
 
         giveItem(buyer, outcome.getItemData());
-        notifySellerSold(outcome);
+        notifySellerSold(outcome, org.tofu.tofunomics.market.gui.MarketGUIUtil.prettifyMaterial(listing.getMaterial()));
         return outcome.getResult();
     }
 
@@ -369,12 +369,16 @@ public class MarketManager {
 
     /**
      * 出品者がオンラインなら売却を通知する。
+     *
+     * @param itemName 売れたアイテムの表示名（%item% 用）
      */
-    private void notifySellerSold(PurchaseOutcome outcome) {
+    private void notifySellerSold(PurchaseOutcome outcome, String itemName) {
         Player seller = Bukkit.getPlayer(outcome.getSellerUuid());
         if (seller != null && seller.isOnline()) {
             seller.sendMessage(configManager.getMarketMessage("sold_notify",
-                    "amount", outcome.getSellerProceeds()));
+                    "item", itemName,
+                    "amount", String.valueOf(outcome.getSellerProceeds()),
+                    "currency", configManager.getCurrencyName()));
         }
     }
 

--- a/src/main/java/org/tofu/tofunomics/market/MarketMessages.java
+++ b/src/main/java/org/tofu/tofunomics/market/MarketMessages.java
@@ -1,0 +1,34 @@
+package org.tofu.tofunomics.market;
+
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.market.gui.MarketGUIUtil;
+
+/**
+ * マーケットの結果メッセージ（messages.market.*）を組み立てるヘルパー。
+ *
+ * 各 {@link MarketResult} に対応するメッセージへ、必要なプレースホルダ
+ * （%item% %price% %currency% %min% %max% %limit% %amount%）をまとめて渡す。
+ * 未使用のプレースホルダは {@code getMessage} 側で無視されるため、常に全て渡してよい。
+ */
+public final class MarketMessages {
+
+    private MarketMessages() {
+    }
+
+    /**
+     * 結果コードに対応するメッセージを、関連プレースホルダを埋めて生成する。
+     *
+     * @param item  対象アイテムの表示名（不要な結果では無視される）
+     * @param price 価格（不要な結果では無視される）
+     */
+    public static String format(ConfigManager configManager, MarketResult result, String item, double price) {
+        return configManager.getMarketMessage(result.getMessageKey(),
+                "item", item != null ? item : "",
+                "price", MarketGUIUtil.formatPrice(price),
+                "currency", configManager.getCurrencyName(),
+                "min", String.valueOf((long) configManager.getMarketMinPrice()),
+                "max", String.valueOf((long) configManager.getMarketMaxPrice()),
+                "limit", String.valueOf(configManager.getMarketMaxListingsPerPlayer()),
+                "amount", MarketGUIUtil.formatPrice(price));
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/MarketResult.java
+++ b/src/main/java/org/tofu/tofunomics/market/MarketResult.java
@@ -8,11 +8,17 @@ package org.tofu.tofunomics.market;
  */
 public enum MarketResult {
 
-    // 成功
+    // 成功（売り）
     LISTED("listed"),
     PURCHASED("purchased"),
     CANCELLED("cancelled"),
     RECLAIMED("reclaimed"),
+
+    // 成功（買い注文＝募集）
+    REQUESTED("requested"),                 // 募集登録（前払い）
+    FULFILLED("fulfilled"),                 // 供給成立
+    ORDER_CANCELLED("request_cancelled"),   // 募集キャンセル＋返金
+    ORDER_RECLAIMED("request_reclaimed"),   // 成立した募集のアイテム回収
 
     // 失敗（出品）
     INVALID_ITEM("invalid_item"),
@@ -26,6 +32,12 @@ public enum MarketResult {
     INSUFFICIENT_FUNDS("insufficient_funds"),
     INVENTORY_FULL("inventory_full"),
     NOT_OWNER("not_owner"),
+
+    // 失敗（買い注文＝募集）
+    NO_MATCHING_ITEM("no_matching_item"),       // 供給アイテム不所持
+    ORDER_NOT_AVAILABLE("request_not_available"),// 募集が成立済み or 存在しない
+    ORDER_NOT_OWNER("request_not_owner"),        // 自分の募集ではない
+    ORDER_LIMIT("request_limit"),                // 募集上限超過
 
     // 失敗（共通）
     MARKET_DISABLED("error"),
@@ -48,6 +60,7 @@ public enum MarketResult {
      * 成功結果かどうか
      */
     public boolean isSuccess() {
-        return this == LISTED || this == PURCHASED || this == CANCELLED || this == RECLAIMED;
+        return this == LISTED || this == PURCHASED || this == CANCELLED || this == RECLAIMED
+                || this == REQUESTED || this == FULFILLED || this == ORDER_CANCELLED || this == ORDER_RECLAIMED;
     }
 }

--- a/src/main/java/org/tofu/tofunomics/market/MarketResult.java
+++ b/src/main/java/org/tofu/tofunomics/market/MarketResult.java
@@ -1,0 +1,53 @@
+package org.tofu.tofunomics.market;
+
+/**
+ * マーケット操作（出品・購入・キャンセル・回収）の結果コード。
+ *
+ * 各コードは {@code messages.market.*} のメッセージキーに対応する。
+ * メッセージ送信は呼び出し側（コマンド/GUI 層）が結果コードに応じて行う。
+ */
+public enum MarketResult {
+
+    // 成功
+    LISTED("listed"),
+    PURCHASED("purchased"),
+    CANCELLED("cancelled"),
+    RECLAIMED("reclaimed"),
+
+    // 失敗（出品）
+    INVALID_ITEM("invalid_item"),
+    INVALID_PRICE("invalid_price"),
+    CURRENCY_NOT_ALLOWED("currency_not_allowed"),
+    LISTING_LIMIT("listing_limit"),
+
+    // 失敗（購入・回収）
+    NOT_AVAILABLE("not_available"),
+    ALREADY_SOLD("already_sold"),
+    INSUFFICIENT_FUNDS("insufficient_funds"),
+    INVENTORY_FULL("inventory_full"),
+    NOT_OWNER("not_owner"),
+
+    // 失敗（共通）
+    MARKET_DISABLED("error"),
+    ERROR("error");
+
+    private final String messageKey;
+
+    MarketResult(String messageKey) {
+        this.messageKey = messageKey;
+    }
+
+    /**
+     * 対応する messages.market 配下のメッセージキー（プレフィックス無し）を返す。
+     */
+    public String getMessageKey() {
+        return messageKey;
+    }
+
+    /**
+     * 成功結果かどうか
+     */
+    public boolean isSuccess() {
+        return this == LISTED || this == PURCHASED || this == CANCELLED || this == RECLAIMED;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/PurchaseOutcome.java
+++ b/src/main/java/org/tofu/tofunomics/market/PurchaseOutcome.java
@@ -1,0 +1,58 @@
+package org.tofu.tofunomics.market;
+
+import java.util.UUID;
+
+/**
+ * 購入決済（DB トランザクション）の結果を表す。
+ *
+ * {@code MarketManager.executePurchaseTransaction} が返し、ラッパー
+ * {@code purchaseListing} が item 付与・出品者通知に付帯情報（itemData/sellerUuid/proceeds）を用いる。
+ */
+public class PurchaseOutcome {
+
+    private final MarketResult result;
+    private final String itemData;      // 付与すべきアイテムの Base64（成功時のみ）
+    private final UUID sellerUuid;      // 出品者（成功時の通知用）
+    private final long sellerProceeds;  // 出品者の受取額（手数料控除後・floor）
+
+    private PurchaseOutcome(MarketResult result, String itemData, UUID sellerUuid, long sellerProceeds) {
+        this.result = result;
+        this.itemData = itemData;
+        this.sellerUuid = sellerUuid;
+        this.sellerProceeds = sellerProceeds;
+    }
+
+    /**
+     * 失敗結果（付帯情報なし）
+     */
+    public static PurchaseOutcome failure(MarketResult result) {
+        return new PurchaseOutcome(result, null, null, 0L);
+    }
+
+    /**
+     * 購入成功結果
+     */
+    public static PurchaseOutcome success(String itemData, UUID sellerUuid, long sellerProceeds) {
+        return new PurchaseOutcome(MarketResult.PURCHASED, itemData, sellerUuid, sellerProceeds);
+    }
+
+    public MarketResult getResult() {
+        return result;
+    }
+
+    public boolean isSuccess() {
+        return result == MarketResult.PURCHASED;
+    }
+
+    public String getItemData() {
+        return itemData;
+    }
+
+    public UUID getSellerUuid() {
+        return sellerUuid;
+    }
+
+    public long getSellerProceeds() {
+        return sellerProceeds;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/gui/BuyOrderBrowseGUI.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/BuyOrderBrowseGUI.java
@@ -1,0 +1,251 @@
+package org.tofu.tofunomics.market.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.MarketBuyOrderDAO;
+import org.tofu.tofunomics.market.MarketManager;
+import org.tofu.tofunomics.market.MarketResult;
+import org.tofu.tofunomics.models.MarketBuyOrder;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 募集（買い注文）一覧 GUI。募集中（open）の全募集をカテゴリでフィルタし、ページングして表示する。
+ * クリックで手持ちから供給して成立させる。クリックイベントの受信は {@link MarketGUIListener} が担当し、
+ * 本クラスは描画とクリック処理ロジックを提供する。
+ *
+ * レイアウト: スロット 0〜7 カテゴリボタン、9〜44 募集（36件/ページ）、45〜53 ナビゲーション。
+ * （売り一覧 {@link MarketBrowseGUI} の鏡像）
+ */
+public class BuyOrderBrowseGUI {
+
+    private static final int INVENTORY_SIZE = 54;
+    private static final int ITEM_START_SLOT = 9;
+    private static final int ITEM_END_SLOT = 44;
+    private static final int ITEMS_PER_PAGE = ITEM_END_SLOT - ITEM_START_SLOT + 1; // 36
+    private static final int SLOT_PREV = 48;
+    private static final int SLOT_INFO = 49;
+    private static final int SLOT_NEXT = 50;
+    private static final int SLOT_CLOSE = 53;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final MarketManager marketManager;
+    private final MarketBuyOrderDAO buyOrderDAO;
+    private final MarketGUIListener listener;
+
+    public BuyOrderBrowseGUI(TofuNomics plugin, ConfigManager configManager, MarketManager marketManager,
+                             MarketBuyOrderDAO buyOrderDAO, MarketGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.marketManager = marketManager;
+        this.buyOrderDAO = buyOrderDAO;
+        this.listener = listener;
+    }
+
+    /**
+     * 募集一覧 GUI を開く。
+     */
+    public void open(Player player) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, INVENTORY_SIZE, "§6マーケット - 募集一覧");
+            MarketGUISession session = new MarketGUISession(
+                    player.getUniqueId(), MarketGUISession.Type.BUY_BROWSE, gui);
+            render(player, session);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("募集一覧GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage(configManager.getMarketMessage("error"));
+        }
+    }
+
+    /**
+     * 現在ページ・カテゴリの内容を描画する。
+     */
+    public void render(Player player, MarketGUISession session) {
+        Inventory gui = session.getInventory();
+        gui.clear();
+        session.clearSlotListings();
+
+        List<MarketBuyOrder> all;
+        try {
+            all = buyOrderDAO.getOpenOrders();
+        } catch (SQLException e) {
+            plugin.getLogger().warning("募集一覧の取得に失敗しました: " + e.getMessage());
+            all = new ArrayList<>();
+        }
+
+        // カテゴリでフィルタ
+        MarketCategory category = session.getCategory();
+        List<MarketBuyOrder> orders = new ArrayList<>();
+        for (MarketBuyOrder order : all) {
+            if (category.matches(Material.matchMaterial(order.getMaterial()))) {
+                orders.add(order);
+            }
+        }
+
+        int totalPages = Math.max(1, (int) Math.ceil(orders.size() / (double) ITEMS_PER_PAGE));
+        if (session.getPage() >= totalPages) {
+            session.setPage(totalPages - 1);
+        }
+        if (session.getPage() < 0) {
+            session.setPage(0);
+        }
+
+        int start = session.getPage() * ITEMS_PER_PAGE;
+        int end = Math.min(start + ITEMS_PER_PAGE, orders.size());
+
+        int slot = ITEM_START_SLOT;
+        for (int i = start; i < end; i++) {
+            MarketBuyOrder order = orders.get(i);
+            gui.setItem(slot, buildDisplayItem(order));
+            session.putSlotBuyOrder(slot, order);
+            slot++;
+        }
+
+        setupCategoryButtons(gui, category);
+        setupNavigation(gui, session, orders.size(), totalPages, all.size());
+    }
+
+    private void setupCategoryButtons(Inventory gui, MarketCategory current) {
+        MarketCategory[] categories = MarketCategory.values();
+        for (int i = 0; i < categories.length && i < 9; i++) {
+            MarketCategory category = categories[i];
+            boolean selected = category == current;
+            gui.setItem(i, MarketGUIUtil.createButton(
+                    category.getIcon(),
+                    (selected ? "§a§l▶ " : "§f") + category.getDisplayName(),
+                    Arrays.asList(
+                            selected ? "§a選択中" : "§7クリックで絞り込み"
+                    )));
+        }
+    }
+
+    private void setupNavigation(Inventory gui, MarketGUISession session, int filteredCount,
+                                 int totalPages, int totalOpen) {
+        if (session.getPage() > 0) {
+            gui.setItem(SLOT_PREV, MarketGUIUtil.createButton(Material.ARROW, "§a前のページ",
+                    Collections.singletonList("§7ページ " + session.getPage() + " へ")));
+        }
+        if (session.getPage() < totalPages - 1) {
+            gui.setItem(SLOT_NEXT, MarketGUIUtil.createButton(Material.ARROW, "§a次のページ",
+                    Collections.singletonList("§7ページ " + (session.getPage() + 2) + " へ")));
+        }
+
+        gui.setItem(SLOT_INFO, MarketGUIUtil.createButton(Material.WRITABLE_BOOK, "§6募集情報",
+                Arrays.asList(
+                        "§fカテゴリ: " + session.getCategory().getDisplayName(),
+                        "§f表示中: §a" + filteredCount + " §f/ 全 " + totalOpen + " 件",
+                        "§fページ: §e" + (session.getPage() + 1) + " / " + totalPages,
+                        "§7募集をクリックして手持ちから供給"
+                )));
+
+        gui.setItem(SLOT_CLOSE, MarketGUIUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = MarketGUIUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            if (gui.getItem(8) == null) {
+                gui.setItem(8, glass);
+            }
+            for (int i = 45; i < INVENTORY_SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    /**
+     * 募集から表示用アイテムを生成する（募集対象 Material の見本アイテムに募集情報を lore で付す）。
+     */
+    private ItemStack buildDisplayItem(MarketBuyOrder order) {
+        Material material = Material.matchMaterial(order.getMaterial());
+        if (material == null) {
+            material = Material.BARRIER;
+        }
+        ItemStack item = new ItemStack(material, Math.max(1, Math.min(order.getAmount(), 64)));
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName("§f" + MarketGUIUtil.prettifyMaterial(order.getMaterial()));
+            List<String> lore = new ArrayList<>();
+            lore.add("");
+            lore.add("§7募集者: §f" + order.getRequesterName());
+            lore.add("§7希望個数: §f" + order.getAmount());
+            lore.add("§7支払総額: §e" + MarketGUIUtil.formatPrice(order.getPrice())
+                    + " " + configManager.getCurrencyName());
+            lore.add("§7供給時受取: §a" + marketManager.calculateSellerProceeds(order.getPrice())
+                    + " " + configManager.getCurrencyName());
+            lore.add("");
+            lore.add("§eクリックで手持ちから供給");
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    /**
+     * クリック処理（{@link MarketGUIListener} から呼ばれる）。
+     */
+    public void handleClick(Player player, MarketGUISession session, int slot, ClickType clickType) {
+        if (slot == SLOT_CLOSE) {
+            player.closeInventory();
+            return;
+        }
+        if (slot == SLOT_PREV) {
+            session.setPage(session.getPage() - 1);
+            render(player, session);
+            return;
+        }
+        if (slot == SLOT_NEXT) {
+            session.setPage(session.getPage() + 1);
+            render(player, session);
+            return;
+        }
+
+        // カテゴリボタン（スロット 0〜7）
+        if (slot >= 0 && slot < MarketCategory.values().length && slot <= 8) {
+            MarketCategory selected = MarketCategory.values()[slot];
+            if (selected != session.getCategory()) {
+                session.setCategory(selected);
+                session.setPage(0);
+                render(player, session);
+            }
+            return;
+        }
+
+        MarketBuyOrder order = session.getBuyOrderAtSlot(slot);
+        if (order == null) {
+            return;
+        }
+
+        MarketResult result = marketManager.fulfillBuyOrder(player, order.getId());
+        sendResultMessage(player, result, order);
+
+        // 募集が成立して一覧から消えるため再描画
+        render(player, session);
+    }
+
+    private void sendResultMessage(Player player, MarketResult result, MarketBuyOrder order) {
+        player.sendMessage(configManager.getMarketMessage(result.getMessageKey(),
+                "item", MarketGUIUtil.prettifyMaterial(order.getMaterial()),
+                "amount", String.valueOf(order.getAmount()),
+                "price", MarketGUIUtil.formatPrice(order.getPrice()),
+                "proceeds", String.valueOf(marketManager.calculateSellerProceeds(order.getPrice())),
+                "currency", configManager.getCurrencyName()));
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/gui/MarketBrowseGUI.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MarketBrowseGUI.java
@@ -22,14 +22,18 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * マーケット一覧 GUI。出品中（active）の全出品をページングして表示し、
+ * マーケット一覧 GUI。出品中（active）の全出品をカテゴリでフィルタし、ページングして表示する。
  * クリックで購入する。クリックイベントの受信は {@link MarketGUIListener} が担当し、
  * 本クラスは描画とクリック処理ロジックを提供する。
+ *
+ * レイアウト: スロット 0〜7 カテゴリボタン、9〜44 出品（36件/ページ）、45〜53 ナビゲーション。
  */
 public class MarketBrowseGUI {
 
     private static final int INVENTORY_SIZE = 54;
-    private static final int ITEMS_PER_PAGE = 45;   // スロット 0〜44 を出品表示に使う
+    private static final int ITEM_START_SLOT = 9;   // 出品表示の開始スロット（1段目はカテゴリボタン）
+    private static final int ITEM_END_SLOT = 44;    // 出品表示の終端スロット（含む）
+    private static final int ITEMS_PER_PAGE = ITEM_END_SLOT - ITEM_START_SLOT + 1; // 36
     private static final int SLOT_PREV = 48;
     private static final int SLOT_INFO = 49;
     private static final int SLOT_NEXT = 50;
@@ -68,19 +72,28 @@ public class MarketBrowseGUI {
     }
 
     /**
-     * 現在ページの内容を描画する（active 出品をページ分割して表示）。
+     * 現在ページ・カテゴリの内容を描画する。
      */
     public void render(Player player, MarketGUISession session) {
         Inventory gui = session.getInventory();
         gui.clear();
         session.clearSlotListings();
 
-        List<MarketListing> listings;
+        List<MarketListing> all;
         try {
-            listings = listingDAO.getActiveListings();
+            all = listingDAO.getActiveListings();
         } catch (SQLException e) {
             plugin.getLogger().warning("マーケット出品一覧の取得に失敗しました: " + e.getMessage());
-            listings = new ArrayList<>();
+            all = new ArrayList<>();
+        }
+
+        // カテゴリでフィルタ
+        MarketCategory category = session.getCategory();
+        List<MarketListing> listings = new ArrayList<>();
+        for (MarketListing listing : all) {
+            if (category.matches(Material.matchMaterial(listing.getMaterial()))) {
+                listings.add(listing);
+            }
         }
 
         int totalPages = Math.max(1, (int) Math.ceil(listings.size() / (double) ITEMS_PER_PAGE));
@@ -94,7 +107,7 @@ public class MarketBrowseGUI {
         int start = session.getPage() * ITEMS_PER_PAGE;
         int end = Math.min(start + ITEMS_PER_PAGE, listings.size());
 
-        int slot = 0;
+        int slot = ITEM_START_SLOT;
         for (int i = start; i < end; i++) {
             MarketListing listing = listings.get(i);
             gui.setItem(slot, buildDisplayItem(listing));
@@ -102,10 +115,29 @@ public class MarketBrowseGUI {
             slot++;
         }
 
-        setupNavigation(gui, session, listings.size(), totalPages);
+        setupCategoryButtons(gui, category);
+        setupNavigation(gui, session, listings.size(), totalPages, all.size());
     }
 
-    private void setupNavigation(Inventory gui, MarketGUISession session, int totalListings, int totalPages) {
+    /**
+     * カテゴリボタンを上段（スロット 0〜7）に配置する。
+     */
+    private void setupCategoryButtons(Inventory gui, MarketCategory current) {
+        MarketCategory[] categories = MarketCategory.values();
+        for (int i = 0; i < categories.length && i < 9; i++) {
+            MarketCategory category = categories[i];
+            boolean selected = category == current;
+            gui.setItem(i, MarketGUIUtil.createButton(
+                    category.getIcon(),
+                    (selected ? "§a§l▶ " : "§f") + category.getDisplayName(),
+                    Arrays.asList(
+                            selected ? "§a選択中" : "§7クリックで絞り込み"
+                    )));
+        }
+    }
+
+    private void setupNavigation(Inventory gui, MarketGUISession session, int filteredCount,
+                                 int totalPages, int totalActive) {
         if (session.getPage() > 0) {
             gui.setItem(SLOT_PREV, MarketGUIUtil.createButton(Material.ARROW, "§a前のページ",
                     Collections.singletonList("§7ページ " + session.getPage() + " へ")));
@@ -117,7 +149,8 @@ public class MarketBrowseGUI {
 
         gui.setItem(SLOT_INFO, MarketGUIUtil.createButton(Material.BOOK, "§6マーケット情報",
                 Arrays.asList(
-                        "§f出品数: §a" + totalListings + " 件",
+                        "§fカテゴリ: " + session.getCategory().getDisplayName(),
+                        "§f表示中: §a" + filteredCount + " §f/ 全 " + totalActive + " 件",
                         "§fページ: §e" + (session.getPage() + 1) + " / " + totalPages,
                         "§7アイテムをクリックして購入"
                 )));
@@ -128,7 +161,11 @@ public class MarketBrowseGUI {
         if (configManager.isGuiDecorationEnabled()) {
             ItemStack glass = MarketGUIUtil.createButton(
                     Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
-            for (int i = ITEMS_PER_PAGE; i < INVENTORY_SIZE; i++) {
+            // カテゴリボタン段の余り（8）と最下段の空きを装飾で埋める
+            if (gui.getItem(8) == null) {
+                gui.setItem(8, glass);
+            }
+            for (int i = 45; i < INVENTORY_SIZE; i++) {
                 if (gui.getItem(i) == null) {
                     gui.setItem(i, glass);
                 }
@@ -186,6 +223,17 @@ public class MarketBrowseGUI {
         if (slot == SLOT_NEXT) {
             session.setPage(session.getPage() + 1);
             render(player, session);
+            return;
+        }
+
+        // カテゴリボタン（スロット 0〜7）
+        if (slot >= 0 && slot < MarketCategory.values().length && slot <= 8) {
+            MarketCategory selected = MarketCategory.values()[slot];
+            if (selected != session.getCategory()) {
+                session.setCategory(selected);
+                session.setPage(0);
+                render(player, session);
+            }
             return;
         }
 

--- a/src/main/java/org/tofu/tofunomics/market/gui/MarketBrowseGUI.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MarketBrowseGUI.java
@@ -1,0 +1,210 @@
+package org.tofu.tofunomics.market.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.MarketListingDAO;
+import org.tofu.tofunomics.market.MarketItemSerializer;
+import org.tofu.tofunomics.market.MarketManager;
+import org.tofu.tofunomics.market.MarketResult;
+import org.tofu.tofunomics.models.MarketListing;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * マーケット一覧 GUI。出品中（active）の全出品をページングして表示し、
+ * クリックで購入する。クリックイベントの受信は {@link MarketGUIListener} が担当し、
+ * 本クラスは描画とクリック処理ロジックを提供する。
+ */
+public class MarketBrowseGUI {
+
+    private static final int INVENTORY_SIZE = 54;
+    private static final int ITEMS_PER_PAGE = 45;   // スロット 0〜44 を出品表示に使う
+    private static final int SLOT_PREV = 48;
+    private static final int SLOT_INFO = 49;
+    private static final int SLOT_NEXT = 50;
+    private static final int SLOT_CLOSE = 53;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final MarketManager marketManager;
+    private final MarketListingDAO listingDAO;
+    private final MarketGUIListener listener;
+
+    public MarketBrowseGUI(TofuNomics plugin, ConfigManager configManager, MarketManager marketManager,
+                           MarketListingDAO listingDAO, MarketGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.marketManager = marketManager;
+        this.listingDAO = listingDAO;
+        this.listener = listener;
+    }
+
+    /**
+     * 一覧 GUI を開く。
+     */
+    public void open(Player player) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, INVENTORY_SIZE, "§6マーケット - 出品一覧");
+            MarketGUISession session = new MarketGUISession(
+                    player.getUniqueId(), MarketGUISession.Type.BROWSE, gui);
+            render(player, session);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("マーケット一覧GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage(configManager.getMarketMessage("error"));
+        }
+    }
+
+    /**
+     * 現在ページの内容を描画する（active 出品をページ分割して表示）。
+     */
+    public void render(Player player, MarketGUISession session) {
+        Inventory gui = session.getInventory();
+        gui.clear();
+        session.clearSlotListings();
+
+        List<MarketListing> listings;
+        try {
+            listings = listingDAO.getActiveListings();
+        } catch (SQLException e) {
+            plugin.getLogger().warning("マーケット出品一覧の取得に失敗しました: " + e.getMessage());
+            listings = new ArrayList<>();
+        }
+
+        int totalPages = Math.max(1, (int) Math.ceil(listings.size() / (double) ITEMS_PER_PAGE));
+        if (session.getPage() >= totalPages) {
+            session.setPage(totalPages - 1);
+        }
+        if (session.getPage() < 0) {
+            session.setPage(0);
+        }
+
+        int start = session.getPage() * ITEMS_PER_PAGE;
+        int end = Math.min(start + ITEMS_PER_PAGE, listings.size());
+
+        int slot = 0;
+        for (int i = start; i < end; i++) {
+            MarketListing listing = listings.get(i);
+            gui.setItem(slot, buildDisplayItem(listing));
+            session.putSlotListing(slot, listing);
+            slot++;
+        }
+
+        setupNavigation(gui, session, listings.size(), totalPages);
+    }
+
+    private void setupNavigation(Inventory gui, MarketGUISession session, int totalListings, int totalPages) {
+        if (session.getPage() > 0) {
+            gui.setItem(SLOT_PREV, MarketGUIUtil.createButton(Material.ARROW, "§a前のページ",
+                    Collections.singletonList("§7ページ " + session.getPage() + " へ")));
+        }
+        if (session.getPage() < totalPages - 1) {
+            gui.setItem(SLOT_NEXT, MarketGUIUtil.createButton(Material.ARROW, "§a次のページ",
+                    Collections.singletonList("§7ページ " + (session.getPage() + 2) + " へ")));
+        }
+
+        gui.setItem(SLOT_INFO, MarketGUIUtil.createButton(Material.BOOK, "§6マーケット情報",
+                Arrays.asList(
+                        "§f出品数: §a" + totalListings + " 件",
+                        "§fページ: §e" + (session.getPage() + 1) + " / " + totalPages,
+                        "§7アイテムをクリックして購入"
+                )));
+
+        gui.setItem(SLOT_CLOSE, MarketGUIUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = MarketGUIUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = ITEMS_PER_PAGE; i < INVENTORY_SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    /**
+     * 出品から表示用アイテムを生成する（実アイテムをデシリアライズし、出品情報を lore に追記）。
+     */
+    private ItemStack buildDisplayItem(MarketListing listing) {
+        ItemStack item = MarketItemSerializer.deserialize(listing.getItemData());
+        if (item == null) {
+            Material material = Material.matchMaterial(listing.getMaterial());
+            if (material == null) {
+                material = Material.BARRIER;
+            }
+            item = new ItemStack(material, Math.max(1, Math.min(listing.getAmount(), 64)));
+        } else {
+            item = item.clone();
+        }
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            if (!meta.hasDisplayName()) {
+                meta.setDisplayName("§f" + MarketGUIUtil.prettifyMaterial(listing.getMaterial()));
+            }
+            List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
+            lore.add("");
+            lore.add("§7出品者: §f" + listing.getSellerName());
+            lore.add("§7個数: §f" + listing.getAmount());
+            lore.add("§7価格: §e" + MarketGUIUtil.formatPrice(listing.getPrice())
+                    + " " + configManager.getCurrencyName());
+            lore.add("");
+            lore.add("§eクリックで購入");
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    /**
+     * クリック処理（{@link MarketGUIListener} から呼ばれる）。
+     */
+    public void handleClick(Player player, MarketGUISession session, int slot, ClickType clickType) {
+        if (slot == SLOT_CLOSE) {
+            player.closeInventory();
+            return;
+        }
+        if (slot == SLOT_PREV) {
+            session.setPage(session.getPage() - 1);
+            render(player, session);
+            return;
+        }
+        if (slot == SLOT_NEXT) {
+            session.setPage(session.getPage() + 1);
+            render(player, session);
+            return;
+        }
+
+        MarketListing listing = session.getListingAtSlot(slot);
+        if (listing == null) {
+            return;
+        }
+
+        MarketResult result = marketManager.purchaseListing(player, listing.getId());
+        sendResultMessage(player, result, listing);
+
+        // 在庫が変化したので再描画（売却済みアイテムを一覧から除去）
+        render(player, session);
+    }
+
+    private void sendResultMessage(Player player, MarketResult result, MarketListing listing) {
+        player.sendMessage(configManager.getMarketMessage(result.getMessageKey(),
+                "item", MarketGUIUtil.prettifyMaterial(listing.getMaterial()),
+                "price", MarketGUIUtil.formatPrice(listing.getPrice()),
+                "currency", configManager.getCurrencyName()));
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/gui/MarketCategory.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MarketCategory.java
@@ -1,0 +1,107 @@
+package org.tofu.tofunomics.market.gui;
+
+import org.bukkit.Material;
+
+/**
+ * マーケット一覧 GUI のカテゴリ。出品アイテムの Material からカテゴリを分類し、
+ * フィルタリングに用いる。分類は TradingGUI のカテゴリ体系に概ね合わせている。
+ */
+public enum MarketCategory {
+
+    ALL("§7すべて", Material.CHEST),
+    MINING("§8鉱物", Material.DIAMOND_PICKAXE),
+    FARMING("§a農作物", Material.WHEAT),
+    LOGGING("§2木材", Material.OAK_LOG),
+    FISHING("§9海産物", Material.COD),
+    CRAFTING("§6製作品", Material.CRAFTING_TABLE),
+    MATERIALS("§5素材", Material.BLAZE_POWDER),
+    OTHER("§fその他", Material.ENDER_PEARL);
+
+    private final String displayName;
+    private final Material icon;
+
+    MarketCategory(String displayName, Material icon) {
+        this.displayName = displayName;
+        this.icon = icon;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public Material getIcon() {
+        return icon;
+    }
+
+    /**
+     * Material をいずれか1つのカテゴリに分類する（ALL を除く）。
+     * どの具体カテゴリにも該当しなければ {@link #OTHER}。
+     */
+    public static MarketCategory classify(Material material) {
+        if (material == null) {
+            return OTHER;
+        }
+        String name = material.name().toLowerCase();
+        // LOGGING を FARMING より先に判定（"log" 等の取りこぼし防止）
+        if (isMining(name)) return MINING;
+        if (isLogging(name)) return LOGGING;
+        if (isFarming(name)) return FARMING;
+        if (isFishing(name)) return FISHING;
+        if (isCrafting(name)) return CRAFTING;
+        if (isMaterials(name)) return MATERIALS;
+        return OTHER;
+    }
+
+    /**
+     * 指定 Material がこのカテゴリに含まれるか。ALL は常に true。
+     */
+    public boolean matches(Material material) {
+        if (this == ALL) {
+            return true;
+        }
+        return classify(material) == this;
+    }
+
+    private static boolean isMining(String name) {
+        return name.contains("ore") || name.contains("ingot") || name.contains("coal")
+                || name.contains("diamond") || name.contains("emerald") || name.contains("redstone")
+                || name.contains("lapis") || name.contains("quartz") || name.contains("netherite")
+                || name.contains("stone") || name.contains("cobblestone") || name.contains("andesite")
+                || name.contains("diorite") || name.contains("granite") || name.startsWith("raw_");
+    }
+
+    private static boolean isLogging(String name) {
+        return name.contains("log") || name.contains("wood") || name.contains("plank")
+                || name.contains("stick") || name.contains("bark") || name.contains("stem")
+                || name.endsWith("_sapling");
+    }
+
+    private static boolean isFarming(String name) {
+        return name.contains("wheat") || name.contains("potato") || name.contains("carrot")
+                || name.contains("beetroot") || name.contains("pumpkin") || name.contains("melon")
+                || name.contains("apple") || name.contains("bread") || name.contains("sugar")
+                || name.contains("cocoa") || name.contains("seeds") || name.contains("egg")
+                || name.contains("beef") || name.contains("porkchop") || name.contains("chicken")
+                || name.contains("mutton");
+    }
+
+    private static boolean isFishing(String name) {
+        return name.contains("cod") || name.contains("salmon") || name.contains("fish")
+                || name.contains("kelp") || name.contains("seagrass") || name.contains("prismarine")
+                || name.contains("nautilus");
+    }
+
+    private static boolean isCrafting(String name) {
+        return name.contains("sword") || name.contains("pickaxe") || name.contains("_axe")
+                || name.endsWith("axe") || name.contains("shovel") || name.contains("hoe")
+                || name.contains("helmet") || name.contains("chestplate") || name.contains("leggings")
+                || name.contains("boots") || name.contains("bow") || name.contains("shield");
+    }
+
+    private static boolean isMaterials(String name) {
+        return name.contains("powder") || name.contains("dust") || name.contains("tear")
+                || name.contains("eye") || name.contains("membrane") || name.contains("cream")
+                || name.contains("string") || name.contains("gunpowder") || name.contains("blaze")
+                || name.contains("ender") || name.contains("slime");
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/gui/MarketGUIListener.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MarketGUIListener.java
@@ -30,17 +30,27 @@ public class MarketGUIListener implements Listener {
 
     private MarketBrowseGUI browseGUI;
     private MyListingsGUI myListingsGUI;
+    private BuyOrderBrowseGUI buyOrderBrowseGUI;
+    private MyBuyOrdersGUI myBuyOrdersGUI;
 
     public MarketGUIListener(TofuNomics plugin) {
         this.plugin = plugin;
     }
 
     /**
-     * GUI 参照を注入する（循環依存を避けるためセッターで後から設定）。
+     * 売り GUI 参照を注入する（循環依存を避けるためセッターで後から設定）。
      */
     public void setGUIs(MarketBrowseGUI browseGUI, MyListingsGUI myListingsGUI) {
         this.browseGUI = browseGUI;
         this.myListingsGUI = myListingsGUI;
+    }
+
+    /**
+     * 買い注文（募集）GUI 参照を注入する。
+     */
+    public void setBuyOrderGUIs(BuyOrderBrowseGUI buyOrderBrowseGUI, MyBuyOrdersGUI myBuyOrdersGUI) {
+        this.buyOrderBrowseGUI = buyOrderBrowseGUI;
+        this.myBuyOrdersGUI = myBuyOrdersGUI;
     }
 
     /**
@@ -92,6 +102,16 @@ public class MarketGUIListener implements Listener {
             case MY_LISTINGS:
                 if (myListingsGUI != null) {
                     myListingsGUI.handleClick(player, session, slot, clickType);
+                }
+                break;
+            case BUY_BROWSE:
+                if (buyOrderBrowseGUI != null) {
+                    buyOrderBrowseGUI.handleClick(player, session, slot, clickType);
+                }
+                break;
+            case MY_BUY_ORDERS:
+                if (myBuyOrdersGUI != null) {
+                    myBuyOrdersGUI.handleClick(player, session, slot, clickType);
                 }
                 break;
             default:

--- a/src/main/java/org/tofu/tofunomics/market/gui/MarketGUIListener.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MarketGUIListener.java
@@ -1,0 +1,126 @@
+package org.tofu.tofunomics.market.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * マーケット GUI（一覧・自分の出品）のクリック/クローズイベントを集約して処理するリスナー。
+ *
+ * 開いている GUI のセッションを {@link ConcurrentHashMap} で管理し、
+ * セッション種別に応じて {@link MarketBrowseGUI} / {@link MyListingsGUI} のクリック処理へ振り分ける。
+ *
+ * 配線順（S4）: 本リスナーを生成 → 各 GUI を生成（コンストラクタに本リスナーを渡す）
+ * → {@link #setGUIs(MarketBrowseGUI, MyListingsGUI)} で GUI 参照を注入 → registerEvents。
+ */
+public class MarketGUIListener implements Listener {
+
+    private final TofuNomics plugin;
+    private final Map<UUID, MarketGUISession> sessions = new ConcurrentHashMap<>();
+
+    private MarketBrowseGUI browseGUI;
+    private MyListingsGUI myListingsGUI;
+
+    public MarketGUIListener(TofuNomics plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * GUI 参照を注入する（循環依存を避けるためセッターで後から設定）。
+     */
+    public void setGUIs(MarketBrowseGUI browseGUI, MyListingsGUI myListingsGUI) {
+        this.browseGUI = browseGUI;
+        this.myListingsGUI = myListingsGUI;
+    }
+
+    /**
+     * GUI を開いた際にセッションを登録する。
+     */
+    public void registerSession(UUID playerId, MarketGUISession session) {
+        sessions.put(playerId, session);
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) {
+            return;
+        }
+        Player player = (Player) event.getWhoClicked();
+        MarketGUISession session = sessions.get(player.getUniqueId());
+        if (session == null || !session.getInventory().equals(event.getInventory())) {
+            return;
+        }
+
+        // GUI 内のクリックは全てキャンセル（アイテムの持ち出し防止）
+        event.setCancelled(true);
+
+        // クリック対象スロットが GUI の範囲外（プレイヤーインベントリ等）の場合は無視
+        if (event.getRawSlot() < 0 || event.getRawSlot() >= session.getInventory().getSize()) {
+            return;
+        }
+
+        ItemStack clicked = event.getCurrentItem();
+        if (clicked == null || clicked.getType() == Material.AIR) {
+            return;
+        }
+
+        try {
+            dispatchClick(player, session, event.getSlot(), event.getClick());
+        } catch (Exception e) {
+            plugin.getLogger().severe("マーケットGUIクリック処理中にエラーが発生しました: " + e.getMessage());
+        }
+    }
+
+    private void dispatchClick(Player player, MarketGUISession session, int slot,
+                               org.bukkit.event.inventory.ClickType clickType) {
+        switch (session.getType()) {
+            case BROWSE:
+                if (browseGUI != null) {
+                    browseGUI.handleClick(player, session, slot, clickType);
+                }
+                break;
+            case MY_LISTINGS:
+                if (myListingsGUI != null) {
+                    myListingsGUI.handleClick(player, session, slot, clickType);
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player)) {
+            return;
+        }
+        Player player = (Player) event.getPlayer();
+        MarketGUISession session = sessions.get(player.getUniqueId());
+        if (session != null && session.getInventory().equals(event.getInventory())) {
+            sessions.remove(player.getUniqueId());
+        }
+    }
+
+    /**
+     * 開いている全マーケット GUI を閉じる（プラグイン無効化時用）。
+     */
+    public void closeAll() {
+        for (MarketGUISession session : sessions.values()) {
+            Player player = Bukkit.getPlayer(session.getPlayerId());
+            if (player != null && player.isOnline()) {
+                player.closeInventory();
+            }
+        }
+        sessions.clear();
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/gui/MarketGUISession.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MarketGUISession.java
@@ -1,0 +1,76 @@
+package org.tofu.tofunomics.market.gui;
+
+import org.bukkit.inventory.Inventory;
+import org.tofu.tofunomics.models.MarketListing;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * マーケット GUI（一覧・自分の出品）の開いている状態を保持するセッション。
+ *
+ * どの種類の GUI が開いているか、現在ページ、各スロットに対応する出品を保持し、
+ * クリック時にスロットから出品を解決できるようにする。
+ */
+public class MarketGUISession {
+
+    /** GUI の種別 */
+    public enum Type {
+        BROWSE,       // マーケット一覧（全 active）
+        MY_LISTINGS   // 自分の出品管理
+    }
+
+    private final UUID playerId;
+    private final Type type;
+    private final Inventory inventory;
+    private int page;
+
+    // スロット番号 → そのスロットに表示している出品
+    private final Map<Integer, MarketListing> slotListings = new HashMap<>();
+
+    public MarketGUISession(UUID playerId, Type type, Inventory inventory) {
+        this.playerId = playerId;
+        this.type = type;
+        this.inventory = inventory;
+        this.page = 0;
+    }
+
+    public UUID getPlayerId() {
+        return playerId;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    /**
+     * 描画時にスロット→出品のマッピングをクリアする
+     */
+    public void clearSlotListings() {
+        slotListings.clear();
+    }
+
+    public void putSlotListing(int slot, MarketListing listing) {
+        slotListings.put(slot, listing);
+    }
+
+    /**
+     * クリックされたスロットに対応する出品を取得する（無ければ null）
+     */
+    public MarketListing getListingAtSlot(int slot) {
+        return slotListings.get(slot);
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/gui/MarketGUISession.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MarketGUISession.java
@@ -26,6 +26,9 @@ public class MarketGUISession {
     private final Inventory inventory;
     private int page;
 
+    // 現在のカテゴリフィルタ（一覧 GUI でのみ使用）
+    private MarketCategory category = MarketCategory.ALL;
+
     // スロット番号 → そのスロットに表示している出品
     private final Map<Integer, MarketListing> slotListings = new HashMap<>();
 
@@ -54,6 +57,14 @@ public class MarketGUISession {
 
     public void setPage(int page) {
         this.page = page;
+    }
+
+    public MarketCategory getCategory() {
+        return category;
+    }
+
+    public void setCategory(MarketCategory category) {
+        this.category = category;
     }
 
     /**

--- a/src/main/java/org/tofu/tofunomics/market/gui/MarketGUISession.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MarketGUISession.java
@@ -1,6 +1,7 @@
 package org.tofu.tofunomics.market.gui;
 
 import org.bukkit.inventory.Inventory;
+import org.tofu.tofunomics.models.MarketBuyOrder;
 import org.tofu.tofunomics.models.MarketListing;
 
 import java.util.HashMap;
@@ -17,8 +18,10 @@ public class MarketGUISession {
 
     /** GUI の種別 */
     public enum Type {
-        BROWSE,       // マーケット一覧（全 active）
-        MY_LISTINGS   // 自分の出品管理
+        BROWSE,        // マーケット一覧（全 active）
+        MY_LISTINGS,   // 自分の出品管理
+        BUY_BROWSE,    // 募集一覧（全 open）
+        MY_BUY_ORDERS  // 自分の募集管理
     }
 
     private final UUID playerId;
@@ -31,6 +34,9 @@ public class MarketGUISession {
 
     // スロット番号 → そのスロットに表示している出品
     private final Map<Integer, MarketListing> slotListings = new HashMap<>();
+
+    // スロット番号 → そのスロットに表示している募集（買い注文 GUI でのみ使用）
+    private final Map<Integer, MarketBuyOrder> slotBuyOrders = new HashMap<>();
 
     public MarketGUISession(UUID playerId, Type type, Inventory inventory) {
         this.playerId = playerId;
@@ -68,10 +74,11 @@ public class MarketGUISession {
     }
 
     /**
-     * 描画時にスロット→出品のマッピングをクリアする
+     * 描画時にスロット→出品/募集のマッピングをクリアする（売り・買い両方）
      */
     public void clearSlotListings() {
         slotListings.clear();
+        slotBuyOrders.clear();
     }
 
     public void putSlotListing(int slot, MarketListing listing) {
@@ -83,5 +90,16 @@ public class MarketGUISession {
      */
     public MarketListing getListingAtSlot(int slot) {
         return slotListings.get(slot);
+    }
+
+    public void putSlotBuyOrder(int slot, MarketBuyOrder order) {
+        slotBuyOrders.put(slot, order);
+    }
+
+    /**
+     * クリックされたスロットに対応する募集を取得する（無ければ null）
+     */
+    public MarketBuyOrder getBuyOrderAtSlot(int slot) {
+        return slotBuyOrders.get(slot);
     }
 }

--- a/src/main/java/org/tofu/tofunomics/market/gui/MarketGUIUtil.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MarketGUIUtil.java
@@ -1,0 +1,61 @@
+package org.tofu.tofunomics.market.gui;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+
+/**
+ * マーケット GUI 共通のヘルパー（ボタン生成・価格整形・Material 名整形）。
+ */
+public final class MarketGUIUtil {
+
+    private MarketGUIUtil() {
+    }
+
+    /**
+     * 表示用ボタン（クリックしても消費されない装飾/操作アイテム）を生成する。
+     */
+    public static ItemStack createButton(Material material, String name, List<String> lore) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    /**
+     * 価格を表示用文字列に整形する。整数値なら小数点を付けない。
+     */
+    public static String formatPrice(double price) {
+        if (price == Math.floor(price) && !Double.isInfinite(price)) {
+            return String.valueOf((long) price);
+        }
+        return String.valueOf(price);
+    }
+
+    /**
+     * Material 名（例: DIAMOND_SWORD）を読みやすい表示名（Diamond Sword）に整形する。
+     */
+    public static String prettifyMaterial(String material) {
+        if (material == null || material.isEmpty()) {
+            return "アイテム";
+        }
+        String[] parts = material.toLowerCase().split("_");
+        StringBuilder sb = new StringBuilder();
+        for (String part : parts) {
+            if (part.isEmpty()) {
+                continue;
+            }
+            if (sb.length() > 0) {
+                sb.append(" ");
+            }
+            sb.append(Character.toUpperCase(part.charAt(0))).append(part.substring(1));
+        }
+        return sb.length() > 0 ? sb.toString() : "アイテム";
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/gui/MyBuyOrdersGUI.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MyBuyOrdersGUI.java
@@ -1,0 +1,236 @@
+package org.tofu.tofunomics.market.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.MarketBuyOrderDAO;
+import org.tofu.tofunomics.market.MarketManager;
+import org.tofu.tofunomics.market.MarketResult;
+import org.tofu.tofunomics.models.MarketBuyOrder;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 自分の募集管理 GUI。募集者の全募集（status 問わず）をページングして表示する。
+ * open をクリックでキャンセル（前払い返金）、fulfilled をクリックで供給アイテムを回収する。
+ * クリックイベントの受信は {@link MarketGUIListener} が担当する。
+ * （自分の出品 {@link MyListingsGUI} の鏡像）
+ */
+public class MyBuyOrdersGUI {
+
+    private static final int INVENTORY_SIZE = 54;
+    private static final int ITEMS_PER_PAGE = 45;
+    private static final int SLOT_PREV = 48;
+    private static final int SLOT_INFO = 49;
+    private static final int SLOT_NEXT = 50;
+    private static final int SLOT_CLOSE = 53;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final MarketManager marketManager;
+    private final MarketBuyOrderDAO buyOrderDAO;
+    private final MarketGUIListener listener;
+
+    public MyBuyOrdersGUI(TofuNomics plugin, ConfigManager configManager, MarketManager marketManager,
+                          MarketBuyOrderDAO buyOrderDAO, MarketGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.marketManager = marketManager;
+        this.buyOrderDAO = buyOrderDAO;
+        this.listener = listener;
+    }
+
+    /**
+     * 自分の募集 GUI を開く。
+     */
+    public void open(Player player) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, INVENTORY_SIZE, "§6マーケット - あなたの募集");
+            MarketGUISession session = new MarketGUISession(
+                    player.getUniqueId(), MarketGUISession.Type.MY_BUY_ORDERS, gui);
+            render(player, session);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("自分の募集GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage(configManager.getMarketMessage("error"));
+        }
+    }
+
+    /**
+     * 現在ページの内容を描画する。
+     */
+    public void render(Player player, MarketGUISession session) {
+        Inventory gui = session.getInventory();
+        gui.clear();
+        session.clearSlotListings();
+
+        List<MarketBuyOrder> orders;
+        try {
+            orders = buyOrderDAO.getOrdersByRequester(player.getUniqueId());
+        } catch (SQLException e) {
+            plugin.getLogger().warning("自分の募集一覧の取得に失敗しました: " + e.getMessage());
+            orders = new ArrayList<>();
+        }
+
+        int totalPages = Math.max(1, (int) Math.ceil(orders.size() / (double) ITEMS_PER_PAGE));
+        if (session.getPage() >= totalPages) {
+            session.setPage(totalPages - 1);
+        }
+        if (session.getPage() < 0) {
+            session.setPage(0);
+        }
+
+        int start = session.getPage() * ITEMS_PER_PAGE;
+        int end = Math.min(start + ITEMS_PER_PAGE, orders.size());
+
+        int slot = 0;
+        for (int i = start; i < end; i++) {
+            MarketBuyOrder order = orders.get(i);
+            gui.setItem(slot, buildDisplayItem(order));
+            session.putSlotBuyOrder(slot, order);
+            slot++;
+        }
+
+        setupNavigation(gui, session, orders.size(), totalPages);
+    }
+
+    private void setupNavigation(Inventory gui, MarketGUISession session, int totalOrders, int totalPages) {
+        if (session.getPage() > 0) {
+            gui.setItem(SLOT_PREV, MarketGUIUtil.createButton(Material.ARROW, "§a前のページ",
+                    Collections.singletonList("§7ページ " + session.getPage() + " へ")));
+        }
+        if (session.getPage() < totalPages - 1) {
+            gui.setItem(SLOT_NEXT, MarketGUIUtil.createButton(Material.ARROW, "§a次のページ",
+                    Collections.singletonList("§7ページ " + (session.getPage() + 2) + " へ")));
+        }
+
+        gui.setItem(SLOT_INFO, MarketGUIUtil.createButton(Material.WRITABLE_BOOK, "§6あなたの募集",
+                Arrays.asList(
+                        "§f募集数: §a" + totalOrders + " 件",
+                        "§fページ: §e" + (session.getPage() + 1) + " / " + totalPages,
+                        "§7募集中をクリックでキャンセル＋返金",
+                        "§7成立済みをクリックでアイテム回収"
+                )));
+
+        gui.setItem(SLOT_CLOSE, MarketGUIUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = MarketGUIUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = ITEMS_PER_PAGE; i < INVENTORY_SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    private ItemStack buildDisplayItem(MarketBuyOrder order) {
+        Material material = Material.matchMaterial(order.getMaterial());
+        if (material == null) {
+            material = Material.BARRIER;
+        }
+        ItemStack item = new ItemStack(material, Math.max(1, Math.min(order.getAmount(), 64)));
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName("§f" + MarketGUIUtil.prettifyMaterial(order.getMaterial()));
+            List<String> lore = new ArrayList<>();
+            lore.add("");
+            lore.add("§7希望個数: §f" + order.getAmount());
+            lore.add("§7前払い額: §e" + MarketGUIUtil.formatPrice(order.getPrice())
+                    + " " + configManager.getCurrencyName());
+            lore.add("§7状態: " + statusLabel(order.getStatus()));
+            lore.add("");
+            lore.addAll(actionHint(order));
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private String statusLabel(String status) {
+        switch (status) {
+            case MarketBuyOrder.STATUS_OPEN:
+                return "§a募集中";
+            case MarketBuyOrder.STATUS_FULFILLED:
+                return "§e成立（回収待ち）";
+            case MarketBuyOrder.STATUS_RECLAIMED:
+                return "§7回収済み";
+            case MarketBuyOrder.STATUS_CANCELLED:
+                return "§7キャンセル済み";
+            case MarketBuyOrder.STATUS_EXPIRED:
+                return "§c期限切れ（返金済み）";
+            default:
+                return "§7" + status;
+        }
+    }
+
+    private List<String> actionHint(MarketBuyOrder order) {
+        if (order.isOpen()) {
+            return Collections.singletonList("§eクリックでキャンセルして前払いを返金");
+        }
+        if (order.isFulfilled()) {
+            return Collections.singletonList("§eクリックで供給されたアイテムを回収");
+        }
+        return Collections.singletonList("§7操作できません");
+    }
+
+    /**
+     * クリック処理（{@link MarketGUIListener} から呼ばれる）。
+     */
+    public void handleClick(Player player, MarketGUISession session, int slot, ClickType clickType) {
+        if (slot == SLOT_CLOSE) {
+            player.closeInventory();
+            return;
+        }
+        if (slot == SLOT_PREV) {
+            session.setPage(session.getPage() - 1);
+            render(player, session);
+            return;
+        }
+        if (slot == SLOT_NEXT) {
+            session.setPage(session.getPage() + 1);
+            render(player, session);
+            return;
+        }
+
+        MarketBuyOrder order = session.getBuyOrderAtSlot(slot);
+        if (order == null) {
+            return;
+        }
+
+        MarketResult result;
+        if (order.isOpen()) {
+            result = marketManager.cancelBuyOrder(player, order.getId());
+        } else if (order.isFulfilled()) {
+            result = marketManager.reclaimBuyOrder(player, order.getId());
+        } else {
+            // reclaimed / cancelled / expired は操作不可
+            return;
+        }
+
+        sendResultMessage(player, result, order);
+        render(player, session);
+    }
+
+    private void sendResultMessage(Player player, MarketResult result, MarketBuyOrder order) {
+        player.sendMessage(configManager.getMarketMessage(result.getMessageKey(),
+                "item", MarketGUIUtil.prettifyMaterial(order.getMaterial()),
+                "amount", String.valueOf(order.getAmount()),
+                "price", MarketGUIUtil.formatPrice(order.getPrice()),
+                "currency", configManager.getCurrencyName()));
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/gui/MyListingsGUI.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MyListingsGUI.java
@@ -1,0 +1,240 @@
+package org.tofu.tofunomics.market.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.MarketListingDAO;
+import org.tofu.tofunomics.market.MarketItemSerializer;
+import org.tofu.tofunomics.market.MarketManager;
+import org.tofu.tofunomics.market.MarketResult;
+import org.tofu.tofunomics.models.MarketListing;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 自分の出品管理 GUI。出品者の全出品（status 問わず）をページングして表示する。
+ * active をクリックでキャンセル回収、expired をクリックで回収する。
+ * クリックイベントの受信は {@link MarketGUIListener} が担当する。
+ */
+public class MyListingsGUI {
+
+    private static final int INVENTORY_SIZE = 54;
+    private static final int ITEMS_PER_PAGE = 45;
+    private static final int SLOT_PREV = 48;
+    private static final int SLOT_INFO = 49;
+    private static final int SLOT_NEXT = 50;
+    private static final int SLOT_CLOSE = 53;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final MarketManager marketManager;
+    private final MarketListingDAO listingDAO;
+    private final MarketGUIListener listener;
+
+    public MyListingsGUI(TofuNomics plugin, ConfigManager configManager, MarketManager marketManager,
+                         MarketListingDAO listingDAO, MarketGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.marketManager = marketManager;
+        this.listingDAO = listingDAO;
+        this.listener = listener;
+    }
+
+    /**
+     * 自分の出品 GUI を開く。
+     */
+    public void open(Player player) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, INVENTORY_SIZE, "§6マーケット - あなたの出品");
+            MarketGUISession session = new MarketGUISession(
+                    player.getUniqueId(), MarketGUISession.Type.MY_LISTINGS, gui);
+            render(player, session);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("自分の出品GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage(configManager.getMarketMessage("error"));
+        }
+    }
+
+    /**
+     * 現在ページの内容を描画する。
+     */
+    public void render(Player player, MarketGUISession session) {
+        Inventory gui = session.getInventory();
+        gui.clear();
+        session.clearSlotListings();
+
+        List<MarketListing> listings;
+        try {
+            listings = listingDAO.getListingsBySeller(player.getUniqueId());
+        } catch (SQLException e) {
+            plugin.getLogger().warning("自分の出品一覧の取得に失敗しました: " + e.getMessage());
+            listings = new ArrayList<>();
+        }
+
+        int totalPages = Math.max(1, (int) Math.ceil(listings.size() / (double) ITEMS_PER_PAGE));
+        if (session.getPage() >= totalPages) {
+            session.setPage(totalPages - 1);
+        }
+        if (session.getPage() < 0) {
+            session.setPage(0);
+        }
+
+        int start = session.getPage() * ITEMS_PER_PAGE;
+        int end = Math.min(start + ITEMS_PER_PAGE, listings.size());
+
+        int slot = 0;
+        for (int i = start; i < end; i++) {
+            MarketListing listing = listings.get(i);
+            gui.setItem(slot, buildDisplayItem(listing));
+            session.putSlotListing(slot, listing);
+            slot++;
+        }
+
+        setupNavigation(gui, session, listings.size(), totalPages);
+    }
+
+    private void setupNavigation(Inventory gui, MarketGUISession session, int totalListings, int totalPages) {
+        if (session.getPage() > 0) {
+            gui.setItem(SLOT_PREV, MarketGUIUtil.createButton(Material.ARROW, "§a前のページ",
+                    Collections.singletonList("§7ページ " + session.getPage() + " へ")));
+        }
+        if (session.getPage() < totalPages - 1) {
+            gui.setItem(SLOT_NEXT, MarketGUIUtil.createButton(Material.ARROW, "§a次のページ",
+                    Collections.singletonList("§7ページ " + (session.getPage() + 2) + " へ")));
+        }
+
+        gui.setItem(SLOT_INFO, MarketGUIUtil.createButton(Material.BOOK, "§6あなたの出品",
+                Arrays.asList(
+                        "§f出品数: §a" + totalListings + " 件",
+                        "§fページ: §e" + (session.getPage() + 1) + " / " + totalPages,
+                        "§7出品中をクリックでキャンセル回収",
+                        "§7期限切れをクリックで回収"
+                )));
+
+        gui.setItem(SLOT_CLOSE, MarketGUIUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = MarketGUIUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = ITEMS_PER_PAGE; i < INVENTORY_SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    private ItemStack buildDisplayItem(MarketListing listing) {
+        ItemStack item = MarketItemSerializer.deserialize(listing.getItemData());
+        if (item == null) {
+            Material material = Material.matchMaterial(listing.getMaterial());
+            if (material == null) {
+                material = Material.BARRIER;
+            }
+            item = new ItemStack(material, Math.max(1, Math.min(listing.getAmount(), 64)));
+        } else {
+            item = item.clone();
+        }
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            if (!meta.hasDisplayName()) {
+                meta.setDisplayName("§f" + MarketGUIUtil.prettifyMaterial(listing.getMaterial()));
+            }
+            List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
+            lore.add("");
+            lore.add("§7個数: §f" + listing.getAmount());
+            lore.add("§7価格: §e" + MarketGUIUtil.formatPrice(listing.getPrice())
+                    + " " + configManager.getCurrencyName());
+            lore.add("§7状態: " + statusLabel(listing.getStatus()));
+            lore.add("");
+            lore.addAll(actionHint(listing));
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private String statusLabel(String status) {
+        switch (status) {
+            case MarketListing.STATUS_ACTIVE:
+                return "§a出品中";
+            case MarketListing.STATUS_EXPIRED:
+                return "§c期限切れ";
+            case MarketListing.STATUS_SOLD:
+                return "§e売却済み";
+            case MarketListing.STATUS_RECLAIMED:
+                return "§7回収済み";
+            default:
+                return "§7" + status;
+        }
+    }
+
+    private List<String> actionHint(MarketListing listing) {
+        if (listing.isActive()) {
+            return Collections.singletonList("§eクリックでキャンセルしてアイテムを回収");
+        }
+        if (listing.isExpired()) {
+            return Collections.singletonList("§eクリックでアイテムを回収");
+        }
+        return Collections.singletonList("§7操作できません");
+    }
+
+    /**
+     * クリック処理（{@link MarketGUIListener} から呼ばれる）。
+     */
+    public void handleClick(Player player, MarketGUISession session, int slot, ClickType clickType) {
+        if (slot == SLOT_CLOSE) {
+            player.closeInventory();
+            return;
+        }
+        if (slot == SLOT_PREV) {
+            session.setPage(session.getPage() - 1);
+            render(player, session);
+            return;
+        }
+        if (slot == SLOT_NEXT) {
+            session.setPage(session.getPage() + 1);
+            render(player, session);
+            return;
+        }
+
+        MarketListing listing = session.getListingAtSlot(slot);
+        if (listing == null) {
+            return;
+        }
+
+        MarketResult result;
+        if (listing.isActive()) {
+            result = marketManager.cancelListing(player, listing.getId());
+        } else if (listing.isExpired()) {
+            result = marketManager.reclaimListing(player, listing.getId());
+        } else {
+            // sold / reclaimed は操作不可
+            return;
+        }
+
+        sendResultMessage(player, result, listing);
+        render(player, session);
+    }
+
+    private void sendResultMessage(Player player, MarketResult result, MarketListing listing) {
+        player.sendMessage(configManager.getMarketMessage(result.getMessageKey(),
+                "item", MarketGUIUtil.prettifyMaterial(listing.getMaterial()),
+                "price", MarketGUIUtil.formatPrice(listing.getPrice()),
+                "currency", configManager.getCurrencyName()));
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/models/MarketBuyOrder.java
+++ b/src/main/java/org/tofu/tofunomics/models/MarketBuyOrder.java
@@ -1,0 +1,165 @@
+package org.tofu.tofunomics.models;
+
+import java.sql.Timestamp;
+import java.util.UUID;
+
+/**
+ * プレイヤー間マーケットの買い注文（募集）を表すモデルクラス
+ *
+ * 売り出品（{@link MarketListing}）の鏡像。募集者が「このアイテムをこの値段で買いたい」と
+ * 募集を出し、別プレイヤーが手持ちから供給して成立させる。
+ *
+ * 代金は募集時に前払い（エスクロー）として募集者の現金から全額拘束される。
+ * 成立時は供給者の bank へ floor(price×0.95) が入金され、差額は通貨総量から消却される。
+ * キャンセル/期限切れ時は前払い分を全額返金する。
+ */
+public class MarketBuyOrder {
+
+    // 募集ステータス定数
+    public static final String STATUS_OPEN = "open";             // 募集中（前払いエスクロー済み）
+    public static final String STATUS_FULFILLED = "fulfilled";   // 供給成立（募集者の回収待ち）
+    public static final String STATUS_RECLAIMED = "reclaimed";   // 募集者が供給アイテムを回収済み
+    public static final String STATUS_CANCELLED = "cancelled";   // 募集者がキャンセル（前払い返金済み）
+    public static final String STATUS_EXPIRED = "expired";       // 期限切れ（前払い返金済み）
+
+    private int id;
+    private UUID requesterUuid;
+    private String requesterName;
+    private String material;       // 募集する Material 名
+    private int amount;            // 募集個数
+    private double price;          // 前払いエスクロー総額
+    private String status;
+    private UUID supplierUuid;     // 供給者（成立時、nullable）
+    private String itemData;       // 供給されたアイテム（Base64、成立時に保存、回収用、nullable）
+    private Timestamp listedAt;
+    private Long expiresAtMillis;  // 失効時刻（epoch millis）。NULL = 無期限
+    private Timestamp fulfilledAt; // 成立時刻（nullable）
+
+    public MarketBuyOrder() {
+    }
+
+    /**
+     * 新規募集用コンストラクタ（id・listedAt は INSERT 時/DB側で確定）
+     */
+    public MarketBuyOrder(UUID requesterUuid, String requesterName, String material,
+                          int amount, double price, Long expiresAtMillis) {
+        this.requesterUuid = requesterUuid;
+        this.requesterName = requesterName;
+        this.material = material;
+        this.amount = amount;
+        this.price = price;
+        this.status = STATUS_OPEN;
+        this.expiresAtMillis = expiresAtMillis;
+    }
+
+    /**
+     * 募集中（供給可能）かどうか
+     */
+    public boolean isOpen() {
+        return STATUS_OPEN.equals(status);
+    }
+
+    /**
+     * 供給成立済み（募集者の回収待ち）かどうか
+     */
+    public boolean isFulfilled() {
+        return STATUS_FULFILLED.equals(status);
+    }
+
+    // Getters and Setters
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public UUID getRequesterUuid() {
+        return requesterUuid;
+    }
+
+    public void setRequesterUuid(UUID requesterUuid) {
+        this.requesterUuid = requesterUuid;
+    }
+
+    public String getRequesterName() {
+        return requesterName;
+    }
+
+    public void setRequesterName(String requesterName) {
+        this.requesterName = requesterName;
+    }
+
+    public String getMaterial() {
+        return material;
+    }
+
+    public void setMaterial(String material) {
+        this.material = material;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public void setAmount(int amount) {
+        this.amount = amount;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+
+    public void setPrice(double price) {
+        this.price = price;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public UUID getSupplierUuid() {
+        return supplierUuid;
+    }
+
+    public void setSupplierUuid(UUID supplierUuid) {
+        this.supplierUuid = supplierUuid;
+    }
+
+    public String getItemData() {
+        return itemData;
+    }
+
+    public void setItemData(String itemData) {
+        this.itemData = itemData;
+    }
+
+    public Timestamp getListedAt() {
+        return listedAt;
+    }
+
+    public void setListedAt(Timestamp listedAt) {
+        this.listedAt = listedAt;
+    }
+
+    public Long getExpiresAtMillis() {
+        return expiresAtMillis;
+    }
+
+    public void setExpiresAtMillis(Long expiresAtMillis) {
+        this.expiresAtMillis = expiresAtMillis;
+    }
+
+    public Timestamp getFulfilledAt() {
+        return fulfilledAt;
+    }
+
+    public void setFulfilledAt(Timestamp fulfilledAt) {
+        this.fulfilledAt = fulfilledAt;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/models/MarketListing.java
+++ b/src/main/java/org/tofu/tofunomics/models/MarketListing.java
@@ -1,0 +1,171 @@
+package org.tofu.tofunomics.models;
+
+import java.sql.Timestamp;
+import java.util.UUID;
+
+/**
+ * プレイヤー間マーケットの出品を表すモデルクラス
+ *
+ * 公開マーケット型：出品者がオフラインでも他プレイヤーが購入できる。
+ * 代金は出品者の bank_balance へ入金され、手数料は通貨総量から消却される。
+ */
+public class MarketListing {
+
+    // 出品ステータス定数
+    public static final String STATUS_ACTIVE = "active";       // 出品中（購入可能）
+    public static final String STATUS_SOLD = "sold";           // 売却済み
+    public static final String STATUS_EXPIRED = "expired";     // 期限切れ（出品者の回収待ち）
+    public static final String STATUS_RECLAIMED = "reclaimed"; // 出品者が回収済み（キャンセル含む）
+
+    private int id;
+    private UUID sellerUuid;
+    private String sellerName;
+    private String itemData;       // Base64(BukkitObjectStream) でシリアライズした ItemStack
+    private String displayName;    // GUI 表示用（nullable）
+    private String material;       // フィルタ・表示用 Material 名
+    private int amount;
+    private double price;          // 出品価格（スタック全体の total）
+    private String status;
+    private UUID buyerUuid;        // 購入者（nullable）
+    private Timestamp listedAt;
+    private Long expiresAtMillis;  // 失効時刻（epoch millis）。NULL = 無期限（listing_duration_days=0）
+    private Timestamp soldAt;      // nullable
+
+    public MarketListing() {
+    }
+
+    /**
+     * 新規出品用コンストラクタ（id・listedAt は INSERT 時/DB側で確定）
+     */
+    public MarketListing(UUID sellerUuid, String sellerName, String itemData, String displayName,
+                         String material, int amount, double price, Long expiresAtMillis) {
+        this.sellerUuid = sellerUuid;
+        this.sellerName = sellerName;
+        this.itemData = itemData;
+        this.displayName = displayName;
+        this.material = material;
+        this.amount = amount;
+        this.price = price;
+        this.status = STATUS_ACTIVE;
+        this.expiresAtMillis = expiresAtMillis;
+    }
+
+    /**
+     * 出品中（購入可能）かどうか
+     */
+    public boolean isActive() {
+        return STATUS_ACTIVE.equals(status);
+    }
+
+    /**
+     * 期限切れ状態かどうか
+     */
+    public boolean isExpired() {
+        return STATUS_EXPIRED.equals(status);
+    }
+
+    // Getters and Setters
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public UUID getSellerUuid() {
+        return sellerUuid;
+    }
+
+    public void setSellerUuid(UUID sellerUuid) {
+        this.sellerUuid = sellerUuid;
+    }
+
+    public String getSellerName() {
+        return sellerName;
+    }
+
+    public void setSellerName(String sellerName) {
+        this.sellerName = sellerName;
+    }
+
+    public String getItemData() {
+        return itemData;
+    }
+
+    public void setItemData(String itemData) {
+        this.itemData = itemData;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getMaterial() {
+        return material;
+    }
+
+    public void setMaterial(String material) {
+        this.material = material;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public void setAmount(int amount) {
+        this.amount = amount;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+
+    public void setPrice(double price) {
+        this.price = price;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public UUID getBuyerUuid() {
+        return buyerUuid;
+    }
+
+    public void setBuyerUuid(UUID buyerUuid) {
+        this.buyerUuid = buyerUuid;
+    }
+
+    public Timestamp getListedAt() {
+        return listedAt;
+    }
+
+    public void setListedAt(Timestamp listedAt) {
+        this.listedAt = listedAt;
+    }
+
+    public Long getExpiresAtMillis() {
+        return expiresAtMillis;
+    }
+
+    public void setExpiresAtMillis(Long expiresAtMillis) {
+        this.expiresAtMillis = expiresAtMillis;
+    }
+
+    public Timestamp getSoldAt() {
+        return soldAt;
+    }
+
+    public void setSoldAt(Timestamp soldAt) {
+        this.soldAt = soldAt;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2055,8 +2055,10 @@ market:
   listing_duration_days: 7        # 出品の有効日数（0で無期限）
   min_price: 1                    # 最低出品価格
   max_price: 1000000              # 最高出品価格
-  allow_self_purchase: false      # 自分の出品を購入可能にするか
+  allow_self_purchase: false      # 自分の出品を購入可能にするか（買い注文への自己供給可否も兼ねる）
   expire_check_interval: 3600     # 期限切れチェック間隔（秒）
+  max_buy_orders_per_player: 10   # 買い注文（募集）の同時保有上限
+  # fee_rate / listing_duration_days / min_price / max_price は買い注文と共用
 
 # メッセージ設定
 messages:
@@ -2078,6 +2080,17 @@ messages:
     insufficient_funds: "&c残高が不足しています。"
     inventory_full: "&cインベントリに空きがありません。アイテムを整理してください。"
     not_owner: "&cこれはあなたの出品ではありません。"
+    # 募集（買い注文）
+    requested: "&a%item% x%amount% の募集を &e%price% %currency%&a で登録しました（前払い）。"
+    fulfilled: "&a募集に応じ %item% x%amount% を供給しました。&e%proceeds% %currency%&a を受け取りました。"
+    fulfilled_notify: "&aあなたの募集（%item% x%amount%）が成立しました。アイテムは /market myrequests から回収できます。"
+    request_cancelled: "&a募集をキャンセルし、前払い分を返金しました。"
+    request_reclaimed: "&a成立した募集からアイテムを回収しました。"
+    request_expired_refund: "&e募集が期限切れになり、前払い分を返金しました。"
+    request_limit: "&c募集数の上限（%limit%）に達しています。"
+    no_matching_item: "&c供給するアイテム（%item% x%amount%）を所持していません。"
+    request_not_available: "&cこの募集は既に成立済みか、存在しません。"
+    request_not_owner: "&cこれはあなたの募集ではありません。"
     error: "&c処理中にエラーが発生しました。もう一度お試しください。"
   no_permission: "&c権限がありません。"
   player_not_found: "&cプレイヤーが見つかりません。"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2047,10 +2047,38 @@ scoreboard:
       - "&e/scoreboard on"
       - "&7で表示できます"
 
+# プレイヤー間マーケット設定
+market:
+  enabled: true
+  fee_rate: 0.05                  # 販売手数料率（出品者受取 = price × (1 - fee_rate)、端数は切り捨て）
+  max_listings_per_player: 10     # 1人あたり同時出品上限
+  listing_duration_days: 7        # 出品の有効日数（0で無期限）
+  min_price: 1                    # 最低出品価格
+  max_price: 1000000              # 最高出品価格
+  allow_self_purchase: false      # 自分の出品を購入可能にするか
+  expire_check_interval: 3600     # 期限切れチェック間隔（秒）
+
 # メッセージ設定
 messages:
   # 共通メッセージ
   prefix: "&6[TofuNomics] &f"
+  # プレイヤー間マーケット
+  market:
+    listed: "&a%item% を &e%price% %currency%&a で出品しました。"
+    purchased: "&a%item% を &e%price% %currency%&a で購入しました。"
+    sold_notify: "&a出品した %item% が売れました！手数料を引いた &e%amount% %currency%&a を受け取りました。"
+    cancelled: "&a出品をキャンセルし、アイテムを回収しました。"
+    reclaimed: "&a期限切れの出品からアイテムを回収しました。"
+    invalid_item: "&c出品するアイテムを手に持ってください。"
+    invalid_price: "&c価格は &e%min%&c 〜 &e%max%&c の整数で指定してください。"
+    currency_not_allowed: "&c通貨アイテムは出品できません。"
+    listing_limit: "&c出品数の上限（%limit%）に達しています。"
+    not_available: "&cこの出品は購入できません。"
+    already_sold: "&cこの出品は既に売り切れました。"
+    insufficient_funds: "&c残高が不足しています。"
+    inventory_full: "&cインベントリに空きがありません。アイテムを整理してください。"
+    not_owner: "&cこれはあなたの出品ではありません。"
+    error: "&c処理中にエラーが発生しました。もう一度お試しください。"
   no_permission: "&c権限がありません。"
   player_not_found: "&cプレイヤーが見つかりません。"
   invalid_amount: "&c無効な金額です。"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -89,7 +89,7 @@ commands:
     permission: tofunomics.citymap.use
   market:
     description: プレイヤー間マーケット
-    usage: /market <sell|mylistings|cancel|reclaim|reload> [args]
+    usage: /market <sell|mylistings|cancel|reclaim|buy|requests|myrequests|cancelrequest|reclaimrequest|reload> [args]
     aliases: [mk]
     permission: tofunomics.market.use
 
@@ -285,15 +285,20 @@ permissions:
     children:
       tofunomics.market.use: true
       tofunomics.market.sell: true
+      tofunomics.market.buy: true
       tofunomics.market.admin: false
     default: op
 
   tofunomics.market.use:
-    description: マーケットの閲覧・購入・自分の出品管理
+    description: マーケットの閲覧・購入・自分の出品/募集管理
     default: true
 
   tofunomics.market.sell:
     description: マーケットへの出品
+    default: true
+
+  tofunomics.market.buy:
+    description: 募集（買い注文）の登録
     default: true
 
   tofunomics.market.admin:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -87,6 +87,11 @@ commands:
     description: 中心都市の案内地図を入手する
     usage: /citymap
     permission: tofunomics.citymap.use
+  market:
+    description: プレイヤー間マーケット
+    usage: /market <sell|mylistings|cancel|reclaim|reload> [args]
+    aliases: [mk]
+    permission: tofunomics.market.use
 
 permissions:
   tofunomics.*:
@@ -100,6 +105,7 @@ permissions:
       tofunomics.jobs.*: true
       tofunomics.trade.*: true
       tofunomics.scoreboard.*: true
+      tofunomics.market.*: true
       tofunomics.admin: false
     default: op
   
@@ -272,4 +278,24 @@ permissions:
   
   tofunomics.rules.reset:
     description: ルール同意状態をリセット（テスト用）
+    default: op
+
+  tofunomics.market.*:
+    description: プレイヤー間マーケット関連権限（全て）
+    children:
+      tofunomics.market.use: true
+      tofunomics.market.sell: true
+      tofunomics.market.admin: false
+    default: op
+
+  tofunomics.market.use:
+    description: マーケットの閲覧・購入・自分の出品管理
+    default: true
+
+  tofunomics.market.sell:
+    description: マーケットへの出品
+    default: true
+
+  tofunomics.market.admin:
+    description: マーケットの管理操作（設定再読み込み等）
     default: op

--- a/src/test/java/org/tofu/tofunomics/dao/MarketBuyOrderDAOTest.java
+++ b/src/test/java/org/tofu/tofunomics/dao/MarketBuyOrderDAOTest.java
@@ -1,0 +1,233 @@
+package org.tofu.tofunomics.dao;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.tofu.tofunomics.models.MarketBuyOrder;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * MarketBuyOrderDAO 単体テスト
+ *
+ * 本番 DatabaseManager と同一の DDL を SQLite インメモリ DB に作成して検証する
+ * （AUTOINCREMENT・DEFAULT CURRENT_TIMESTAMP・epoch millis 比較など SQLite 固有挙動を本番同等に再現）。
+ */
+public class MarketBuyOrderDAOTest {
+
+    private Connection connection;
+    private MarketBuyOrderDAO dao;
+    private final double DELTA = 0.001;
+
+    @Before
+    public void setUp() throws SQLException {
+        connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+
+        String createTable = "CREATE TABLE IF NOT EXISTS market_buy_orders (" +
+                "    id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                "    requester_uuid TEXT NOT NULL," +
+                "    requester_name TEXT NOT NULL," +
+                "    material TEXT NOT NULL," +
+                "    amount INTEGER NOT NULL," +
+                "    price REAL NOT NULL," +
+                "    status TEXT NOT NULL DEFAULT 'open'," +
+                "    supplier_uuid TEXT," +
+                "    item_data TEXT," +
+                "    listed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+                "    expires_at INTEGER," +
+                "    fulfilled_at TIMESTAMP" +
+                ");";
+
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(createTable);
+        }
+
+        dao = new MarketBuyOrderDAO(connection);
+    }
+
+    @After
+    public void tearDown() throws SQLException {
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    /**
+     * テスト用の open 募集を作成して id を返すヘルパー
+     */
+    private int insertOpen(UUID requester, String requesterName, int amount, double price, Long expiresAtMillis) throws SQLException {
+        MarketBuyOrder order = new MarketBuyOrder(
+                requester, requesterName, "DIAMOND", amount, price, expiresAtMillis);
+        return dao.insertBuyOrder(order);
+    }
+
+    @Test
+    public void testInsertAndGetById() throws SQLException {
+        UUID requester = UUID.randomUUID();
+        int id = insertOpen(requester, "Alice", 10, 100.0, null);
+
+        assertTrue("生成された id は正の値であるべき", id > 0);
+
+        MarketBuyOrder fetched = dao.getById(id);
+        assertNotNull("挿入した募集が取得できるべき", fetched);
+        assertEquals(requester, fetched.getRequesterUuid());
+        assertEquals("Alice", fetched.getRequesterName());
+        assertEquals("DIAMOND", fetched.getMaterial());
+        assertEquals(10, fetched.getAmount());
+        assertEquals(100.0, fetched.getPrice(), DELTA);
+        assertEquals(MarketBuyOrder.STATUS_OPEN, fetched.getStatus());
+        assertNull("無期限募集の expires_at は null であるべき", fetched.getExpiresAtMillis());
+        assertNull("未成立の supplier_uuid は null であるべき", fetched.getSupplierUuid());
+        assertNull("未成立の item_data は null であるべき", fetched.getItemData());
+        assertNull("未成立の fulfilled_at は null であるべき", fetched.getFulfilledAt());
+        assertNotNull("listed_at は DEFAULT で自動設定されるべき", fetched.getListedAt());
+    }
+
+    @Test
+    public void testGetByIdNotFound() throws SQLException {
+        assertNull("存在しない id は null を返すべき", dao.getById(9999));
+    }
+
+    @Test
+    public void testGetOpenOrders() throws SQLException {
+        UUID r1 = UUID.randomUUID();
+        UUID r2 = UUID.randomUUID();
+        int id1 = insertOpen(r1, "Alice", 10, 100.0, null);
+        insertOpen(r2, "Bob", 5, 200.0, null);
+
+        // 1件を fulfilled にする → open 一覧から除外される
+        dao.markAsFulfilled(id1, UUID.randomUUID(), "SUPPLIED_BASE64", System.currentTimeMillis());
+
+        List<MarketBuyOrder> open = dao.getOpenOrders();
+        assertEquals("open のみ取得されるべき", 1, open.size());
+        assertEquals("Bob", open.get(0).getRequesterName());
+    }
+
+    @Test
+    public void testGetOrdersByRequester() throws SQLException {
+        UUID requester = UUID.randomUUID();
+        UUID other = UUID.randomUUID();
+        int id1 = insertOpen(requester, "Alice", 10, 100.0, null);
+        insertOpen(requester, "Alice", 8, 150.0, null);
+        insertOpen(other, "Bob", 5, 200.0, null);
+
+        // status 問わず自分の募集を全件取得
+        dao.markAsFulfilled(id1, UUID.randomUUID(), "SUPPLIED_BASE64", System.currentTimeMillis());
+
+        List<MarketBuyOrder> mine = dao.getOrdersByRequester(requester);
+        assertEquals("自分の募集は status 問わず全件取得されるべき", 2, mine.size());
+    }
+
+    @Test
+    public void testCountOpenByRequester() throws SQLException {
+        UUID requester = UUID.randomUUID();
+        int id1 = insertOpen(requester, "Alice", 10, 100.0, null);
+        insertOpen(requester, "Alice", 8, 150.0, null);
+
+        assertEquals(2, dao.countOpenByRequester(requester));
+
+        // 1件 fulfilled にすると open カウントから外れる
+        dao.markAsFulfilled(id1, UUID.randomUUID(), "SUPPLIED_BASE64", System.currentTimeMillis());
+        assertEquals(1, dao.countOpenByRequester(requester));
+    }
+
+    /**
+     * 二重供給防止の核心：markAsFulfilled は open の行のみ更新し、影響行数 1 のときだけ true。
+     */
+    @Test
+    public void testMarkAsFulfilledOptimisticLock() throws SQLException {
+        UUID requester = UUID.randomUUID();
+        int id = insertOpen(requester, "Alice", 10, 100.0, null);
+
+        UUID supplier1 = UUID.randomUUID();
+        UUID supplier2 = UUID.randomUUID();
+
+        boolean first = dao.markAsFulfilled(id, supplier1, "ITEM1", System.currentTimeMillis());
+        boolean second = dao.markAsFulfilled(id, supplier2, "ITEM2", System.currentTimeMillis());
+
+        assertTrue("最初の供給は成功するべき", first);
+        assertFalse("2回目の供給は失敗するべき（二重供給防止）", second);
+
+        MarketBuyOrder fetched = dao.getById(id);
+        assertEquals(MarketBuyOrder.STATUS_FULFILLED, fetched.getStatus());
+        assertEquals("供給者は最初の供給者であるべき", supplier1, fetched.getSupplierUuid());
+        assertEquals("供給アイテムは最初のものであるべき", "ITEM1", fetched.getItemData());
+        assertNotNull(fetched.getFulfilledAt());
+    }
+
+    @Test
+    public void testGetExpiredOpenOrders() throws SQLException {
+        UUID requester = UUID.randomUUID();
+        insertOpen(requester, "Alice", 10, 100.0, 1000L);   // 失効=epoch 1000
+        insertOpen(requester, "Alice", 5, 200.0, null);     // 無期限
+        insertOpen(requester, "Alice", 3, 300.0, 5000L);    // 失効=epoch 5000
+
+        assertEquals("now=500 では期限切れ0件", 0, dao.getExpiredOpenOrders(500L).size());
+
+        // now=2000 → epoch 1000 のみ期限切れ。無期限・未来失効は対象外
+        List<MarketBuyOrder> expired = dao.getExpiredOpenOrders(2000L);
+        assertEquals("now=2000 では期限切れ1件", 1, expired.size());
+        assertEquals(100.0, expired.get(0).getPrice(), DELTA);
+    }
+
+    /**
+     * 期限切れ募集は fulfilled になっていると対象外（既に成立した募集は返金対象にしない）。
+     */
+    @Test
+    public void testGetExpiredOpenOrdersExcludesFulfilled() throws SQLException {
+        UUID requester = UUID.randomUUID();
+        int id = insertOpen(requester, "Alice", 10, 100.0, 1000L);
+        dao.markAsFulfilled(id, UUID.randomUUID(), "ITEM", System.currentTimeMillis());
+
+        assertEquals("fulfilled 済みは期限切れ取得の対象外", 0, dao.getExpiredOpenOrders(2000L).size());
+    }
+
+    @Test
+    public void testUpdateStatusConditionalCancel() throws SQLException {
+        UUID requester = UUID.randomUUID();
+        int id = insertOpen(requester, "Alice", 10, 100.0, null);
+
+        // open → cancelled（キャンセル）
+        boolean ok = dao.updateStatusConditional(id, MarketBuyOrder.STATUS_OPEN, MarketBuyOrder.STATUS_CANCELLED);
+        assertTrue("open からのキャンセルは成功するべき", ok);
+        assertEquals(MarketBuyOrder.STATUS_CANCELLED, dao.getById(id).getStatus());
+
+        // 既に cancelled のため再度の open 起点の遷移は失敗
+        boolean again = dao.updateStatusConditional(id, MarketBuyOrder.STATUS_OPEN, MarketBuyOrder.STATUS_CANCELLED);
+        assertFalse("期待ステータス不一致の遷移は失敗するべき", again);
+    }
+
+    @Test
+    public void testUpdateStatusConditionalExpire() throws SQLException {
+        UUID requester = UUID.randomUUID();
+        int id = insertOpen(requester, "Alice", 10, 100.0, 1000L);
+
+        // open → expired（期限切れ）。返金は Manager 側で行うため DAO は状態遷移のみ
+        boolean ok = dao.updateStatusConditional(id, MarketBuyOrder.STATUS_OPEN, MarketBuyOrder.STATUS_EXPIRED);
+        assertTrue("open からの期限切れ化は成功するべき", ok);
+        assertEquals(MarketBuyOrder.STATUS_EXPIRED, dao.getById(id).getStatus());
+    }
+
+    @Test
+    public void testReclaimFulfilledOrder() throws SQLException {
+        UUID requester = UUID.randomUUID();
+        int id = insertOpen(requester, "Alice", 10, 100.0, null);
+        dao.markAsFulfilled(id, UUID.randomUUID(), "SUPPLIED_BASE64", System.currentTimeMillis());
+
+        // fulfilled → reclaimed（回収）
+        boolean ok = dao.updateStatusConditional(id, MarketBuyOrder.STATUS_FULFILLED, MarketBuyOrder.STATUS_RECLAIMED);
+        assertTrue("fulfilled からの回収は成功するべき", ok);
+        assertEquals(MarketBuyOrder.STATUS_RECLAIMED, dao.getById(id).getStatus());
+
+        // 二重回収防止
+        boolean again = dao.updateStatusConditional(id, MarketBuyOrder.STATUS_FULFILLED, MarketBuyOrder.STATUS_RECLAIMED);
+        assertFalse("二重回収は失敗するべき", again);
+    }
+}

--- a/src/test/java/org/tofu/tofunomics/dao/MarketListingDAOTest.java
+++ b/src/test/java/org/tofu/tofunomics/dao/MarketListingDAOTest.java
@@ -1,0 +1,216 @@
+package org.tofu.tofunomics.dao;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.tofu.tofunomics.models.MarketListing;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * MarketListingDAO 単体テスト
+ *
+ * 本番 DatabaseManager と同一の DDL を SQLite インメモリ DB に作成して検証する
+ * （AUTOINCREMENT・DEFAULT CURRENT_TIMESTAMP・epoch millis 比較など SQLite 固有挙動を本番同等に再現）。
+ */
+public class MarketListingDAOTest {
+
+    private Connection connection;
+    private MarketListingDAO dao;
+    private final double DELTA = 0.001;
+
+    @Before
+    public void setUp() throws SQLException {
+        connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+
+        String createTable = "CREATE TABLE IF NOT EXISTS market_listings (" +
+                "    id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                "    seller_uuid TEXT NOT NULL," +
+                "    seller_name TEXT NOT NULL," +
+                "    item_data TEXT NOT NULL," +
+                "    display_name TEXT," +
+                "    material TEXT NOT NULL," +
+                "    amount INTEGER NOT NULL," +
+                "    price REAL NOT NULL," +
+                "    status TEXT NOT NULL DEFAULT 'active'," +
+                "    buyer_uuid TEXT," +
+                "    listed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+                "    expires_at INTEGER," +
+                "    sold_at TIMESTAMP" +
+                ");";
+
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(createTable);
+        }
+
+        dao = new MarketListingDAO(connection);
+    }
+
+    @After
+    public void tearDown() throws SQLException {
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    /**
+     * テスト用の active 出品を作成して id を返すヘルパー
+     */
+    private int insertActive(UUID seller, String sellerName, double price, Long expiresAtMillis) throws SQLException {
+        MarketListing listing = new MarketListing(
+                seller, sellerName, "DUMMY_BASE64", "テストアイテム", "DIAMOND", 5, price, expiresAtMillis);
+        return dao.insertListing(listing);
+    }
+
+    @Test
+    public void testInsertAndGetById() throws SQLException {
+        UUID seller = UUID.randomUUID();
+        int id = insertActive(seller, "Alice", 100.0, null);
+
+        assertTrue("生成された id は正の値であるべき", id > 0);
+
+        MarketListing fetched = dao.getById(id);
+        assertNotNull("挿入した出品が取得できるべき", fetched);
+        assertEquals(seller, fetched.getSellerUuid());
+        assertEquals("Alice", fetched.getSellerName());
+        assertEquals("DUMMY_BASE64", fetched.getItemData());
+        assertEquals("DIAMOND", fetched.getMaterial());
+        assertEquals(5, fetched.getAmount());
+        assertEquals(100.0, fetched.getPrice(), DELTA);
+        assertEquals(MarketListing.STATUS_ACTIVE, fetched.getStatus());
+        assertNull("無期限出品の expires_at は null であるべき", fetched.getExpiresAtMillis());
+        assertNull("未売却の buyer_uuid は null であるべき", fetched.getBuyerUuid());
+        assertNotNull("listed_at は DEFAULT で自動設定されるべき", fetched.getListedAt());
+    }
+
+    @Test
+    public void testGetByIdNotFound() throws SQLException {
+        assertNull("存在しない id は null を返すべき", dao.getById(9999));
+    }
+
+    @Test
+    public void testGetActiveListings() throws SQLException {
+        UUID s1 = UUID.randomUUID();
+        UUID s2 = UUID.randomUUID();
+        int id1 = insertActive(s1, "Alice", 100.0, null);
+        insertActive(s2, "Bob", 200.0, null);
+
+        // 1件を sold にする → active 一覧から除外される
+        dao.markAsSold(id1, UUID.randomUUID(), System.currentTimeMillis());
+
+        List<MarketListing> active = dao.getActiveListings();
+        assertEquals("active のみ取得されるべき", 1, active.size());
+        assertEquals("Bob", active.get(0).getSellerName());
+    }
+
+    @Test
+    public void testGetListingsBySeller() throws SQLException {
+        UUID seller = UUID.randomUUID();
+        UUID other = UUID.randomUUID();
+        int id1 = insertActive(seller, "Alice", 100.0, null);
+        insertActive(seller, "Alice", 150.0, null);
+        insertActive(other, "Bob", 200.0, null);
+
+        // status 問わず自分の出品を全件取得
+        dao.markAsSold(id1, UUID.randomUUID(), System.currentTimeMillis());
+
+        List<MarketListing> mine = dao.getListingsBySeller(seller);
+        assertEquals("自分の出品は status 問わず全件取得されるべき", 2, mine.size());
+    }
+
+    @Test
+    public void testCountActiveBySeller() throws SQLException {
+        UUID seller = UUID.randomUUID();
+        int id1 = insertActive(seller, "Alice", 100.0, null);
+        insertActive(seller, "Alice", 150.0, null);
+
+        assertEquals(2, dao.countActiveBySeller(seller));
+
+        // 1件 sold にすると active カウントから外れる
+        dao.markAsSold(id1, UUID.randomUUID(), System.currentTimeMillis());
+        assertEquals(1, dao.countActiveBySeller(seller));
+    }
+
+    /**
+     * 二重購入防止の核心：markAsSold は active の行のみ更新し、影響行数 1 のときだけ true。
+     */
+    @Test
+    public void testMarkAsSoldOptimisticLock() throws SQLException {
+        UUID seller = UUID.randomUUID();
+        int id = insertActive(seller, "Alice", 100.0, null);
+
+        UUID buyer1 = UUID.randomUUID();
+        UUID buyer2 = UUID.randomUUID();
+
+        boolean first = dao.markAsSold(id, buyer1, System.currentTimeMillis());
+        boolean second = dao.markAsSold(id, buyer2, System.currentTimeMillis());
+
+        assertTrue("最初の購入は成功するべき", first);
+        assertFalse("2回目の購入は失敗するべき（二重購入防止）", second);
+
+        MarketListing fetched = dao.getById(id);
+        assertEquals(MarketListing.STATUS_SOLD, fetched.getStatus());
+        assertEquals("購入者は最初の購入者であるべき", buyer1, fetched.getBuyerUuid());
+        assertNotNull(fetched.getSoldAt());
+    }
+
+    @Test
+    public void testExpireActiveListings() throws SQLException {
+        UUID seller = UUID.randomUUID();
+        int expiringId = insertActive(seller, "Alice", 100.0, 1000L);   // 失効=epoch 1000
+        int permanentId = insertActive(seller, "Alice", 200.0, null);   // 無期限
+        int futureId = insertActive(seller, "Alice", 300.0, 5000L);     // 失効=epoch 5000
+
+        // now=2000 → expiringId のみ期限切れ
+        int expiredCount = dao.expireActiveListings(2000L);
+        assertEquals("期限切れ化される件数は1件であるべき", 1, expiredCount);
+
+        assertEquals(MarketListing.STATUS_EXPIRED, dao.getById(expiringId).getStatus());
+        assertEquals("無期限は対象外", MarketListing.STATUS_ACTIVE, dao.getById(permanentId).getStatus());
+        assertEquals("未来失効は対象外", MarketListing.STATUS_ACTIVE, dao.getById(futureId).getStatus());
+    }
+
+    @Test
+    public void testGetExpiredActiveListings() throws SQLException {
+        UUID seller = UUID.randomUUID();
+        insertActive(seller, "Alice", 100.0, 1000L);
+        insertActive(seller, "Alice", 200.0, null);
+
+        assertEquals("now=500 では期限切れ0件", 0, dao.getExpiredActiveListings(500L).size());
+        assertEquals("now=2000 では期限切れ1件", 1, dao.getExpiredActiveListings(2000L).size());
+    }
+
+    @Test
+    public void testUpdateStatusConditional() throws SQLException {
+        UUID seller = UUID.randomUUID();
+        int id = insertActive(seller, "Alice", 100.0, null);
+
+        // active → reclaimed（キャンセル）
+        boolean ok = dao.updateStatusConditional(id, MarketListing.STATUS_ACTIVE, MarketListing.STATUS_RECLAIMED);
+        assertTrue("active からの状態遷移は成功するべき", ok);
+        assertEquals(MarketListing.STATUS_RECLAIMED, dao.getById(id).getStatus());
+
+        // 既に reclaimed のため再度の active 起点の遷移は失敗
+        boolean again = dao.updateStatusConditional(id, MarketListing.STATUS_ACTIVE, MarketListing.STATUS_RECLAIMED);
+        assertFalse("期待ステータス不一致の遷移は失敗するべき", again);
+    }
+
+    @Test
+    public void testReclaimExpiredListing() throws SQLException {
+        UUID seller = UUID.randomUUID();
+        int id = insertActive(seller, "Alice", 100.0, 1000L);
+        dao.expireActiveListings(2000L);
+
+        // expired → reclaimed（回収）
+        boolean ok = dao.updateStatusConditional(id, MarketListing.STATUS_EXPIRED, MarketListing.STATUS_RECLAIMED);
+        assertTrue("expired からの回収は成功するべき", ok);
+        assertEquals(MarketListing.STATUS_RECLAIMED, dao.getById(id).getStatus());
+    }
+}

--- a/src/test/java/org/tofu/tofunomics/market/MarketItemSerializerTest.java
+++ b/src/test/java/org/tofu/tofunomics/market/MarketItemSerializerTest.java
@@ -1,0 +1,43 @@
+package org.tofu.tofunomics.market;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * MarketItemSerializer 単体テスト
+ *
+ * ItemStack の往復（serialize → deserialize）は Bukkit サーバ実装（ItemFactory）に依存し、
+ * MockBukkit を導入していない本プロジェクトのユニットテストでは再現できないため、
+ * E2E 検証（実サーバでの出品→購入）に委ねる。
+ * 本テストでは Bukkit 非依存のエッジケース（null・空・不正入力）の防御挙動を検証する。
+ */
+public class MarketItemSerializerTest {
+
+    @Test
+    public void testSerializeNullReturnsNull() {
+        assertNull("null アイテムは null を返すべき", MarketItemSerializer.serialize(null));
+    }
+
+    @Test
+    public void testDeserializeNullReturnsNull() {
+        assertNull("null データは null を返すべき", MarketItemSerializer.deserialize(null));
+    }
+
+    @Test
+    public void testDeserializeEmptyReturnsNull() {
+        assertNull("空文字列は null を返すべき", MarketItemSerializer.deserialize(""));
+    }
+
+    @Test
+    public void testDeserializeInvalidBase64ReturnsNull() {
+        // Base64 として不正な文字列 → IllegalArgumentException を握りつぶして null
+        assertNull("不正な Base64 は null を返すべき", MarketItemSerializer.deserialize("!!! not base64 !!!"));
+    }
+
+    @Test
+    public void testDeserializeValidBase64ButNotItemStackReturnsNull() {
+        // Base64 としては妥当だが ItemStack のバイナリではない → null
+        assertNull("ItemStack でないデータは null を返すべき", MarketItemSerializer.deserialize("aGVsbG8gd29ybGQ="));
+    }
+}

--- a/src/test/java/org/tofu/tofunomics/market/MarketManagerTest.java
+++ b/src/test/java/org/tofu/tofunomics/market/MarketManagerTest.java
@@ -1,0 +1,308 @@
+package org.tofu.tofunomics.market;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.MarketListingDAO;
+import org.tofu.tofunomics.dao.PlayerDAO;
+import org.tofu.tofunomics.models.MarketListing;
+import org.tofu.tofunomics.models.Player;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * MarketManager のコアロジック単体テスト。
+ *
+ * Bukkit 非依存の決済コア（executeCreateListing / executePurchaseTransaction / executeReclaim /
+ * 手数料計算 / 価格検証）を、SQLite インメモリ DB と Mockito 化した ConfigManager で検証する。
+ * Player/ItemStack/インベントリに依存するラッパーは E2E 検証に委ねる。
+ */
+public class MarketManagerTest {
+
+    private Connection connection;
+    private PlayerDAO playerDAO;
+    private MarketListingDAO listingDAO;
+    private ConfigManager configManager;
+    private MarketManager manager;
+    private final double DELTA = 0.001;
+
+    @Before
+    public void setUp() throws SQLException {
+        connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+
+        try (Statement st = connection.createStatement()) {
+            st.execute("CREATE TABLE IF NOT EXISTS players (" +
+                    "uuid TEXT PRIMARY KEY," +
+                    "balance REAL NOT NULL DEFAULT 0.0," +
+                    "bank_balance REAL NOT NULL DEFAULT 0.0," +
+                    "created_at TIMESTAMP," +
+                    "updated_at TIMESTAMP);");
+            st.execute("CREATE TABLE IF NOT EXISTS market_listings (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "seller_uuid TEXT NOT NULL," +
+                    "seller_name TEXT NOT NULL," +
+                    "item_data TEXT NOT NULL," +
+                    "display_name TEXT," +
+                    "material TEXT NOT NULL," +
+                    "amount INTEGER NOT NULL," +
+                    "price REAL NOT NULL," +
+                    "status TEXT NOT NULL DEFAULT 'active'," +
+                    "buyer_uuid TEXT," +
+                    "listed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+                    "expires_at INTEGER," +
+                    "sold_at TIMESTAMP);");
+        }
+
+        playerDAO = new PlayerDAO(connection);
+        listingDAO = new MarketListingDAO(connection);
+
+        configManager = mock(ConfigManager.class);
+        when(configManager.isMarketEnabled()).thenReturn(true);
+        when(configManager.getMarketFeeRate()).thenReturn(0.05);
+        when(configManager.getMarketMinPrice()).thenReturn(1.0);
+        when(configManager.getMarketMaxPrice()).thenReturn(1000000.0);
+        when(configManager.getMarketMaxListingsPerPlayer()).thenReturn(10);
+        when(configManager.getMarketListingDurationDays()).thenReturn(7);
+        when(configManager.isMarketAllowSelfPurchase()).thenReturn(false);
+
+        manager = new MarketManager(connection, playerDAO, listingDAO, configManager,
+                Logger.getLogger("MarketManagerTest"));
+    }
+
+    @After
+    public void tearDown() throws SQLException {
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    // ---- テスト用ヘルパー ----
+
+    private UUID createPlayer(double bankBalance) throws SQLException {
+        UUID uuid = UUID.randomUUID();
+        Player player = new Player(uuid, 0.0);
+        player.setBankBalance(bankBalance);
+        Timestamp now = new Timestamp(System.currentTimeMillis());
+        player.setCreatedAt(now);
+        player.setUpdatedAt(now);
+        playerDAO.createPlayer(player);
+        return uuid;
+    }
+
+    private int createActiveListing(UUID seller, double price) {
+        return manager.executeCreateListing(seller, "Seller", "DUMMY_BASE64", "テスト", "DIAMOND", 1,
+                price, System.currentTimeMillis()) == MarketResult.LISTED
+                ? lastListingIdOf(seller) : -1;
+    }
+
+    private int lastListingIdOf(UUID seller) {
+        try {
+            return listingDAO.getListingsBySeller(seller).get(0).getId();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private double bankOf(UUID uuid) throws SQLException {
+        return playerDAO.getPlayer(uuid).getBankBalance();
+    }
+
+    // ---- 価格検証・手数料計算 ----
+
+    @Test
+    public void testIsValidPrice() {
+        assertFalse("0は無効", manager.isValidPrice(0));
+        assertTrue("1は有効", manager.isValidPrice(1));
+        assertTrue("上限は有効", manager.isValidPrice(1000000));
+        assertFalse("上限超過は無効", manager.isValidPrice(1000001));
+        assertFalse("非整数は無効", manager.isValidPrice(100.5));
+    }
+
+    @Test
+    public void testCalculateSellerProceeds() {
+        assertEquals("floor(100*0.95)=95", 95L, manager.calculateSellerProceeds(100));
+        assertEquals("floor(101*0.95)=95 (95.95切り捨て)", 95L, manager.calculateSellerProceeds(101));
+        assertEquals("floor(1*0.95)=0", 0L, manager.calculateSellerProceeds(1));
+    }
+
+    // ---- 出品 ----
+
+    @Test
+    public void testExecuteCreateListingSuccess() throws SQLException {
+        UUID seller = createPlayer(0);
+        MarketResult result = manager.executeCreateListing(
+                seller, "Seller", "DATA", "名前", "DIAMOND", 3, 100, System.currentTimeMillis());
+        assertEquals(MarketResult.LISTED, result);
+        assertEquals(1, listingDAO.countActiveBySeller(seller));
+    }
+
+    @Test
+    public void testExecuteCreateListingInvalidPrice() throws SQLException {
+        UUID seller = createPlayer(0);
+        assertEquals(MarketResult.INVALID_PRICE, manager.executeCreateListing(
+                seller, "Seller", "DATA", "名前", "DIAMOND", 1, 0, System.currentTimeMillis()));
+    }
+
+    @Test
+    public void testExecuteCreateListingLimit() throws SQLException {
+        UUID seller = createPlayer(0);
+        when(configManager.getMarketMaxListingsPerPlayer()).thenReturn(2);
+        assertEquals(MarketResult.LISTED, createListingResult(seller, 100));
+        assertEquals(MarketResult.LISTED, createListingResult(seller, 100));
+        assertEquals("上限到達で出品拒否", MarketResult.LISTING_LIMIT, createListingResult(seller, 100));
+    }
+
+    private MarketResult createListingResult(UUID seller, double price) {
+        return manager.executeCreateListing(seller, "Seller", "DATA", "名前", "DIAMOND", 1, price,
+                System.currentTimeMillis());
+    }
+
+    // ---- 購入決済 ----
+
+    @Test
+    public void testPurchaseSuccess() throws SQLException {
+        UUID seller = createPlayer(0);
+        UUID buyer = createPlayer(1000);
+        int id = createActiveListing(seller, 100);
+
+        PurchaseOutcome outcome = manager.executePurchaseTransaction(buyer, id, true, System.currentTimeMillis());
+
+        assertTrue("購入成功", outcome.isSuccess());
+        assertEquals("出品者受取=floor(100*0.95)=95", 95L, outcome.getSellerProceeds());
+        assertEquals("購入者残高=1000-100", 900.0, bankOf(buyer), DELTA);
+        assertEquals("出品者残高=0+95", 95.0, bankOf(seller), DELTA);
+        assertEquals(MarketListing.STATUS_SOLD, listingDAO.getById(id).getStatus());
+    }
+
+    @Test
+    public void testPurchaseInsufficientFunds() throws SQLException {
+        UUID seller = createPlayer(0);
+        UUID buyer = createPlayer(50);
+        int id = createActiveListing(seller, 100);
+
+        PurchaseOutcome outcome = manager.executePurchaseTransaction(buyer, id, true, System.currentTimeMillis());
+
+        assertEquals(MarketResult.INSUFFICIENT_FUNDS, outcome.getResult());
+        assertEquals("残高は変わらない", 50.0, bankOf(buyer), DELTA);
+        assertEquals("出品はactiveのまま", MarketListing.STATUS_ACTIVE, listingDAO.getById(id).getStatus());
+    }
+
+    @Test
+    public void testPurchaseInventoryFull() throws SQLException {
+        UUID seller = createPlayer(0);
+        UUID buyer = createPlayer(1000);
+        int id = createActiveListing(seller, 100);
+
+        PurchaseOutcome outcome = manager.executePurchaseTransaction(buyer, id, false, System.currentTimeMillis());
+
+        assertEquals(MarketResult.INVENTORY_FULL, outcome.getResult());
+        assertEquals("残高は変わらない", 1000.0, bankOf(buyer), DELTA);
+        assertEquals(MarketListing.STATUS_ACTIVE, listingDAO.getById(id).getStatus());
+    }
+
+    @Test
+    public void testPurchaseSelfRejected() throws SQLException {
+        UUID seller = createPlayer(1000);
+        int id = createActiveListing(seller, 100);
+
+        PurchaseOutcome outcome = manager.executePurchaseTransaction(seller, id, true, System.currentTimeMillis());
+
+        assertEquals("自己購入は拒否", MarketResult.NOT_AVAILABLE, outcome.getResult());
+        assertEquals(MarketListing.STATUS_ACTIVE, listingDAO.getById(id).getStatus());
+    }
+
+    @Test
+    public void testPurchaseSelfAllowedByConfig() throws SQLException {
+        when(configManager.isMarketAllowSelfPurchase()).thenReturn(true);
+        UUID seller = createPlayer(1000);
+        int id = createActiveListing(seller, 100);
+
+        PurchaseOutcome outcome = manager.executePurchaseTransaction(seller, id, true, System.currentTimeMillis());
+
+        assertTrue("config許可時は自己購入成功", outcome.isSuccess());
+    }
+
+    @Test
+    public void testDoublePurchaseRejected() throws SQLException {
+        UUID seller = createPlayer(0);
+        UUID buyer1 = createPlayer(1000);
+        UUID buyer2 = createPlayer(1000);
+        int id = createActiveListing(seller, 100);
+
+        PurchaseOutcome first = manager.executePurchaseTransaction(buyer1, id, true, System.currentTimeMillis());
+        PurchaseOutcome second = manager.executePurchaseTransaction(buyer2, id, true, System.currentTimeMillis());
+
+        assertTrue("1人目は成功", first.isSuccess());
+        assertEquals("2人目は売り切れ", MarketResult.ALREADY_SOLD, second.getResult());
+        assertEquals("2人目の残高は変わらない", 1000.0, bankOf(buyer2), DELTA);
+    }
+
+    // ---- キャンセル・回収 ----
+
+    @Test
+    public void testCancelSuccess() throws SQLException {
+        UUID seller = createPlayer(0);
+        int id = createActiveListing(seller, 100);
+
+        MarketResult result = manager.executeReclaim(seller, id, MarketListing.STATUS_ACTIVE, true);
+
+        assertEquals(MarketResult.CANCELLED, result);
+        assertEquals(MarketListing.STATUS_RECLAIMED, listingDAO.getById(id).getStatus());
+    }
+
+    @Test
+    public void testCancelNotOwner() throws SQLException {
+        UUID seller = createPlayer(0);
+        UUID other = createPlayer(0);
+        int id = createActiveListing(seller, 100);
+
+        MarketResult result = manager.executeReclaim(other, id, MarketListing.STATUS_ACTIVE, true);
+
+        assertEquals(MarketResult.NOT_OWNER, result);
+        assertEquals(MarketListing.STATUS_ACTIVE, listingDAO.getById(id).getStatus());
+    }
+
+    @Test
+    public void testCancelInventoryFull() throws SQLException {
+        UUID seller = createPlayer(0);
+        int id = createActiveListing(seller, 100);
+
+        MarketResult result = manager.executeReclaim(seller, id, MarketListing.STATUS_ACTIVE, false);
+
+        assertEquals(MarketResult.INVENTORY_FULL, result);
+        assertEquals("満杯なら出品維持", MarketListing.STATUS_ACTIVE, listingDAO.getById(id).getStatus());
+    }
+
+    @Test
+    public void testReclaimExpired() throws SQLException {
+        UUID seller = createPlayer(0);
+        int id = createActiveListing(seller, 100);
+        listingDAO.updateStatusConditional(id, MarketListing.STATUS_ACTIVE, MarketListing.STATUS_EXPIRED);
+
+        MarketResult result = manager.executeReclaim(seller, id, MarketListing.STATUS_EXPIRED, true);
+
+        assertEquals(MarketResult.RECLAIMED, result);
+        assertEquals(MarketListing.STATUS_RECLAIMED, listingDAO.getById(id).getStatus());
+    }
+
+    @Test
+    public void testReclaimWrongStatus() throws SQLException {
+        UUID seller = createPlayer(0);
+        int id = createActiveListing(seller, 100);
+
+        // active の出品を expired 起点で回収しようとすると拒否
+        MarketResult result = manager.executeReclaim(seller, id, MarketListing.STATUS_EXPIRED, true);
+
+        assertEquals(MarketResult.NOT_AVAILABLE, result);
+    }
+}

--- a/src/test/java/org/tofu/tofunomics/market/MarketManagerTest.java
+++ b/src/test/java/org/tofu/tofunomics/market/MarketManagerTest.java
@@ -75,8 +75,10 @@ public class MarketManagerTest {
         when(configManager.getMarketListingDurationDays()).thenReturn(7);
         when(configManager.isMarketAllowSelfPurchase()).thenReturn(false);
 
+        // currencyConverter は購入決済コア（executePurchaseTransaction）では未使用のため null。
+        // 現金回収は Bukkit 依存ラッパー（purchaseListing）側で行うため E2E 検証に委ねる。
         manager = new MarketManager(connection, playerDAO, listingDAO, configManager,
-                Logger.getLogger("MarketManagerTest"));
+                null, Logger.getLogger("MarketManagerTest"));
     }
 
     @After
@@ -175,39 +177,14 @@ public class MarketManagerTest {
         UUID buyer = createPlayer(1000);
         int id = createActiveListing(seller, 100);
 
-        PurchaseOutcome outcome = manager.executePurchaseTransaction(buyer, id, true, System.currentTimeMillis());
+        PurchaseOutcome outcome = manager.executePurchaseTransaction(buyer, id, System.currentTimeMillis());
 
         assertTrue("購入成功", outcome.isSuccess());
         assertEquals("出品者受取=floor(100*0.95)=95", 95L, outcome.getSellerProceeds());
-        assertEquals("購入者残高=1000-100", 900.0, bankOf(buyer), DELTA);
+        // 購入者は現金（金塊）で支払うため、決済コアは bank_balance を変更しない
+        assertEquals("購入者の銀行残高は不変", 1000.0, bankOf(buyer), DELTA);
         assertEquals("出品者残高=0+95", 95.0, bankOf(seller), DELTA);
         assertEquals(MarketListing.STATUS_SOLD, listingDAO.getById(id).getStatus());
-    }
-
-    @Test
-    public void testPurchaseInsufficientFunds() throws SQLException {
-        UUID seller = createPlayer(0);
-        UUID buyer = createPlayer(50);
-        int id = createActiveListing(seller, 100);
-
-        PurchaseOutcome outcome = manager.executePurchaseTransaction(buyer, id, true, System.currentTimeMillis());
-
-        assertEquals(MarketResult.INSUFFICIENT_FUNDS, outcome.getResult());
-        assertEquals("残高は変わらない", 50.0, bankOf(buyer), DELTA);
-        assertEquals("出品はactiveのまま", MarketListing.STATUS_ACTIVE, listingDAO.getById(id).getStatus());
-    }
-
-    @Test
-    public void testPurchaseInventoryFull() throws SQLException {
-        UUID seller = createPlayer(0);
-        UUID buyer = createPlayer(1000);
-        int id = createActiveListing(seller, 100);
-
-        PurchaseOutcome outcome = manager.executePurchaseTransaction(buyer, id, false, System.currentTimeMillis());
-
-        assertEquals(MarketResult.INVENTORY_FULL, outcome.getResult());
-        assertEquals("残高は変わらない", 1000.0, bankOf(buyer), DELTA);
-        assertEquals(MarketListing.STATUS_ACTIVE, listingDAO.getById(id).getStatus());
     }
 
     @Test
@@ -215,7 +192,7 @@ public class MarketManagerTest {
         UUID seller = createPlayer(1000);
         int id = createActiveListing(seller, 100);
 
-        PurchaseOutcome outcome = manager.executePurchaseTransaction(seller, id, true, System.currentTimeMillis());
+        PurchaseOutcome outcome = manager.executePurchaseTransaction(seller, id, System.currentTimeMillis());
 
         assertEquals("自己購入は拒否", MarketResult.NOT_AVAILABLE, outcome.getResult());
         assertEquals(MarketListing.STATUS_ACTIVE, listingDAO.getById(id).getStatus());
@@ -227,7 +204,7 @@ public class MarketManagerTest {
         UUID seller = createPlayer(1000);
         int id = createActiveListing(seller, 100);
 
-        PurchaseOutcome outcome = manager.executePurchaseTransaction(seller, id, true, System.currentTimeMillis());
+        PurchaseOutcome outcome = manager.executePurchaseTransaction(seller, id, System.currentTimeMillis());
 
         assertTrue("config許可時は自己購入成功", outcome.isSuccess());
     }
@@ -239,12 +216,13 @@ public class MarketManagerTest {
         UUID buyer2 = createPlayer(1000);
         int id = createActiveListing(seller, 100);
 
-        PurchaseOutcome first = manager.executePurchaseTransaction(buyer1, id, true, System.currentTimeMillis());
-        PurchaseOutcome second = manager.executePurchaseTransaction(buyer2, id, true, System.currentTimeMillis());
+        PurchaseOutcome first = manager.executePurchaseTransaction(buyer1, id, System.currentTimeMillis());
+        PurchaseOutcome second = manager.executePurchaseTransaction(buyer2, id, System.currentTimeMillis());
 
         assertTrue("1人目は成功", first.isSuccess());
         assertEquals("2人目は売り切れ", MarketResult.ALREADY_SOLD, second.getResult());
-        assertEquals("2人目の残高は変わらない", 1000.0, bankOf(buyer2), DELTA);
+        // 出品者への二重入金が無いこと（95のみ）
+        assertEquals("出品者受取は1回分のみ", 95.0, bankOf(seller), DELTA);
     }
 
     // ---- キャンセル・回収 ----

--- a/src/test/java/org/tofu/tofunomics/market/MarketManagerTest.java
+++ b/src/test/java/org/tofu/tofunomics/market/MarketManagerTest.java
@@ -4,8 +4,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.MarketBuyOrderDAO;
 import org.tofu.tofunomics.dao.MarketListingDAO;
 import org.tofu.tofunomics.dao.PlayerDAO;
+import org.tofu.tofunomics.models.MarketBuyOrder;
 import org.tofu.tofunomics.models.MarketListing;
 import org.tofu.tofunomics.models.Player;
 
@@ -32,6 +34,7 @@ public class MarketManagerTest {
     private Connection connection;
     private PlayerDAO playerDAO;
     private MarketListingDAO listingDAO;
+    private MarketBuyOrderDAO buyOrderDAO;
     private ConfigManager configManager;
     private MarketManager manager;
     private final double DELTA = 0.001;
@@ -61,10 +64,24 @@ public class MarketManagerTest {
                     "listed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
                     "expires_at INTEGER," +
                     "sold_at TIMESTAMP);");
+            st.execute("CREATE TABLE IF NOT EXISTS market_buy_orders (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "requester_uuid TEXT NOT NULL," +
+                    "requester_name TEXT NOT NULL," +
+                    "material TEXT NOT NULL," +
+                    "amount INTEGER NOT NULL," +
+                    "price REAL NOT NULL," +
+                    "status TEXT NOT NULL DEFAULT 'open'," +
+                    "supplier_uuid TEXT," +
+                    "item_data TEXT," +
+                    "listed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+                    "expires_at INTEGER," +
+                    "fulfilled_at TIMESTAMP);");
         }
 
         playerDAO = new PlayerDAO(connection);
         listingDAO = new MarketListingDAO(connection);
+        buyOrderDAO = new MarketBuyOrderDAO(connection);
 
         configManager = mock(ConfigManager.class);
         when(configManager.isMarketEnabled()).thenReturn(true);
@@ -74,10 +91,11 @@ public class MarketManagerTest {
         when(configManager.getMarketMaxListingsPerPlayer()).thenReturn(10);
         when(configManager.getMarketListingDurationDays()).thenReturn(7);
         when(configManager.isMarketAllowSelfPurchase()).thenReturn(false);
+        when(configManager.getMarketMaxBuyOrdersPerPlayer()).thenReturn(10);
 
-        // currencyConverter は購入決済コア（executePurchaseTransaction）では未使用のため null。
-        // 現金回収は Bukkit 依存ラッパー（purchaseListing）側で行うため E2E 検証に委ねる。
-        manager = new MarketManager(connection, playerDAO, listingDAO, configManager,
+        // currencyConverter は購入/供給の決済コアでは未使用のため null。
+        // 現金回収・返金は Bukkit 依存ラッパー側で行うため E2E 検証に委ねる。
+        manager = new MarketManager(connection, playerDAO, listingDAO, buyOrderDAO, configManager,
                 null, Logger.getLogger("MarketManagerTest"));
     }
 
@@ -282,5 +300,217 @@ public class MarketManagerTest {
         MarketResult result = manager.executeReclaim(seller, id, MarketListing.STATUS_EXPIRED, true);
 
         assertEquals(MarketResult.NOT_AVAILABLE, result);
+    }
+
+    // ====================================================================
+    // 買い注文（募集）コアロジック
+    // ====================================================================
+
+    /**
+     * 募集を 1 件登録して id を返すヘルパー
+     */
+    private int createOpenOrder(UUID requester, String material, int amount, double price) {
+        MarketResult r = manager.executeCreateBuyOrder(
+                requester, "Requester", material, amount, price, System.currentTimeMillis());
+        if (r != MarketResult.REQUESTED) {
+            throw new IllegalStateException("募集登録に失敗: " + r);
+        }
+        try {
+            return buyOrderDAO.getOrdersByRequester(requester).get(0).getId();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // ---- 募集登録 ----
+
+    @Test
+    public void testExecuteCreateBuyOrderSuccess() throws SQLException {
+        UUID requester = createPlayer(0);
+        MarketResult result = manager.executeCreateBuyOrder(
+                requester, "Requester", "DIAMOND", 10, 100, System.currentTimeMillis());
+        assertEquals(MarketResult.REQUESTED, result);
+        assertEquals(1, buyOrderDAO.countOpenByRequester(requester));
+    }
+
+    @Test
+    public void testExecuteCreateBuyOrderInvalidPrice() throws SQLException {
+        UUID requester = createPlayer(0);
+        assertEquals(MarketResult.INVALID_PRICE, manager.executeCreateBuyOrder(
+                requester, "Requester", "DIAMOND", 10, 0, System.currentTimeMillis()));
+    }
+
+    @Test
+    public void testExecuteCreateBuyOrderInvalidAmount() throws SQLException {
+        UUID requester = createPlayer(0);
+        assertEquals(MarketResult.INVALID_ITEM, manager.executeCreateBuyOrder(
+                requester, "Requester", "DIAMOND", 0, 100, System.currentTimeMillis()));
+    }
+
+    @Test
+    public void testExecuteCreateBuyOrderLimit() throws SQLException {
+        UUID requester = createPlayer(0);
+        when(configManager.getMarketMaxBuyOrdersPerPlayer()).thenReturn(2);
+        assertEquals(MarketResult.REQUESTED, createBuyOrderResult(requester, 100));
+        assertEquals(MarketResult.REQUESTED, createBuyOrderResult(requester, 100));
+        assertEquals("上限到達で募集拒否", MarketResult.ORDER_LIMIT, createBuyOrderResult(requester, 100));
+    }
+
+    private MarketResult createBuyOrderResult(UUID requester, double price) {
+        return manager.executeCreateBuyOrder(requester, "Requester", "DIAMOND", 5, price,
+                System.currentTimeMillis());
+    }
+
+    // ---- 供給決済 ----
+
+    @Test
+    public void testFulfillSuccess() throws SQLException {
+        UUID requester = createPlayer(0);
+        UUID supplier = createPlayer(0);
+        int id = createOpenOrder(requester, "DIAMOND", 10, 100);
+
+        FulfillOutcome outcome = manager.executeFulfillTransaction(
+                supplier, id, "SUPPLIED_BASE64", System.currentTimeMillis());
+
+        assertTrue("供給成立", outcome.isSuccess());
+        assertEquals("供給者受取=floor(100*0.95)=95", 95L, outcome.getSupplierProceeds());
+        assertEquals("通知先は募集者", requester, outcome.getRequesterUuid());
+        assertEquals("供給者の銀行残高=0+95", 95.0, bankOf(supplier), DELTA);
+        assertEquals("募集者の残高は不変", 0.0, bankOf(requester), DELTA);
+
+        MarketBuyOrder fulfilled = buyOrderDAO.getById(id);
+        assertEquals(MarketBuyOrder.STATUS_FULFILLED, fulfilled.getStatus());
+        assertEquals(supplier, fulfilled.getSupplierUuid());
+        assertEquals("SUPPLIED_BASE64", fulfilled.getItemData());
+    }
+
+    /**
+     * 二重供給防止：同一募集への 2 回目の供給決済は楽観ロックで弾かれる。
+     */
+    @Test
+    public void testFulfillDoubleSupplyRejected() throws SQLException {
+        UUID requester = createPlayer(0);
+        UUID supplier1 = createPlayer(0);
+        UUID supplier2 = createPlayer(0);
+        int id = createOpenOrder(requester, "DIAMOND", 10, 100);
+
+        FulfillOutcome first = manager.executeFulfillTransaction(supplier1, id, "ITEM1", System.currentTimeMillis());
+        FulfillOutcome second = manager.executeFulfillTransaction(supplier2, id, "ITEM2", System.currentTimeMillis());
+
+        assertTrue("最初の供給は成功", first.isSuccess());
+        assertEquals("2回目は成立済みで拒否", MarketResult.ORDER_NOT_AVAILABLE, second.getResult());
+        assertEquals("供給者は最初の供給者", supplier1, buyOrderDAO.getById(id).getSupplierUuid());
+        assertEquals("2人目の残高は不変", 0.0, bankOf(supplier2), DELTA);
+    }
+
+    // ---- キャンセル ----
+
+    @Test
+    public void testCancelBuyOrderSuccess() throws SQLException {
+        UUID requester = createPlayer(0);
+        int id = createOpenOrder(requester, "DIAMOND", 10, 100);
+
+        MarketResult result = manager.executeCancelBuyOrder(requester, id);
+
+        assertEquals(MarketResult.ORDER_CANCELLED, result);
+        assertEquals(MarketBuyOrder.STATUS_CANCELLED, buyOrderDAO.getById(id).getStatus());
+    }
+
+    @Test
+    public void testCancelBuyOrderNotOwner() throws SQLException {
+        UUID requester = createPlayer(0);
+        UUID other = createPlayer(0);
+        int id = createOpenOrder(requester, "DIAMOND", 10, 100);
+
+        MarketResult result = manager.executeCancelBuyOrder(other, id);
+
+        assertEquals("他人の募集はキャンセル不可", MarketResult.ORDER_NOT_OWNER, result);
+        assertEquals(MarketBuyOrder.STATUS_OPEN, buyOrderDAO.getById(id).getStatus());
+    }
+
+    @Test
+    public void testCancelBuyOrderAlreadyFulfilled() throws SQLException {
+        UUID requester = createPlayer(0);
+        UUID supplier = createPlayer(0);
+        int id = createOpenOrder(requester, "DIAMOND", 10, 100);
+        manager.executeFulfillTransaction(supplier, id, "ITEM", System.currentTimeMillis());
+
+        // 成立済み（open でない）はキャンセル不可
+        MarketResult result = manager.executeCancelBuyOrder(requester, id);
+
+        assertEquals(MarketResult.ORDER_NOT_AVAILABLE, result);
+    }
+
+    // ---- 回収 ----
+
+    @Test
+    public void testReclaimBuyOrderSuccess() throws SQLException {
+        UUID requester = createPlayer(0);
+        UUID supplier = createPlayer(0);
+        int id = createOpenOrder(requester, "DIAMOND", 10, 100);
+        manager.executeFulfillTransaction(supplier, id, "SUPPLIED", System.currentTimeMillis());
+
+        MarketResult result = manager.executeReclaimBuyOrder(requester, id, true);
+
+        assertEquals(MarketResult.ORDER_RECLAIMED, result);
+        assertEquals(MarketBuyOrder.STATUS_RECLAIMED, buyOrderDAO.getById(id).getStatus());
+    }
+
+    @Test
+    public void testReclaimBuyOrderNotFulfilled() throws SQLException {
+        UUID requester = createPlayer(0);
+        int id = createOpenOrder(requester, "DIAMOND", 10, 100);
+
+        // まだ open（未成立）は回収不可
+        MarketResult result = manager.executeReclaimBuyOrder(requester, id, true);
+
+        assertEquals(MarketResult.ORDER_NOT_AVAILABLE, result);
+    }
+
+    @Test
+    public void testReclaimBuyOrderInventoryFull() throws SQLException {
+        UUID requester = createPlayer(0);
+        UUID supplier = createPlayer(0);
+        int id = createOpenOrder(requester, "DIAMOND", 10, 100);
+        manager.executeFulfillTransaction(supplier, id, "SUPPLIED", System.currentTimeMillis());
+
+        // インベントリ空き無し → 回収拒否（status は fulfilled のまま）
+        MarketResult result = manager.executeReclaimBuyOrder(requester, id, false);
+
+        assertEquals(MarketResult.INVENTORY_FULL, result);
+        assertEquals(MarketBuyOrder.STATUS_FULFILLED, buyOrderDAO.getById(id).getStatus());
+    }
+
+    // ---- 期限切れ返金 ----
+
+    @Test
+    public void testExpireBuyOrdersRefundsToBank() throws SQLException {
+        UUID requester = createPlayer(0);
+        // 期限切れにするため listing_duration_days=0（無期限）を避け、過去失効を直接挿入する
+        MarketBuyOrder expiring = new MarketBuyOrder(requester, "Requester", "DIAMOND", 10, 100.0, 1000L);
+        buyOrderDAO.insertBuyOrder(expiring);
+        MarketBuyOrder permanent = new MarketBuyOrder(requester, "Requester", "DIAMOND", 5, 200.0, null);
+        buyOrderDAO.insertBuyOrder(permanent);
+
+        int count = manager.expireBuyOrders();
+
+        assertEquals("期限切れ返金は1件", 1, count);
+        assertEquals("前払い100が bank へ返金される", 100.0, bankOf(requester), DELTA);
+        assertEquals(MarketBuyOrder.STATUS_EXPIRED, buyOrderDAO.getById(expiring.getId()).getStatus());
+        assertEquals("無期限は対象外", MarketBuyOrder.STATUS_OPEN, buyOrderDAO.getById(permanent.getId()).getStatus());
+    }
+
+    @Test
+    public void testExpireBuyOrdersSkipsFulfilled() throws SQLException {
+        UUID requester = createPlayer(0);
+        UUID supplier = createPlayer(0);
+        MarketBuyOrder order = new MarketBuyOrder(requester, "Requester", "DIAMOND", 10, 100.0, 1000L);
+        buyOrderDAO.insertBuyOrder(order);
+        manager.executeFulfillTransaction(supplier, order.getId(), "ITEM", System.currentTimeMillis());
+
+        int count = manager.expireBuyOrders();
+
+        assertEquals("成立済みは期限切れ返金の対象外", 0, count);
+        assertEquals("募集者へ二重返金されない", 0.0, bankOf(requester), DELTA);
     }
 }


### PR DESCRIPTION
## 概要
プレイヤー間マーケット機能を実装します。既存の**売り出品**（S1〜S4）に加え、本PRで対になる**買い注文（募集）**（B1〜B5）を追加しました。

## 買い注文（募集）機能
あるプレイヤーが「このアイテムをこの値段で買いたい」と募集を出し、別プレイヤーが手持ちから供給して成立させる、売り出品の鏡像機能です。

### 仕様
- **前払いエスクロー**: 募集時に募集者の現金（金塊）から price 全額を回収・拘束
- **手数料**: 売りと同じ消却型5%。供給者受取 = `floor(price×0.95)`、差額は通貨総量から消却
- **オフライン対応**: 募集者がオフラインでも供給成立可。供給アイテムは注文に保存し、後で GUI から回収
- **ライフサイクル**: open → fulfilled → reclaimed / open → cancelled（返金）/ open → expired（自動返金）

### コマンド
- `/market buy <material> <個数> <価格>` 募集登録（前払い）
- `/market requests` / `myrequests` 募集一覧 / 自分の募集GUI
- `/market cancelrequest <id>` / `reclaimrequest <id>` キャンセル返金 / アイテム回収

## 実装内訳
| 段階 | 内容 |
|---|---|
| B1 | DB層（MarketBuyOrder / DAO / market_buy_orders テーブル） |
| B2 | ロジック層（MarketManager に募集コア＋ラッパー、楽観ロック、通貨保存則） |
| B3 | GUI＋期限切れ返金タスク（BuyOrderBrowseGUI / MyBuyOrdersGUI） |
| B4 | コマンド＋配線（MarketCommand / TofuNomics / plugin.yml） |
| fix | 募集メッセージのサーバーconfig起動時自動補完 |

## 通貨保存則
- 募集→キャンセル/期限切れ: 純増減ゼロ（全額返金）
- 募集→供給成立: 供給者に `floor(price×0.95)` 入金、差額は消却（fee は成立時のみ）
- エスクロー返金は楽観ロック（open限定UPDATE）を経てから実行し、二重返金を防止

## テスト
- 全 **247件 green**（MarketBuyOrderDAOTest 11件、MarketManagerTest 買い注文ケース15件追加 等）
- 二重供給防止・手数料floor・所有者チェック・期限切れ返金/成立済みスキップを検証

## デプロイ・E2E
- lobby-1.21 へデプロイ済み、E2E（募集→供給→回収→キャンセル→各メッセージ表示）確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)