### PR TITLE
feat: marketコマンドを統合ハブGUIに一本化

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -131,6 +131,8 @@ public final class TofuNomics extends JavaPlugin {
     private org.tofu.tofunomics.market.gui.MyServicesGUI myServicesGUI;
     private org.tofu.tofunomics.market.gui.RepairWorkGUI repairWorkGUI;
     private org.tofu.tofunomics.market.gui.MarketGUIListener marketGUIListener;
+    private org.tofu.tofunomics.market.gui.MarketHubGUI marketHubGUI;
+    private org.tofu.tofunomics.market.gui.ChatInputManager chatInputManager;
     private org.tofu.tofunomics.market.MarketExpirationTask marketExpirationTask;
 
     @Override
@@ -408,6 +410,15 @@ public final class TofuNomics extends JavaPlugin {
             myServicesGUI = new org.tofu.tofunomics.market.gui.MyServicesGUI(
                 this, configManager, marketManager, marketServiceRequestDAO, marketGUIListener);
             marketGUIListener.setServiceGUIs(serviceBrowseGUI, myServicesGUI);
+
+            // チャット入力基盤を生成・登録し、全操作の入口となるハブGUIを生成して配線する
+            chatInputManager = new org.tofu.tofunomics.market.gui.ChatInputManager(this, configManager);
+            getServer().getPluginManager().registerEvents(chatInputManager, this);
+            marketHubGUI = new org.tofu.tofunomics.market.gui.MarketHubGUI(
+                this, configManager, marketManager, chatInputManager, marketGUIListener);
+            marketHubGUI.setGUIs(marketBrowseGUI, myListingsGUI, buyOrderBrowseGUI,
+                myBuyOrdersGUI, serviceBrowseGUI, myServicesGUI);
+            marketGUIListener.setHubGUI(marketHubGUI);
 
             // 期限切れ定期タスクの起動（expire_check_interval 秒 × 20 = ticks）
             long intervalTicks = Math.max(1L, (long) configManager.getMarketExpireCheckInterval() * 20L);
@@ -835,7 +846,7 @@ public final class TofuNomics extends JavaPlugin {
                     new org.tofu.tofunomics.commands.MarketCommand(
                         configManager, marketManager, marketListingDAO, marketBuyOrderDAO,
                         marketServiceRequestDAO,
-                        marketBrowseGUI, myListingsGUI, buyOrderBrowseGUI, myBuyOrdersGUI,
+                        marketHubGUI, myListingsGUI, buyOrderBrowseGUI, myBuyOrdersGUI,
                         serviceBrowseGUI, myServicesGUI);
                 getCommand("market").setExecutor(marketCommand);
                 getCommand("market").setTabCompleter(marketCommand);

--- a/src/main/java/org/tofu/tofunomics/commands/MarketCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/MarketCommand.java
@@ -15,8 +15,8 @@ import org.tofu.tofunomics.market.MarketManager;
 import org.tofu.tofunomics.market.MarketMessages;
 import org.tofu.tofunomics.market.MarketResult;
 import org.tofu.tofunomics.market.gui.BuyOrderBrowseGUI;
-import org.tofu.tofunomics.market.gui.MarketBrowseGUI;
 import org.tofu.tofunomics.market.gui.MarketGUIUtil;
+import org.tofu.tofunomics.market.gui.MarketHubGUI;
 import org.tofu.tofunomics.market.gui.MyBuyOrdersGUI;
 import org.tofu.tofunomics.market.gui.MyListingsGUI;
 import org.tofu.tofunomics.market.gui.MyServicesGUI;
@@ -61,7 +61,7 @@ public class MarketCommand implements CommandExecutor, TabCompleter {
     private final MarketListingDAO listingDAO;
     private final MarketBuyOrderDAO buyOrderDAO;
     private final MarketServiceRequestDAO serviceRequestDAO;
-    private final MarketBrowseGUI browseGUI;
+    private final MarketHubGUI hubGUI;
     private final MyListingsGUI myListingsGUI;
     private final BuyOrderBrowseGUI buyOrderBrowseGUI;
     private final MyBuyOrdersGUI myBuyOrdersGUI;
@@ -71,7 +71,8 @@ public class MarketCommand implements CommandExecutor, TabCompleter {
     public MarketCommand(ConfigManager configManager, MarketManager marketManager,
                          MarketListingDAO listingDAO, MarketBuyOrderDAO buyOrderDAO,
                          MarketServiceRequestDAO serviceRequestDAO,
-                         MarketBrowseGUI browseGUI, MyListingsGUI myListingsGUI,
+                         MarketHubGUI hubGUI,
+                         MyListingsGUI myListingsGUI,
                          BuyOrderBrowseGUI buyOrderBrowseGUI, MyBuyOrdersGUI myBuyOrdersGUI,
                          ServiceBrowseGUI serviceBrowseGUI, MyServicesGUI myServicesGUI) {
         this.configManager = configManager;
@@ -79,7 +80,7 @@ public class MarketCommand implements CommandExecutor, TabCompleter {
         this.listingDAO = listingDAO;
         this.buyOrderDAO = buyOrderDAO;
         this.serviceRequestDAO = serviceRequestDAO;
-        this.browseGUI = browseGUI;
+        this.hubGUI = hubGUI;
         this.myListingsGUI = myListingsGUI;
         this.buyOrderBrowseGUI = buyOrderBrowseGUI;
         this.myBuyOrdersGUI = myBuyOrdersGUI;
@@ -100,7 +101,7 @@ public class MarketCommand implements CommandExecutor, TabCompleter {
         Player player = (Player) sender;
 
         if (args.length == 0) {
-            return handleBrowse(player);
+            return handleHub(player);
         }
 
         switch (args[0].toLowerCase()) {
@@ -146,12 +147,12 @@ public class MarketCommand implements CommandExecutor, TabCompleter {
         }
     }
 
-    private boolean handleBrowse(Player player) {
+    private boolean handleHub(Player player) {
         if (!player.hasPermission(PERM_USE)) {
             player.sendMessage(configManager.getMessage("no_permission"));
             return true;
         }
-        browseGUI.open(player);
+        hubGUI.open(player);
         return true;
     }
 
@@ -474,8 +475,8 @@ public class MarketCommand implements CommandExecutor, TabCompleter {
 
     private void sendUsage(Player player) {
         player.sendMessage("§6=== マーケットコマンド ===");
+        player.sendMessage("§e/market §7- マーケットGUIを開く（推奨・全操作の入口）");
         player.sendMessage("§b▼ 売り");
-        player.sendMessage("§e/market §7- 出品一覧を開く");
         player.sendMessage("§e/market sell <価格> §7- 手持ちアイテムを出品");
         player.sendMessage("§e/market mylistings §7- 自分の出品を管理");
         player.sendMessage("§e/market cancel <ID> §7- 出品をキャンセルして回収");

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -2660,6 +2660,11 @@ public class ConfigManager {
             ensureMessagePath("messages.market.invalid_service_item", "&cこのアイテムはそのサービスの対象にできません（修理・エンチャント不可）。");
             ensureMessagePath("messages.market.service_not_available", "&cこの依頼は既に成立済みか、存在しません。");
             ensureMessagePath("messages.market.service_not_owner", "&cこれはあなたの依頼ではありません。");
+
+            // GUI チャット入力プロンプト
+            ensureMessagePath("messages.market.input_timeout", "&c入力がタイムアウトしました。最初からやり直してください。");
+            ensureMessagePath("messages.market.input_cancelled", "&7入力を中止しました。");
+            ensureMessagePath("messages.market.input_invalid_number", "&c数値で入力してください。");
         } catch (Exception e) {
             plugin.getLogger().warning("マーケットメッセージの初期化に失敗しました: " + e.getMessage());
         }

--- a/src/main/java/org/tofu/tofunomics/market/gui/ChatInputManager.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/ChatInputManager.java
@@ -1,0 +1,134 @@
+package org.tofu.tofunomics.market.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scheduler.BukkitTask;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * GUI からチャット入力を受け付けるための共通プロンプト基盤。
+ *
+ * GUI を閉じてプレイヤーにチャット入力を促し、次のチャットメッセージをコールバックで受け取る。
+ * 「cancel」入力・タイムアウト・ログアウトで保留中のプロンプトは破棄される。
+ * 複数値の入力は {@code onInput} 内で次の {@link #prompt} を呼ぶことでステップ式にチェーンできる。
+ *
+ * 注意: {@link AsyncPlayerChatEvent} は非同期スレッドで発火するため、
+ * コールバックは必ず {@link org.bukkit.scheduler.BukkitScheduler#runTask} でメインスレッドへ同期してから実行する。
+ */
+public class ChatInputManager implements Listener {
+
+    /** 保留中のプロンプト1件 */
+    private static class PendingPrompt {
+        final Consumer<String> onInput;
+        final Runnable onCancel;
+        final BukkitTask timeoutTask;
+
+        PendingPrompt(Consumer<String> onInput, Runnable onCancel, BukkitTask timeoutTask) {
+            this.onInput = onInput;
+            this.onCancel = onCancel;
+            this.timeoutTask = timeoutTask;
+        }
+    }
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final Map<UUID, PendingPrompt> pending = new ConcurrentHashMap<>();
+
+    public ChatInputManager(TofuNomics plugin, ConfigManager configManager) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+    }
+
+    /**
+     * チャット入力プロンプトを開始する。GUI は呼び出し側で閉じておくこと。
+     *
+     * @param player         対象プレイヤー
+     * @param promptMessage  入力を促すメッセージ（色コード適用済み）
+     * @param onInput        入力受領時のコールバック（メインスレッドで実行）
+     * @param onCancel       中止/タイムアウト時のコールバック（メインスレッドで実行、null 可）
+     * @param timeoutSeconds タイムアウト秒数（0 以下で無効）
+     */
+    public void prompt(Player player, String promptMessage,
+                       Consumer<String> onInput, Runnable onCancel, int timeoutSeconds) {
+        cancel(player); // 既存プロンプトがあれば破棄
+        player.sendMessage(promptMessage);
+        player.sendMessage("§7（中止する場合は §fcancel §7と入力）");
+
+        BukkitTask timeoutTask = null;
+        if (timeoutSeconds > 0) {
+            final UUID id = player.getUniqueId();
+            timeoutTask = Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                PendingPrompt p = pending.remove(id);
+                if (p != null) {
+                    Player online = Bukkit.getPlayer(id);
+                    if (online != null && online.isOnline()) {
+                        online.sendMessage(configManager.getMarketMessage("input_timeout"));
+                    }
+                    if (p.onCancel != null) {
+                        p.onCancel.run();
+                    }
+                }
+            }, timeoutSeconds * 20L);
+        }
+
+        pending.put(player.getUniqueId(), new PendingPrompt(onInput, onCancel, timeoutTask));
+    }
+
+    /**
+     * 保留中のプロンプトを破棄する（コールバックは呼ばない）。
+     */
+    public void cancel(Player player) {
+        PendingPrompt p = pending.remove(player.getUniqueId());
+        if (p != null && p.timeoutTask != null) {
+            p.timeoutTask.cancel();
+        }
+    }
+
+    public boolean hasPending(UUID playerId) {
+        return pending.containsKey(playerId);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = false)
+    public void onChat(AsyncPlayerChatEvent event) {
+        final UUID id = event.getPlayer().getUniqueId();
+        PendingPrompt p = pending.remove(id);
+        if (p == null) {
+            return;
+        }
+        // 通常チャットに流さない
+        event.setCancelled(true);
+        if (p.timeoutTask != null) {
+            p.timeoutTask.cancel();
+        }
+
+        final String message = event.getMessage().trim();
+        final Player player = event.getPlayer();
+        // 非同期スレッドなので必ずメインスレッドへ同期してからコールバック実行
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            if (message.equalsIgnoreCase("cancel")) {
+                player.sendMessage(configManager.getMarketMessage("input_cancelled"));
+                if (p.onCancel != null) {
+                    p.onCancel.run();
+                }
+            } else {
+                p.onInput.accept(message);
+            }
+        });
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        cancel(event.getPlayer());
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/gui/MarketGUIListener.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MarketGUIListener.java
@@ -28,6 +28,7 @@ public class MarketGUIListener implements Listener {
     private final TofuNomics plugin;
     private final Map<UUID, MarketGUISession> sessions = new ConcurrentHashMap<>();
 
+    private MarketHubGUI hubGUI;
     private MarketBrowseGUI browseGUI;
     private MyListingsGUI myListingsGUI;
     private BuyOrderBrowseGUI buyOrderBrowseGUI;
@@ -38,6 +39,13 @@ public class MarketGUIListener implements Listener {
 
     public MarketGUIListener(TofuNomics plugin) {
         this.plugin = plugin;
+    }
+
+    /**
+     * ハブ GUI 参照を注入する（循環依存を避けるためセッターで後から設定）。
+     */
+    public void setHubGUI(MarketHubGUI hubGUI) {
+        this.hubGUI = hubGUI;
     }
 
     /**
@@ -112,6 +120,11 @@ public class MarketGUIListener implements Listener {
     private void dispatchClick(Player player, MarketGUISession session, int slot,
                                org.bukkit.event.inventory.ClickType clickType) {
         switch (session.getType()) {
+            case HUB:
+                if (hubGUI != null) {
+                    hubGUI.handleClick(player, session, slot, clickType);
+                }
+                break;
             case BROWSE:
                 if (browseGUI != null) {
                     browseGUI.handleClick(player, session, slot, clickType);

--- a/src/main/java/org/tofu/tofunomics/market/gui/MarketGUISession.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MarketGUISession.java
@@ -19,6 +19,7 @@ public class MarketGUISession {
 
     /** GUI の種別 */
     public enum Type {
+        HUB,            // マーケットハブ（全操作の入口メニュー）
         BROWSE,         // マーケット一覧（全 active）
         MY_LISTINGS,    // 自分の出品管理
         BUY_BROWSE,     // 募集一覧（全 open）

--- a/src/main/java/org/tofu/tofunomics/market/gui/MarketHubGUI.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MarketHubGUI.java
@@ -1,0 +1,425 @@
+package org.tofu.tofunomics.market.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.market.MarketManager;
+import org.tofu.tofunomics.market.MarketMessages;
+import org.tofu.tofunomics.market.MarketResult;
+import org.tofu.tofunomics.market.ServiceProcessor;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * マーケットの統合ハブ GUI。
+ *
+ * {@code /market}（無引数）で開く全操作の入口。閲覧・管理系は各既存 GUI の {@code open()} へ遷移し、
+ * 登録系（出品・募集・修理依頼・エンチャント依頼）は GUI を閉じて {@link ChatInputManager} で
+ * 価格・個数等をチャット入力させてから {@link MarketManager} のロジックを呼ぶ。
+ */
+public class MarketHubGUI {
+
+    private static final String PERM_USE = "tofunomics.market.use";
+    private static final String PERM_SELL = "tofunomics.market.sell";
+    private static final String PERM_BUY = "tofunomics.market.buy";
+    private static final String PERM_SERVICE = "tofunomics.market.service";
+
+    private static final int SIZE = 27;
+    private static final int SLOT_BROWSE = 0;
+    private static final int SLOT_MY_LISTINGS = 1;
+    private static final int SLOT_BUY_BROWSE = 2;
+    private static final int SLOT_MY_BUY = 3;
+    private static final int SLOT_SERVICE_BROWSE = 4;
+    private static final int SLOT_MY_SERVICES = 5;
+    private static final int SLOT_CREATE_LISTING = 11;
+    private static final int SLOT_CREATE_BUY = 12;
+    private static final int SLOT_CREATE_REPAIR = 14;
+    private static final int SLOT_CREATE_ENCHANT = 15;
+    private static final int SLOT_HELP = 22;
+    private static final int SLOT_CLOSE = 26;
+
+    private static final int INPUT_TIMEOUT_SECONDS = 60;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final MarketManager marketManager;
+    private final ChatInputManager chatInput;
+    private final MarketGUIListener listener;
+
+    // 遷移先 GUI（循環依存回避のためセッターで後注入）
+    private MarketBrowseGUI browseGUI;
+    private MyListingsGUI myListingsGUI;
+    private BuyOrderBrowseGUI buyOrderBrowseGUI;
+    private MyBuyOrdersGUI myBuyOrdersGUI;
+    private ServiceBrowseGUI serviceBrowseGUI;
+    private MyServicesGUI myServicesGUI;
+
+    public MarketHubGUI(TofuNomics plugin, ConfigManager configManager, MarketManager marketManager,
+                        ChatInputManager chatInput, MarketGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.marketManager = marketManager;
+        this.chatInput = chatInput;
+        this.listener = listener;
+    }
+
+    /**
+     * 遷移先 GUI 参照を注入する。
+     */
+    public void setGUIs(MarketBrowseGUI browseGUI, MyListingsGUI myListingsGUI,
+                        BuyOrderBrowseGUI buyOrderBrowseGUI, MyBuyOrdersGUI myBuyOrdersGUI,
+                        ServiceBrowseGUI serviceBrowseGUI, MyServicesGUI myServicesGUI) {
+        this.browseGUI = browseGUI;
+        this.myListingsGUI = myListingsGUI;
+        this.buyOrderBrowseGUI = buyOrderBrowseGUI;
+        this.myBuyOrdersGUI = myBuyOrdersGUI;
+        this.serviceBrowseGUI = serviceBrowseGUI;
+        this.myServicesGUI = myServicesGUI;
+    }
+
+    /**
+     * ハブ GUI を開く。
+     */
+    public void open(Player player) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, SIZE, "§6マーケット");
+            MarketGUISession session = new MarketGUISession(
+                    player.getUniqueId(), MarketGUISession.Type.HUB, gui);
+            render(player, gui);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("マーケットハブGUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage(configManager.getMarketMessage("error"));
+        }
+    }
+
+    private void render(Player player, Inventory gui) {
+        boolean serviceEnabled = configManager.isMarketServiceEnabled();
+
+        // 段1: 閲覧・管理（全て market.use）
+        gui.setItem(SLOT_BROWSE, MarketGUIUtil.createButton(Material.CHEST, "§a§l出品一覧",
+                Arrays.asList("§7出品されているアイテムを見て購入します", "§eクリックで開く")));
+        gui.setItem(SLOT_MY_LISTINGS, MarketGUIUtil.createButton(Material.ENDER_CHEST, "§b§l自分の出品",
+                Arrays.asList("§7自分の出品を確認・キャンセル・回収します", "§eクリックで開く")));
+        gui.setItem(SLOT_BUY_BROWSE, MarketGUIUtil.createButton(Material.PAPER, "§a§l募集一覧",
+                Arrays.asList("§7買い注文（募集）に応じて供給します", "§eクリックで開く")));
+        gui.setItem(SLOT_MY_BUY, MarketGUIUtil.createButton(Material.WRITABLE_BOOK, "§b§l自分の募集",
+                Arrays.asList("§7自分の募集を確認・キャンセル・回収します", "§eクリックで開く")));
+        if (serviceEnabled) {
+            gui.setItem(SLOT_SERVICE_BROWSE, MarketGUIUtil.createButton(Material.ANVIL, "§a§lサービス依頼一覧",
+                    Arrays.asList("§7修理・エンチャント依頼を引き受けます", "§eクリックで開く")));
+            gui.setItem(SLOT_MY_SERVICES, MarketGUIUtil.createButton(Material.DAMAGED_ANVIL, "§b§l自分の依頼",
+                    Arrays.asList("§7自分の依頼を確認・キャンセル・回収します", "§eクリックで開く")));
+        }
+
+        // 段2: 新規登録（権限に応じて表示）
+        if (player.hasPermission(PERM_SELL)) {
+            gui.setItem(SLOT_CREATE_LISTING, MarketGUIUtil.createButton(Material.HOPPER, "§6§l出品する",
+                    Arrays.asList("§7手に持ったアイテムを出品します", "§7価格はチャットで入力します", "§eクリックで開始")));
+        }
+        if (player.hasPermission(PERM_BUY)) {
+            gui.setItem(SLOT_CREATE_BUY, MarketGUIUtil.createButton(Material.EMERALD, "§6§l募集する",
+                    Arrays.asList("§7欲しいアイテムの買い注文を出します", "§7アイテム・個数・価格をチャットで入力", "§eクリックで開始")));
+        }
+        if (serviceEnabled && player.hasPermission(PERM_SERVICE)) {
+            gui.setItem(SLOT_CREATE_REPAIR, MarketGUIUtil.createButton(Material.IRON_PICKAXE, "§6§l修理を依頼",
+                    Arrays.asList("§7手に持った道具の修理を依頼します", "§7報酬はチャットで入力します", "§eクリックで開始")));
+            gui.setItem(SLOT_CREATE_ENCHANT, MarketGUIUtil.createButton(Material.ENCHANTED_BOOK, "§6§lエンチャントを依頼",
+                    Arrays.asList("§7手に持った道具へのエンチャントを依頼します", "§7内容・報酬はチャットで入力します", "§eクリックで開始")));
+        }
+
+        // 段3: ヘルプ・閉じる
+        gui.setItem(SLOT_HELP, MarketGUIUtil.createButton(Material.BOOK, "§e§lヘルプ",
+                Collections.singletonList("§7マーケットの使い方を表示します")));
+        gui.setItem(SLOT_CLOSE, MarketGUIUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = MarketGUIUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = 0; i < SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    /**
+     * クリック処理（{@link MarketGUIListener} から呼ばれる）。
+     */
+    public void handleClick(Player player, MarketGUISession session, int slot, ClickType clickType) {
+        switch (slot) {
+            case SLOT_BROWSE:
+                if (browseGUI != null) browseGUI.open(player);
+                break;
+            case SLOT_MY_LISTINGS:
+                if (myListingsGUI != null) myListingsGUI.open(player);
+                break;
+            case SLOT_BUY_BROWSE:
+                if (buyOrderBrowseGUI != null) buyOrderBrowseGUI.open(player);
+                break;
+            case SLOT_MY_BUY:
+                if (myBuyOrdersGUI != null) myBuyOrdersGUI.open(player);
+                break;
+            case SLOT_SERVICE_BROWSE:
+                if (configManager.isMarketServiceEnabled() && serviceBrowseGUI != null) serviceBrowseGUI.open(player);
+                break;
+            case SLOT_MY_SERVICES:
+                if (configManager.isMarketServiceEnabled() && myServicesGUI != null) myServicesGUI.open(player);
+                break;
+            case SLOT_CREATE_LISTING:
+                if (player.hasPermission(PERM_SELL)) startCreateListing(player);
+                break;
+            case SLOT_CREATE_BUY:
+                if (player.hasPermission(PERM_BUY)) startCreateBuyOrder(player);
+                break;
+            case SLOT_CREATE_REPAIR:
+                if (configManager.isMarketServiceEnabled() && player.hasPermission(PERM_SERVICE)) startCreateRepair(player);
+                break;
+            case SLOT_CREATE_ENCHANT:
+                if (configManager.isMarketServiceEnabled() && player.hasPermission(PERM_SERVICE)) startCreateEnchant(player);
+                break;
+            case SLOT_HELP:
+                player.closeInventory();
+                sendHelp(player);
+                break;
+            case SLOT_CLOSE:
+                player.closeInventory();
+                break;
+            default:
+                break;
+        }
+    }
+
+    // ====================================================================
+    // 登録フロー（出品・募集・修理・エンチャント）
+    // ====================================================================
+
+    private void startCreateListing(Player player) {
+        ItemStack hand = player.getInventory().getItemInMainHand();
+        if (hand == null || hand.getType() == Material.AIR) {
+            player.sendMessage(configManager.getMarketMessage("invalid_item"));
+            return; // GUI は開いたまま
+        }
+        String itemName = MarketGUIUtil.prettifyMaterial(hand.getType().name());
+        player.closeInventory();
+        chatInput.prompt(player,
+                "§e「" + itemName + "」の出品価格を金塊（整数）で入力してください。",
+                priceStr -> {
+                    Double price = parsePrice(player, priceStr);
+                    if (price == null) {
+                        reopenHub(player);
+                        return;
+                    }
+                    MarketResult result = marketManager.createListing(player, price);
+                    player.sendMessage(MarketMessages.format(configManager, result, itemName, price));
+                    reopenHub(player);
+                },
+                () -> reopenHub(player), INPUT_TIMEOUT_SECONDS);
+    }
+
+    private void startCreateBuyOrder(Player player) {
+        player.closeInventory();
+        ItemStack hand = player.getInventory().getItemInMainHand();
+        String example = (hand != null && hand.getType() != Material.AIR)
+                ? hand.getType().name() : "DIAMOND";
+        chatInput.prompt(player,
+                "§e募集したいアイテム名を入力してください。§7（例: " + example + "）",
+                materialStr -> {
+                    Material material = Material.matchMaterial(materialStr.toUpperCase());
+                    if (material == null || material == Material.AIR) {
+                        player.sendMessage(configManager.getMarketMessage("invalid_item"));
+                        reopenHub(player);
+                        return;
+                    }
+                    promptBuyAmount(player, material);
+                },
+                () -> reopenHub(player), INPUT_TIMEOUT_SECONDS);
+    }
+
+    private void promptBuyAmount(Player player, Material material) {
+        chatInput.prompt(player,
+                "§e募集する個数を入力してください。",
+                amountStr -> {
+                    Integer amount = parsePositiveInt(player, amountStr);
+                    if (amount == null) {
+                        reopenHub(player);
+                        return;
+                    }
+                    promptBuyPrice(player, material, amount);
+                },
+                () -> reopenHub(player), INPUT_TIMEOUT_SECONDS);
+    }
+
+    private void promptBuyPrice(Player player, Material material, int amount) {
+        chatInput.prompt(player,
+                "§e募集価格を金塊（整数）で入力してください。§7（前払い）",
+                priceStr -> {
+                    Double price = parsePrice(player, priceStr);
+                    if (price == null) {
+                        reopenHub(player);
+                        return;
+                    }
+                    MarketResult result = marketManager.createBuyOrder(player, material, amount, price);
+                    sendBuyOrderMessage(player, result, MarketGUIUtil.prettifyMaterial(material.name()), amount, price);
+                    reopenHub(player);
+                },
+                () -> reopenHub(player), INPUT_TIMEOUT_SECONDS);
+    }
+
+    private void startCreateRepair(Player player) {
+        ItemStack hand = player.getInventory().getItemInMainHand();
+        if (hand == null || hand.getType() == Material.AIR || !ServiceProcessor.isRepairable(hand)) {
+            player.sendMessage(configManager.getMarketMessage("invalid_service_item"));
+            return;
+        }
+        String itemName = MarketGUIUtil.prettifyMaterial(hand.getType().name());
+        player.closeInventory();
+        chatInput.prompt(player,
+                "§e「" + itemName + "」の修理報酬を金塊（整数）で入力してください。§7（前払い）",
+                priceStr -> {
+                    Double price = parsePrice(player, priceStr);
+                    if (price == null) {
+                        reopenHub(player);
+                        return;
+                    }
+                    MarketResult result = marketManager.createRepairRequest(player, price);
+                    sendServiceMessage(player, result, itemName, "修理", price);
+                    reopenHub(player);
+                },
+                () -> reopenHub(player), INPUT_TIMEOUT_SECONDS);
+    }
+
+    private void startCreateEnchant(Player player) {
+        ItemStack hand = player.getInventory().getItemInMainHand();
+        if (hand == null || hand.getType() == Material.AIR) {
+            player.sendMessage(configManager.getMarketMessage("invalid_service_item"));
+            return;
+        }
+        String itemName = MarketGUIUtil.prettifyMaterial(hand.getType().name());
+        player.closeInventory();
+        player.sendMessage("§7指定できるエンチャント: §f"
+                + String.join(", ", configManager.getMarketServiceAllowedEnchantments()));
+        chatInput.prompt(player,
+                "§eエンチャント名を入力してください。",
+                enchantKey -> promptEnchantLevel(player, itemName, enchantKey),
+                () -> reopenHub(player), INPUT_TIMEOUT_SECONDS);
+    }
+
+    private void promptEnchantLevel(Player player, String itemName, String enchantKey) {
+        chatInput.prompt(player,
+                "§eエンチャントレベルを入力してください。§7（1〜"
+                        + configManager.getMarketServiceMaxEnchantLevel() + "）",
+                levelStr -> {
+                    Integer level = parsePositiveInt(player, levelStr);
+                    if (level == null) {
+                        reopenHub(player);
+                        return;
+                    }
+                    promptEnchantPrice(player, itemName, enchantKey, level);
+                },
+                () -> reopenHub(player), INPUT_TIMEOUT_SECONDS);
+    }
+
+    private void promptEnchantPrice(Player player, String itemName, String enchantKey, int level) {
+        chatInput.prompt(player,
+                "§e報酬を金塊（整数）で入力してください。§7（前払い）",
+                priceStr -> {
+                    Double price = parsePrice(player, priceStr);
+                    if (price == null) {
+                        reopenHub(player);
+                        return;
+                    }
+                    MarketResult result = marketManager.createEnchantRequest(player, enchantKey, level, price);
+                    sendServiceMessage(player, result, itemName, "エンチャント", price);
+                    reopenHub(player);
+                },
+                () -> reopenHub(player), INPUT_TIMEOUT_SECONDS);
+    }
+
+    // ====================================================================
+    // ヘルパー
+    // ====================================================================
+
+    /**
+     * 1 tick 後にハブ GUI を再表示する（closeInventory 直後の再 open を避ける）。
+     */
+    private void reopenHub(Player player) {
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (player.isOnline()) {
+                open(player);
+            }
+        }, 1L);
+    }
+
+    private Double parsePrice(Player player, String input) {
+        double price;
+        try {
+            price = Double.parseDouble(input.trim());
+        } catch (NumberFormatException e) {
+            player.sendMessage(configManager.getMarketMessage("input_invalid_number"));
+            return null;
+        }
+        if (!marketManager.isValidPrice(price)) {
+            player.sendMessage(MarketMessages.format(configManager, MarketResult.INVALID_PRICE, "", 0));
+            return null;
+        }
+        return price;
+    }
+
+    private Integer parsePositiveInt(Player player, String input) {
+        int value;
+        try {
+            value = Integer.parseInt(input.trim());
+        } catch (NumberFormatException e) {
+            player.sendMessage(configManager.getMarketMessage("input_invalid_number"));
+            return null;
+        }
+        if (value <= 0) {
+            player.sendMessage(configManager.getMarketMessage("input_invalid_number"));
+            return null;
+        }
+        return value;
+    }
+
+    private void sendBuyOrderMessage(Player player, MarketResult result, String item, int amount, double price) {
+        player.sendMessage(configManager.getMarketMessage(result.getMessageKey(),
+                "item", item != null ? item : "",
+                "amount", String.valueOf(amount),
+                "price", MarketGUIUtil.formatPrice(price),
+                "proceeds", String.valueOf(marketManager.calculateSellerProceeds(price)),
+                "currency", configManager.getCurrencyName(),
+                "min", String.valueOf((long) configManager.getMarketMinPrice()),
+                "max", String.valueOf((long) configManager.getMarketMaxPrice()),
+                "limit", String.valueOf(configManager.getMarketMaxBuyOrdersPerPlayer())));
+    }
+
+    private void sendServiceMessage(Player player, MarketResult result, String item, String service, double price) {
+        player.sendMessage(configManager.getMarketMessage(result.getMessageKey(),
+                "item", item != null ? item : "",
+                "service", service != null ? service : "",
+                "price", MarketGUIUtil.formatPrice(price),
+                "proceeds", String.valueOf(marketManager.calculateSellerProceeds(price)),
+                "currency", configManager.getCurrencyName(),
+                "min", String.valueOf((long) configManager.getMarketMinPrice()),
+                "max", String.valueOf((long) configManager.getMarketMaxPrice()),
+                "limit", String.valueOf(configManager.getMarketServiceMaxRequestsPerPlayer())));
+    }
+
+    private void sendHelp(Player player) {
+        player.sendMessage("§6=== マーケットの使い方 ===");
+        player.sendMessage("§e/market §7- このGUIを開きます（全操作の入口）");
+        player.sendMessage("§7・出品一覧/募集一覧/サービス一覧 から購入・供給・引受ができます");
+        player.sendMessage("§7・出品する/募集する/修理を依頼/エンチャントを依頼 で新規登録できます");
+        player.sendMessage("§7・登録時は価格などをチャットで入力します（cancel で中止）");
+        player.sendMessage("§7従来のコマンド（/market sell 等）も引き続き使えます");
+    }
+}


### PR DESCRIPTION
## 概要
`/market` サブコマンドが15個に増え、ユーザーがコマンドを覚える負担が大きくなっていた。
`/market`（無引数）で**統合ハブGUI**を開き、閲覧・管理・登録の全操作をGUIで完結できるようにした。

## 変更内容
### 新規
- `ChatInputManager` — GUIからチャットで値を入力させる共通基盤（非同期チャットをメインスレッドへ同期してコールバック。`cancel`／タイムアウト／ログアウトで破棄）
- `MarketHubGUI` — 27スロットのハブメニュー
  - 段1: 出品一覧 / 自分の出品 / 募集一覧 / 自分の募集 / サービス一覧 / 自分の依頼
  - 段2: 出品する / 募集する / 修理を依頼 / エンチャントを依頼（権限・サービス有効に応じて表示）
  - 段3: ヘルプ / 閉じる

### 変更
- `MarketGUISession` — `Type.HUB` 追加
- `MarketGUIListener` — hubGUI参照・セッター・dispatch分岐
- `MarketCommand` — 無引数をハブ起動に変更、未使用化した browseGUI 参照を整理、ヘルプ補記
- `TofuNomics` — 生成・注入・イベント登録、コマンド引数差し替え
- `ConfigManager` — `input_timeout`/`input_cancelled`/`input_invalid_number` を自動補完に追加

## 設計判断
- 登録系のビジネスロジックは既存 `MarketManager.createXxx` をそのまま再利用（ロジック重複なし）
- 出品/修理/エンチャントは「手に持ったアイテム」前提を踏襲
- 募集は「手持ちにないものを買う」のが本質のため、アイテム名はチャット入力（手持ちがあれば例示）
- **既存サブコマンド（`/market sell <価格>` 等）は全て後方互換で維持**

## 動作確認
- `mvn clean compile` → BUILD SUCCESS
- ゲーム内動作確認は別途デプロイ後に実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)