### PR TITLE
feat: housingコマンドを統合ハブGUIに一本化

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -57,6 +57,8 @@ public final class TofuNomics extends JavaPlugin {
     private org.tofu.tofunomics.housing.HousingRentalManager housingRentalManager;
     private org.tofu.tofunomics.housing.SelectionManager selectionManager;
     private org.tofu.tofunomics.housing.HousingListener housingListener;
+    private org.tofu.tofunomics.housing.gui.HousingHubGUI housingHubGUI;
+    private org.tofu.tofunomics.housing.gui.HousingGUIListener housingGUIListener;
     private org.tofu.tofunomics.integration.WorldGuardIntegration worldGuardIntegration;
     private org.tofu.tofunomics.protection.HostileMobRemovalManager hostileMobRemovalManager; // 敵対的モブ自動除去マネージャー
 
@@ -132,7 +134,7 @@ public final class TofuNomics extends JavaPlugin {
     private org.tofu.tofunomics.market.gui.RepairWorkGUI repairWorkGUI;
     private org.tofu.tofunomics.market.gui.MarketGUIListener marketGUIListener;
     private org.tofu.tofunomics.market.gui.MarketHubGUI marketHubGUI;
-    private org.tofu.tofunomics.market.gui.ChatInputManager chatInputManager;
+    private org.tofu.tofunomics.gui.ChatInputManager chatInputManager;
     private org.tofu.tofunomics.market.MarketExpirationTask marketExpirationTask;
 
     @Override
@@ -201,6 +203,9 @@ public final class TofuNomics extends JavaPlugin {
 
         // プレイヤー間マーケットシステムの初期化
         initializeMarketSystem();
+
+        // 住居賃貸GUIの初期化（housingRentalManager と chatInputManager の生成後）
+        initializeHousingGUI();
 
         // イベントリスナーの登録
         registerEventListeners();
@@ -273,6 +278,9 @@ public final class TofuNomics extends JavaPlugin {
         }
         if (marketGUIListener != null) {
             marketGUIListener.closeAll();
+        }
+        if (housingGUIListener != null) {
+            housingGUIListener.closeAll();
         }
 
         // データベース接続を閉じる
@@ -412,7 +420,7 @@ public final class TofuNomics extends JavaPlugin {
             marketGUIListener.setServiceGUIs(serviceBrowseGUI, myServicesGUI);
 
             // チャット入力基盤を生成・登録し、全操作の入口となるハブGUIを生成して配線する
-            chatInputManager = new org.tofu.tofunomics.market.gui.ChatInputManager(this, configManager);
+            chatInputManager = new org.tofu.tofunomics.gui.ChatInputManager(this, configManager);
             getServer().getPluginManager().registerEvents(chatInputManager, this);
             marketHubGUI = new org.tofu.tofunomics.market.gui.MarketHubGUI(
                 this, configManager, marketManager, chatInputManager, marketGUIListener);
@@ -794,13 +802,14 @@ public final class TofuNomics extends JavaPlugin {
             
             // 住居賃貸系コマンド
             if (housingRentalManager != null && testModeManager != null) {
-                org.tofu.tofunomics.commands.HousingCommand housingCommand = 
+                org.tofu.tofunomics.commands.HousingCommand housingCommand =
                     new org.tofu.tofunomics.commands.HousingCommand(
                         this,
                         housingRentalManager,
                         selectionManager,
                         testModeManager,
-                        configManager
+                        configManager,
+                        housingHubGUI
                     );
                 getCommand("housing").setExecutor(housingCommand);
                 getCommand("housing").setTabCompleter(housingCommand);
@@ -1291,7 +1300,45 @@ public final class TofuNomics extends JavaPlugin {
             getLogger().severe("住居賃貸システムの初期化中にエラーが発生しました: " + e.getMessage());
         }
     }
-    
+
+    /**
+     * 住居賃貸の統合GUI（ハブ・物件一覧・詳細・自分の契約・管理）を生成・配線する。
+     * housingRentalManager と chatInputManager の生成後に呼ぶこと。
+     */
+    private void initializeHousingGUI() {
+        try {
+            if (housingRentalManager == null || chatInputManager == null) {
+                getLogger().warning("住居賃貸GUIの初期化をスキップしました（依存が未準備）");
+                return;
+            }
+            housingGUIListener = new org.tofu.tofunomics.housing.gui.HousingGUIListener(this);
+            org.tofu.tofunomics.housing.gui.HousingHubGUI hub =
+                new org.tofu.tofunomics.housing.gui.HousingHubGUI(this, configManager, housingGUIListener);
+            org.tofu.tofunomics.housing.gui.HousingBrowseGUI browse =
+                new org.tofu.tofunomics.housing.gui.HousingBrowseGUI(this, configManager, housingRentalManager, housingGUIListener);
+            org.tofu.tofunomics.housing.gui.HousingDetailGUI detail =
+                new org.tofu.tofunomics.housing.gui.HousingDetailGUI(this, configManager, housingRentalManager, chatInputManager, housingGUIListener);
+            org.tofu.tofunomics.housing.gui.MyRentalsGUI myRentals =
+                new org.tofu.tofunomics.housing.gui.MyRentalsGUI(this, configManager, housingRentalManager, housingGUIListener);
+            org.tofu.tofunomics.housing.gui.RentalManageGUI manage =
+                new org.tofu.tofunomics.housing.gui.RentalManageGUI(this, configManager, housingRentalManager, chatInputManager, housingGUIListener);
+
+            // 相互参照を注入（循環依存の解決）
+            hub.setGUIs(browse, myRentals);
+            browse.setGUIs(hub, detail);
+            detail.setGUIs(hub, browse);
+            myRentals.setGUIs(hub, manage);
+            manage.setGUIs(hub, myRentals);
+            housingGUIListener.setGUIs(hub, browse, detail, myRentals, manage);
+
+            getServer().getPluginManager().registerEvents(housingGUIListener, this);
+            housingHubGUI = hub;
+            getLogger().info("住居賃貸GUIを初期化しました");
+        } catch (Exception e) {
+            getLogger().severe("住居賃貸GUI初期化中にエラーが発生しました: " + e.getMessage());
+        }
+    }
+
     private void cleanupHousingSystem() {
         if (selectionManager != null) {
             selectionManager.clearAllSelections();

--- a/src/main/java/org/tofu/tofunomics/commands/HousingCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/HousingCommand.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.tofu.tofunomics.TofuNomics;
 import org.tofu.tofunomics.housing.HousingRentalManager;
 import org.tofu.tofunomics.housing.SelectionManager;
+import org.tofu.tofunomics.housing.gui.HousingHubGUI;
 import org.tofu.tofunomics.models.HousingProperty;
 import org.tofu.tofunomics.models.HousingRental;
 import org.tofu.tofunomics.testing.TestModeManager;
@@ -25,19 +26,26 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
     private final SelectionManager selectionManager;
     private final TestModeManager testModeManager;
     private final org.tofu.tofunomics.config.ConfigManager configManager;
+    private final HousingHubGUI housingHubGUI;
 
-    public HousingCommand(TofuNomics plugin, HousingRentalManager rentalManager, SelectionManager selectionManager, TestModeManager testModeManager, org.tofu.tofunomics.config.ConfigManager configManager) {
+    public HousingCommand(TofuNomics plugin, HousingRentalManager rentalManager, SelectionManager selectionManager, TestModeManager testModeManager, org.tofu.tofunomics.config.ConfigManager configManager, HousingHubGUI housingHubGUI) {
         this.plugin = plugin;
         this.rentalManager = rentalManager;
         this.selectionManager = selectionManager;
         this.testModeManager = testModeManager;
         this.configManager = configManager;
+        this.housingHubGUI = housingHubGUI;
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length == 0) {
-            sendUsage(sender);
+            // 無引数はGUIハブを開く（全操作の入口）。GUI未初期化時やコンソールは従来の使用法表示。
+            if (sender instanceof Player && housingHubGUI != null) {
+                housingHubGUI.open((Player) sender);
+            } else {
+                sendUsage(sender);
+            }
             return true;
         }
 

--- a/src/main/java/org/tofu/tofunomics/gui/ChatInputManager.java
+++ b/src/main/java/org/tofu/tofunomics/gui/ChatInputManager.java
@@ -1,4 +1,4 @@
-package org.tofu.tofunomics.market.gui;
+package org.tofu.tofunomics.gui;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -22,6 +22,8 @@ import java.util.function.Consumer;
  * GUI を閉じてプレイヤーにチャット入力を促し、次のチャットメッセージをコールバックで受け取る。
  * 「cancel」入力・タイムアウト・ログアウトで保留中のプロンプトは破棄される。
  * 複数値の入力は {@code onInput} 内で次の {@link #prompt} を呼ぶことでステップ式にチェーンできる。
+ *
+ * market / housing など複数機能の GUI から共有する（インスタンスは1つでよい）。
  *
  * 注意: {@link AsyncPlayerChatEvent} は非同期スレッドで発火するため、
  * コールバックは必ず {@link org.bukkit.scheduler.BukkitScheduler#runTask} でメインスレッドへ同期してから実行する。

--- a/src/main/java/org/tofu/tofunomics/gui/GuiUtil.java
+++ b/src/main/java/org/tofu/tofunomics/gui/GuiUtil.java
@@ -1,0 +1,63 @@
+package org.tofu.tofunomics.gui;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+
+/**
+ * GUI 共通のヘルパー（ボタン生成・価格整形・Material 名整形）。
+ *
+ * market / housing など複数機能の GUI から共有して利用する。
+ */
+public final class GuiUtil {
+
+    private GuiUtil() {
+    }
+
+    /**
+     * 表示用ボタン（クリックしても消費されない装飾/操作アイテム）を生成する。
+     */
+    public static ItemStack createButton(Material material, String name, List<String> lore) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    /**
+     * 価格を表示用文字列に整形する。整数値なら小数点を付けない。
+     */
+    public static String formatPrice(double price) {
+        if (price == Math.floor(price) && !Double.isInfinite(price)) {
+            return String.valueOf((long) price);
+        }
+        return String.valueOf(price);
+    }
+
+    /**
+     * Material 名（例: DIAMOND_SWORD）を読みやすい表示名（Diamond Sword）に整形する。
+     */
+    public static String prettifyMaterial(String material) {
+        if (material == null || material.isEmpty()) {
+            return "アイテム";
+        }
+        String[] parts = material.toLowerCase().split("_");
+        StringBuilder sb = new StringBuilder();
+        for (String part : parts) {
+            if (part.isEmpty()) {
+                continue;
+            }
+            if (sb.length() > 0) {
+                sb.append(" ");
+            }
+            sb.append(Character.toUpperCase(part.charAt(0))).append(part.substring(1));
+        }
+        return sb.length() > 0 ? sb.toString() : "アイテム";
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingBrowseGUI.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingBrowseGUI.java
@@ -1,0 +1,173 @@
+package org.tofu.tofunomics.housing.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.gui.GuiUtil;
+import org.tofu.tofunomics.housing.HousingRentalManager;
+import org.tofu.tofunomics.models.HousingProperty;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 賃貸可能物件の一覧 GUI（ページング）。物件をクリックすると詳細（{@link HousingDetailGUI}）へ遷移する。
+ */
+public class HousingBrowseGUI {
+
+    private static final int INVENTORY_SIZE = 54;
+    private static final int ITEM_START_SLOT = 9;
+    private static final int ITEM_END_SLOT = 44;
+    private static final int ITEMS_PER_PAGE = ITEM_END_SLOT - ITEM_START_SLOT + 1; // 36
+    private static final int SLOT_PREV = 48;
+    private static final int SLOT_INFO = 49;
+    private static final int SLOT_NEXT = 50;
+    private static final int SLOT_BACK = 45;
+    private static final int SLOT_CLOSE = 53;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final HousingRentalManager rentalManager;
+    private final HousingGUIListener listener;
+
+    private HousingHubGUI hubGUI;
+    private HousingDetailGUI detailGUI;
+
+    public HousingBrowseGUI(TofuNomics plugin, ConfigManager configManager,
+                            HousingRentalManager rentalManager, HousingGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.rentalManager = rentalManager;
+        this.listener = listener;
+    }
+
+    public void setGUIs(HousingHubGUI hubGUI, HousingDetailGUI detailGUI) {
+        this.hubGUI = hubGUI;
+        this.detailGUI = detailGUI;
+    }
+
+    public void open(Player player) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, INVENTORY_SIZE, "§6住居賃貸 - 物件一覧");
+            HousingGUISession session = new HousingGUISession(
+                    player.getUniqueId(), HousingGUISession.Type.BROWSE, gui);
+            render(session);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("住居物件一覧GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage("§c処理中にエラーが発生しました。");
+        }
+    }
+
+    public void render(HousingGUISession session) {
+        Inventory gui = session.getInventory();
+        gui.clear();
+        session.clearSlots();
+
+        List<HousingProperty> properties = rentalManager.getAvailableProperties();
+
+        int totalPages = Math.max(1, (int) Math.ceil(properties.size() / (double) ITEMS_PER_PAGE));
+        if (session.getPage() >= totalPages) {
+            session.setPage(totalPages - 1);
+        }
+        if (session.getPage() < 0) {
+            session.setPage(0);
+        }
+
+        int start = session.getPage() * ITEMS_PER_PAGE;
+        int end = Math.min(start + ITEMS_PER_PAGE, properties.size());
+
+        int slot = ITEM_START_SLOT;
+        for (int i = start; i < end; i++) {
+            HousingProperty property = properties.get(i);
+            gui.setItem(slot, buildPropertyItem(property));
+            session.putSlotProperty(slot, property);
+            slot++;
+        }
+
+        setupNavigation(gui, session, properties.size(), totalPages);
+    }
+
+    private ItemStack buildPropertyItem(HousingProperty property) {
+        return GuiUtil.createButton(Material.OAK_DOOR, "§f" + property.getPropertyName(),
+                Arrays.asList(
+                        "§7ID: §f" + property.getId(),
+                        "§7ワールド: §f" + property.getWorldName(),
+                        property.getDescription() != null ? "§7説明: §f" + property.getDescription() : "§7説明: §8なし",
+                        "",
+                        "§7日額: §a" + GuiUtil.formatPrice(property.getDailyRent()),
+                        "§7週額: §a" + GuiUtil.formatPrice(property.getWeeklyRent()),
+                        "§7月額: §a" + GuiUtil.formatPrice(property.getMonthlyRent()),
+                        "",
+                        "§eクリックで詳細・契約"
+                ));
+    }
+
+    private void setupNavigation(Inventory gui, HousingGUISession session, int total, int totalPages) {
+        if (session.getPage() > 0) {
+            gui.setItem(SLOT_PREV, GuiUtil.createButton(Material.ARROW, "§a前のページ",
+                    Collections.singletonList("§7ページ " + session.getPage() + " へ")));
+        }
+        if (session.getPage() < totalPages - 1) {
+            gui.setItem(SLOT_NEXT, GuiUtil.createButton(Material.ARROW, "§a次のページ",
+                    Collections.singletonList("§7ページ " + (session.getPage() + 2) + " へ")));
+        }
+
+        gui.setItem(SLOT_INFO, GuiUtil.createButton(Material.BOOK, "§6物件情報",
+                Arrays.asList(
+                        "§f賃貸可能: §a" + total + " 件",
+                        "§fページ: §e" + (session.getPage() + 1) + " / " + totalPages
+                )));
+
+        gui.setItem(SLOT_BACK, GuiUtil.createButton(Material.BARRIER, "§e戻る",
+                Collections.singletonList("§7ハブメニューへ戻ります")));
+        gui.setItem(SLOT_CLOSE, GuiUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = GuiUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = 45; i < INVENTORY_SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    public void handleClick(Player player, HousingGUISession session, int slot, ClickType clickType) {
+        if (slot == SLOT_CLOSE) {
+            player.closeInventory();
+            return;
+        }
+        if (slot == SLOT_BACK) {
+            if (hubGUI != null) hubGUI.open(player);
+            return;
+        }
+        if (slot == SLOT_PREV) {
+            session.setPage(session.getPage() - 1);
+            render(session);
+            return;
+        }
+        if (slot == SLOT_NEXT) {
+            session.setPage(session.getPage() + 1);
+            render(session);
+            return;
+        }
+
+        HousingProperty property = session.getPropertyAtSlot(slot);
+        if (property == null) {
+            return;
+        }
+        if (detailGUI != null) {
+            detailGUI.open(player, property);
+        }
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingDetailGUI.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingDetailGUI.java
@@ -1,0 +1,175 @@
+package org.tofu.tofunomics.housing.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.gui.ChatInputManager;
+import org.tofu.tofunomics.gui.GuiUtil;
+import org.tofu.tofunomics.housing.HousingRentalManager;
+import org.tofu.tofunomics.models.HousingProperty;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * 物件詳細 GUI。日/週/月のいずれかを選び、個数（何日/何週/何ヶ月）をチャット入力して契約する。
+ */
+public class HousingDetailGUI {
+
+    private static final int SIZE = 27;
+    private static final int SLOT_ICON = 4;
+    private static final int SLOT_RENT_DAILY = 11;
+    private static final int SLOT_RENT_WEEKLY = 13;
+    private static final int SLOT_RENT_MONTHLY = 15;
+    private static final int SLOT_BACK = 18;
+    private static final int SLOT_CLOSE = 26;
+
+    private static final int INPUT_TIMEOUT_SECONDS = 60;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final HousingRentalManager rentalManager;
+    private final ChatInputManager chatInput;
+    private final HousingGUIListener listener;
+
+    private HousingHubGUI hubGUI;
+    private HousingBrowseGUI browseGUI;
+
+    public HousingDetailGUI(TofuNomics plugin, ConfigManager configManager,
+                            HousingRentalManager rentalManager, ChatInputManager chatInput,
+                            HousingGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.rentalManager = rentalManager;
+        this.chatInput = chatInput;
+        this.listener = listener;
+    }
+
+    public void setGUIs(HousingHubGUI hubGUI, HousingBrowseGUI browseGUI) {
+        this.hubGUI = hubGUI;
+        this.browseGUI = browseGUI;
+    }
+
+    public void open(Player player, HousingProperty property) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, SIZE, "§6物件詳細 - " + property.getPropertyName());
+            HousingGUISession session = new HousingGUISession(
+                    player.getUniqueId(), HousingGUISession.Type.DETAIL, gui);
+            session.setSelectedPropertyId(property.getId());
+            render(gui, property);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("住居物件詳細GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage("§c処理中にエラーが発生しました。");
+        }
+    }
+
+    private void render(Inventory gui, HousingProperty property) {
+        gui.setItem(SLOT_ICON, GuiUtil.createButton(Material.OAK_DOOR, "§f§l" + property.getPropertyName(),
+                Arrays.asList(
+                        "§7ID: §f" + property.getId(),
+                        "§7ワールド: §f" + property.getWorldName(),
+                        property.getDescription() != null ? "§7説明: §f" + property.getDescription() : "§7説明: §8なし",
+                        "§7状態: " + (property.isAvailable() ? "§a利用可能" : "§c賃貸中")
+                )));
+
+        gui.setItem(SLOT_RENT_DAILY, GuiUtil.createButton(Material.LIME_CONCRETE, "§a§l日で借りる",
+                Arrays.asList("§7日額: §a" + GuiUtil.formatPrice(property.getDailyRent()),
+                        "§7クリック後、日数をチャット入力")));
+        gui.setItem(SLOT_RENT_WEEKLY, GuiUtil.createButton(Material.LIME_CONCRETE, "§a§l週で借りる",
+                Arrays.asList("§7週額: §a" + GuiUtil.formatPrice(property.getWeeklyRent()),
+                        "§7クリック後、週数をチャット入力")));
+        gui.setItem(SLOT_RENT_MONTHLY, GuiUtil.createButton(Material.LIME_CONCRETE, "§a§l月で借りる",
+                Arrays.asList("§7月額: §a" + GuiUtil.formatPrice(property.getMonthlyRent()),
+                        "§7クリック後、月数をチャット入力")));
+
+        gui.setItem(SLOT_BACK, GuiUtil.createButton(Material.BARRIER, "§e戻る",
+                Collections.singletonList("§7物件一覧へ戻ります")));
+        gui.setItem(SLOT_CLOSE, GuiUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = GuiUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = 0; i < SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    public void handleClick(Player player, HousingGUISession session, int slot, ClickType clickType) {
+        switch (slot) {
+            case SLOT_RENT_DAILY:
+                startRent(player, session.getSelectedPropertyId(), "daily", "日");
+                break;
+            case SLOT_RENT_WEEKLY:
+                startRent(player, session.getSelectedPropertyId(), "weekly", "週");
+                break;
+            case SLOT_RENT_MONTHLY:
+                startRent(player, session.getSelectedPropertyId(), "monthly", "ヶ月");
+                break;
+            case SLOT_BACK:
+                if (browseGUI != null) browseGUI.open(player);
+                break;
+            case SLOT_CLOSE:
+                player.closeInventory();
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void startRent(Player player, int propertyId, String period, String unitName) {
+        HousingProperty property = rentalManager.getProperty(propertyId);
+        if (property == null || !property.isAvailable()) {
+            player.sendMessage("§cこの物件は現在契約できません。");
+            reopenHub(player);
+            player.closeInventory();
+            return;
+        }
+        player.closeInventory();
+        chatInput.prompt(player,
+                "§e契約期間を入力してください（何" + unitName + "分か、数で入力）。",
+                input -> {
+                    Integer units = parsePositiveInt(player, input);
+                    if (units == null) {
+                        reopenHub(player);
+                        return;
+                    }
+                    HousingRentalManager.RentalResult result =
+                            rentalManager.rentProperty(player.getUniqueId(), propertyId, period, units);
+                    player.sendMessage((result.isSuccess() ? "§a" : "§c") + result.getMessage());
+                    reopenHub(player);
+                },
+                () -> reopenHub(player), INPUT_TIMEOUT_SECONDS);
+    }
+
+    private Integer parsePositiveInt(Player player, String input) {
+        int value;
+        try {
+            value = Integer.parseInt(input.trim());
+        } catch (NumberFormatException e) {
+            player.sendMessage(configManager.getMarketMessage("input_invalid_number"));
+            return null;
+        }
+        if (value <= 0) {
+            player.sendMessage(configManager.getMarketMessage("input_invalid_number"));
+            return null;
+        }
+        return value;
+    }
+
+    private void reopenHub(Player player) {
+        if (hubGUI != null) {
+            hubGUI.reopenLater(player);
+        }
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUIListener.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUIListener.java
@@ -1,0 +1,138 @@
+package org.tofu.tofunomics.housing.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * housing GUI のクリック/クローズイベントを集約して各 GUI のクリック処理へ振り分けるリスナー。
+ *
+ * 開いている GUI のセッションを {@link ConcurrentHashMap} で管理し、
+ * セッション種別に応じて各 GUI の handleClick へ振り分ける（market の MarketGUIListener と同型）。
+ *
+ * 配線順: 本リスナーを生成 → 各 GUI を生成（コンストラクタに本リスナーを渡す）
+ * → {@link #setGUIs} で GUI 参照を注入 → registerEvents。
+ */
+public class HousingGUIListener implements Listener {
+
+    private final TofuNomics plugin;
+    private final Map<UUID, HousingGUISession> sessions = new ConcurrentHashMap<>();
+
+    private HousingHubGUI hubGUI;
+    private HousingBrowseGUI browseGUI;
+    private HousingDetailGUI detailGUI;
+    private MyRentalsGUI myRentalsGUI;
+    private RentalManageGUI manageGUI;
+
+    public HousingGUIListener(TofuNomics plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * GUI 参照を注入する（循環依存を避けるためセッターで後から設定）。
+     */
+    public void setGUIs(HousingHubGUI hubGUI, HousingBrowseGUI browseGUI, HousingDetailGUI detailGUI,
+                        MyRentalsGUI myRentalsGUI, RentalManageGUI manageGUI) {
+        this.hubGUI = hubGUI;
+        this.browseGUI = browseGUI;
+        this.detailGUI = detailGUI;
+        this.myRentalsGUI = myRentalsGUI;
+        this.manageGUI = manageGUI;
+    }
+
+    /**
+     * GUI を開いた際にセッションを登録する。
+     */
+    public void registerSession(UUID playerId, HousingGUISession session) {
+        sessions.put(playerId, session);
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) {
+            return;
+        }
+        Player player = (Player) event.getWhoClicked();
+        HousingGUISession session = sessions.get(player.getUniqueId());
+        if (session == null || !session.getInventory().equals(event.getInventory())) {
+            return;
+        }
+
+        // GUI 内のクリックは全てキャンセル（アイテムの持ち出し防止）
+        event.setCancelled(true);
+
+        if (event.getRawSlot() < 0 || event.getRawSlot() >= session.getInventory().getSize()) {
+            return;
+        }
+
+        ItemStack clicked = event.getCurrentItem();
+        if (clicked == null || clicked.getType() == Material.AIR) {
+            return;
+        }
+
+        try {
+            dispatchClick(player, session, event.getSlot(), event.getClick());
+        } catch (Exception e) {
+            plugin.getLogger().severe("住居GUIクリック処理中にエラーが発生しました: " + e.getMessage());
+        }
+    }
+
+    private void dispatchClick(Player player, HousingGUISession session, int slot,
+                               org.bukkit.event.inventory.ClickType clickType) {
+        switch (session.getType()) {
+            case HUB:
+                if (hubGUI != null) hubGUI.handleClick(player, session, slot, clickType);
+                break;
+            case BROWSE:
+                if (browseGUI != null) browseGUI.handleClick(player, session, slot, clickType);
+                break;
+            case DETAIL:
+                if (detailGUI != null) detailGUI.handleClick(player, session, slot, clickType);
+                break;
+            case MY_RENTALS:
+                if (myRentalsGUI != null) myRentalsGUI.handleClick(player, session, slot, clickType);
+                break;
+            case MANAGE:
+            case CANCEL_CONFIRM:
+                if (manageGUI != null) manageGUI.handleClick(player, session, slot, clickType);
+                break;
+            default:
+                break;
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player)) {
+            return;
+        }
+        Player player = (Player) event.getPlayer();
+        HousingGUISession session = sessions.get(player.getUniqueId());
+        if (session != null && session.getInventory().equals(event.getInventory())) {
+            sessions.remove(player.getUniqueId());
+        }
+    }
+
+    /**
+     * 開いている全 housing GUI を閉じる（プラグイン無効化時用）。
+     */
+    public void closeAll() {
+        for (HousingGUISession session : sessions.values()) {
+            Player player = Bukkit.getPlayer(session.getPlayerId());
+            if (player != null && player.isOnline()) {
+                player.closeInventory();
+            }
+        }
+        sessions.clear();
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUISession.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUISession.java
@@ -1,0 +1,105 @@
+package org.tofu.tofunomics.housing.gui;
+
+import org.bukkit.inventory.Inventory;
+import org.tofu.tofunomics.models.HousingProperty;
+import org.tofu.tofunomics.models.HousingRental;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * housing GUI（ハブ・物件一覧・詳細・自分の契約・契約管理）の開いている状態を保持するセッション。
+ *
+ * どの種類の GUI が開いているか、現在ページ、各スロットに対応する物件/契約、
+ * 詳細・管理画面で選択中の物件ID/契約IDを保持し、クリック時に解決できるようにする。
+ */
+public class HousingGUISession {
+
+    /** GUI の種別 */
+    public enum Type {
+        HUB,            // ハブ（全操作の入口）
+        BROWSE,         // 物件一覧（利用可能）
+        DETAIL,         // 物件詳細（借りる）
+        MY_RENTALS,     // 自分の契約一覧
+        MANAGE,         // 契約管理（延長・解約）
+        CANCEL_CONFIRM  // 解約の確認
+    }
+
+    private final UUID playerId;
+    private final Type type;
+    private final Inventory inventory;
+    private int page;
+
+    // 詳細・管理画面で選択中の対象（-1=未設定）
+    private int selectedPropertyId = -1;
+    private int selectedRentalId = -1;
+
+    // スロット番号 → 表示中の物件/契約
+    private final Map<Integer, HousingProperty> slotProperties = new HashMap<>();
+    private final Map<Integer, HousingRental> slotRentals = new HashMap<>();
+
+    public HousingGUISession(UUID playerId, Type type, Inventory inventory) {
+        this.playerId = playerId;
+        this.type = type;
+        this.inventory = inventory;
+        this.page = 0;
+    }
+
+    public UUID getPlayerId() {
+        return playerId;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    public int getSelectedPropertyId() {
+        return selectedPropertyId;
+    }
+
+    public void setSelectedPropertyId(int selectedPropertyId) {
+        this.selectedPropertyId = selectedPropertyId;
+    }
+
+    public int getSelectedRentalId() {
+        return selectedRentalId;
+    }
+
+    public void setSelectedRentalId(int selectedRentalId) {
+        this.selectedRentalId = selectedRentalId;
+    }
+
+    public void clearSlots() {
+        slotProperties.clear();
+        slotRentals.clear();
+    }
+
+    public void putSlotProperty(int slot, HousingProperty property) {
+        slotProperties.put(slot, property);
+    }
+
+    public HousingProperty getPropertyAtSlot(int slot) {
+        return slotProperties.get(slot);
+    }
+
+    public void putSlotRental(int slot, HousingRental rental) {
+        slotRentals.put(slot, rental);
+    }
+
+    public HousingRental getRentalAtSlot(int slot) {
+        return slotRentals.get(slot);
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingHubGUI.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingHubGUI.java
@@ -1,0 +1,122 @@
+package org.tofu.tofunomics.housing.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.gui.GuiUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * 住居賃貸の統合ハブ GUI。
+ *
+ * {@code /housing}（無引数）で開く全操作の入口。物件一覧・自分の契約へボタン遷移する。
+ * 管理者操作（物件登録など）は従来コマンドのまま（ここには含めない）。
+ */
+public class HousingHubGUI {
+
+    private static final String PERM_USE = "tofunomics.housing.use";
+
+    private static final int SIZE = 27;
+    private static final int SLOT_BROWSE = 11;
+    private static final int SLOT_MY_RENTALS = 15;
+    private static final int SLOT_HELP = 22;
+    private static final int SLOT_CLOSE = 26;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final HousingGUIListener listener;
+
+    private HousingBrowseGUI browseGUI;
+    private MyRentalsGUI myRentalsGUI;
+
+    public HousingHubGUI(TofuNomics plugin, ConfigManager configManager, HousingGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.listener = listener;
+    }
+
+    public void setGUIs(HousingBrowseGUI browseGUI, MyRentalsGUI myRentalsGUI) {
+        this.browseGUI = browseGUI;
+        this.myRentalsGUI = myRentalsGUI;
+    }
+
+    public void open(Player player) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, SIZE, "§6住居賃貸");
+            HousingGUISession session = new HousingGUISession(
+                    player.getUniqueId(), HousingGUISession.Type.HUB, gui);
+            render(gui);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("住居ハブGUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage("§c処理中にエラーが発生しました。");
+        }
+    }
+
+    private void render(Inventory gui) {
+        gui.setItem(SLOT_BROWSE, GuiUtil.createButton(Material.OAK_DOOR, "§a§l物件一覧",
+                Arrays.asList("§7賃貸可能な物件を見て契約します", "§eクリックで開く")));
+        gui.setItem(SLOT_MY_RENTALS, GuiUtil.createButton(Material.PAPER, "§b§l自分の契約",
+                Arrays.asList("§7契約中の物件を確認・延長・解約します", "§eクリックで開く")));
+        gui.setItem(SLOT_HELP, GuiUtil.createButton(Material.BOOK, "§e§lヘルプ",
+                Collections.singletonList("§7住居賃貸の使い方を表示します")));
+        gui.setItem(SLOT_CLOSE, GuiUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = GuiUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = 0; i < SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    public void handleClick(Player player, HousingGUISession session, int slot, ClickType clickType) {
+        switch (slot) {
+            case SLOT_BROWSE:
+                if (browseGUI != null) browseGUI.open(player);
+                break;
+            case SLOT_MY_RENTALS:
+                if (myRentalsGUI != null) myRentalsGUI.open(player);
+                break;
+            case SLOT_HELP:
+                player.closeInventory();
+                sendHelp(player);
+                break;
+            case SLOT_CLOSE:
+                player.closeInventory();
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void sendHelp(Player player) {
+        player.sendMessage("§6=== 住居賃貸の使い方 ===");
+        player.sendMessage("§e/housing §7- このGUIを開きます（全操作の入口）");
+        player.sendMessage("§7・物件一覧 から物件を選び、日/週/月を選んで契約できます");
+        player.sendMessage("§7・自分の契約 から延長・解約ができます");
+        player.sendMessage("§7・契約時は期間（数）をチャットで入力します（cancel で中止）");
+        player.sendMessage("§7従来のコマンド（/housing rent 等）も引き続き使えます");
+    }
+
+    // ハブが対象でないクラスからの再表示用ヘルパー
+    void reopenLater(Player player) {
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (player.isOnline()) {
+                open(player);
+            }
+        }, 1L);
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/housing/gui/MyRentalsGUI.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/MyRentalsGUI.java
@@ -1,0 +1,180 @@
+package org.tofu.tofunomics.housing.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.gui.GuiUtil;
+import org.tofu.tofunomics.housing.HousingRentalManager;
+import org.tofu.tofunomics.models.HousingProperty;
+import org.tofu.tofunomics.models.HousingRental;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 自分の契約一覧 GUI（ページング）。契約をクリックすると管理画面（{@link RentalManageGUI}）へ遷移する。
+ */
+public class MyRentalsGUI {
+
+    private static final int INVENTORY_SIZE = 54;
+    private static final int ITEM_START_SLOT = 9;
+    private static final int ITEM_END_SLOT = 44;
+    private static final int ITEMS_PER_PAGE = ITEM_END_SLOT - ITEM_START_SLOT + 1; // 36
+    private static final int SLOT_PREV = 48;
+    private static final int SLOT_INFO = 49;
+    private static final int SLOT_NEXT = 50;
+    private static final int SLOT_BACK = 45;
+    private static final int SLOT_CLOSE = 53;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final HousingRentalManager rentalManager;
+    private final HousingGUIListener listener;
+
+    private HousingHubGUI hubGUI;
+    private RentalManageGUI manageGUI;
+
+    public MyRentalsGUI(TofuNomics plugin, ConfigManager configManager,
+                        HousingRentalManager rentalManager, HousingGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.rentalManager = rentalManager;
+        this.listener = listener;
+    }
+
+    public void setGUIs(HousingHubGUI hubGUI, RentalManageGUI manageGUI) {
+        this.hubGUI = hubGUI;
+        this.manageGUI = manageGUI;
+    }
+
+    public void open(Player player) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, INVENTORY_SIZE, "§6住居賃貸 - 自分の契約");
+            HousingGUISession session = new HousingGUISession(
+                    player.getUniqueId(), HousingGUISession.Type.MY_RENTALS, gui);
+            render(player, session);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("自分の契約GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage("§c処理中にエラーが発生しました。");
+        }
+    }
+
+    public void render(Player player, HousingGUISession session) {
+        Inventory gui = session.getInventory();
+        gui.clear();
+        session.clearSlots();
+
+        World world = resolveWorld();
+        List<HousingRental> rentals = rentalManager.getPlayerRentals(player.getUniqueId());
+
+        int totalPages = Math.max(1, (int) Math.ceil(rentals.size() / (double) ITEMS_PER_PAGE));
+        if (session.getPage() >= totalPages) {
+            session.setPage(totalPages - 1);
+        }
+        if (session.getPage() < 0) {
+            session.setPage(0);
+        }
+
+        int start = session.getPage() * ITEMS_PER_PAGE;
+        int end = Math.min(start + ITEMS_PER_PAGE, rentals.size());
+
+        int slot = ITEM_START_SLOT;
+        for (int i = start; i < end; i++) {
+            HousingRental rental = rentals.get(i);
+            gui.setItem(slot, buildRentalItem(rental, world));
+            session.putSlotRental(slot, rental);
+            slot++;
+        }
+
+        setupNavigation(gui, session, rentals.size(), totalPages);
+    }
+
+    private ItemStack buildRentalItem(HousingRental rental, World world) {
+        HousingProperty property = rentalManager.getProperty(rental.getPropertyId());
+        String name = property != null ? property.getPropertyName() : "物件 #" + rental.getPropertyId();
+        String remaining = world != null ? rental.getFormattedRemainingTime(world) : "不明";
+
+        List<String> lore = new ArrayList<>();
+        lore.add("§7物件ID: §f" + rental.getPropertyId());
+        lore.add("§7残り: §e" + remaining);
+        lore.add("§7支払総額: §a" + GuiUtil.formatPrice(rental.getTotalCost()));
+        lore.add("");
+        lore.add("§eクリックで延長・解約");
+        return GuiUtil.createButton(Material.PAPER, "§f" + name, lore);
+    }
+
+    private void setupNavigation(Inventory gui, HousingGUISession session, int total, int totalPages) {
+        if (session.getPage() > 0) {
+            gui.setItem(SLOT_PREV, GuiUtil.createButton(Material.ARROW, "§a前のページ",
+                    Collections.singletonList("§7ページ " + session.getPage() + " へ")));
+        }
+        if (session.getPage() < totalPages - 1) {
+            gui.setItem(SLOT_NEXT, GuiUtil.createButton(Material.ARROW, "§a次のページ",
+                    Collections.singletonList("§7ページ " + (session.getPage() + 2) + " へ")));
+        }
+
+        gui.setItem(SLOT_INFO, GuiUtil.createButton(Material.BOOK, "§6契約情報",
+                java.util.Arrays.asList(
+                        "§f契約中: §a" + total + " 件",
+                        "§fページ: §e" + (session.getPage() + 1) + " / " + totalPages
+                )));
+
+        gui.setItem(SLOT_BACK, GuiUtil.createButton(Material.BARRIER, "§e戻る",
+                Collections.singletonList("§7ハブメニューへ戻ります")));
+        gui.setItem(SLOT_CLOSE, GuiUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = GuiUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = 45; i < INVENTORY_SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    public void handleClick(Player player, HousingGUISession session, int slot, ClickType clickType) {
+        if (slot == SLOT_CLOSE) {
+            player.closeInventory();
+            return;
+        }
+        if (slot == SLOT_BACK) {
+            if (hubGUI != null) hubGUI.open(player);
+            return;
+        }
+        if (slot == SLOT_PREV) {
+            session.setPage(session.getPage() - 1);
+            render(player, session);
+            return;
+        }
+        if (slot == SLOT_NEXT) {
+            session.setPage(session.getPage() + 1);
+            render(player, session);
+            return;
+        }
+
+        HousingRental rental = session.getRentalAtSlot(slot);
+        if (rental == null) {
+            return;
+        }
+        if (manageGUI != null) {
+            manageGUI.open(player, rental);
+        }
+    }
+
+    private World resolveWorld() {
+        String worldName = plugin.getConfig().getString("housing_rental.world_name", "world");
+        return Bukkit.getWorld(worldName);
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/housing/gui/RentalManageGUI.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/RentalManageGUI.java
@@ -1,0 +1,217 @@
+package org.tofu.tofunomics.housing.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.gui.ChatInputManager;
+import org.tofu.tofunomics.gui.GuiUtil;
+import org.tofu.tofunomics.housing.HousingRentalManager;
+import org.tofu.tofunomics.models.HousingProperty;
+import org.tofu.tofunomics.models.HousingRental;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * 契約管理 GUI（延長・解約）と、解約の確認画面を扱う。
+ *
+ * 延長は追加日数をチャット入力。解約は不可逆のため確認画面（はい/いいえ）を挟む。
+ */
+public class RentalManageGUI {
+
+    private static final int SIZE = 27;
+    private static final int SLOT_ICON = 4;
+    private static final int SLOT_EXTEND = 11;
+    private static final int SLOT_CANCEL = 15;
+    private static final int SLOT_BACK = 18;
+    private static final int SLOT_CLOSE = 26;
+
+    // 確認画面
+    private static final int SLOT_CONFIRM_YES = 11;
+    private static final int SLOT_CONFIRM_NO = 15;
+
+    private static final int INPUT_TIMEOUT_SECONDS = 60;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final HousingRentalManager rentalManager;
+    private final ChatInputManager chatInput;
+    private final HousingGUIListener listener;
+
+    private HousingHubGUI hubGUI;
+    private MyRentalsGUI myRentalsGUI;
+
+    public RentalManageGUI(TofuNomics plugin, ConfigManager configManager,
+                           HousingRentalManager rentalManager, ChatInputManager chatInput,
+                           HousingGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.rentalManager = rentalManager;
+        this.chatInput = chatInput;
+        this.listener = listener;
+    }
+
+    public void setGUIs(HousingHubGUI hubGUI, MyRentalsGUI myRentalsGUI) {
+        this.hubGUI = hubGUI;
+        this.myRentalsGUI = myRentalsGUI;
+    }
+
+    public void open(Player player, HousingRental rental) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, SIZE, "§6契約管理");
+            HousingGUISession session = new HousingGUISession(
+                    player.getUniqueId(), HousingGUISession.Type.MANAGE, gui);
+            session.setSelectedRentalId(rental.getId());
+            session.setSelectedPropertyId(rental.getPropertyId());
+            renderManage(gui, rental);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("契約管理GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage("§c処理中にエラーが発生しました。");
+        }
+    }
+
+    private void openCancelConfirm(Player player, int propertyId) {
+        HousingProperty property = rentalManager.getProperty(propertyId);
+        String name = property != null ? property.getPropertyName() : "物件 #" + propertyId;
+        Inventory gui = Bukkit.createInventory(null, SIZE, "§c解約の確認");
+        HousingGUISession session = new HousingGUISession(
+                player.getUniqueId(), HousingGUISession.Type.CANCEL_CONFIRM, gui);
+        session.setSelectedPropertyId(propertyId);
+        renderConfirm(gui, name);
+        listener.registerSession(player.getUniqueId(), session);
+        player.openInventory(gui);
+    }
+
+    private void renderManage(Inventory gui, HousingRental rental) {
+        World world = resolveWorld();
+        HousingProperty property = rentalManager.getProperty(rental.getPropertyId());
+        String name = property != null ? property.getPropertyName() : "物件 #" + rental.getPropertyId();
+        String remaining = world != null ? rental.getFormattedRemainingTime(world) : "不明";
+
+        gui.setItem(SLOT_ICON, GuiUtil.createButton(Material.PAPER, "§f§l" + name,
+                Arrays.asList(
+                        "§7物件ID: §f" + rental.getPropertyId(),
+                        "§7残り: §e" + remaining,
+                        "§7支払総額: §a" + GuiUtil.formatPrice(rental.getTotalCost())
+                )));
+        gui.setItem(SLOT_EXTEND, GuiUtil.createButton(Material.CLOCK, "§e§l延長する",
+                Arrays.asList("§7追加日数をチャットで入力します", "§7（日額 × 日数を追加で支払い）")));
+        gui.setItem(SLOT_CANCEL, GuiUtil.createButton(Material.RED_CONCRETE, "§c§l解約する",
+                Collections.singletonList("§7契約を解約します（確認あり）")));
+        gui.setItem(SLOT_BACK, GuiUtil.createButton(Material.BARRIER, "§e戻る",
+                Collections.singletonList("§7自分の契約一覧へ戻ります")));
+        gui.setItem(SLOT_CLOSE, GuiUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        decorate(gui);
+    }
+
+    private void renderConfirm(Inventory gui, String name) {
+        gui.setItem(SLOT_ICON, GuiUtil.createButton(Material.RED_CONCRETE, "§c§l本当に解約しますか？",
+                Arrays.asList("§7対象: §f" + name, "§7解約すると物件は他の人が借りられます")));
+        gui.setItem(SLOT_CONFIRM_YES, GuiUtil.createButton(Material.LIME_CONCRETE, "§a§lはい、解約する",
+                Collections.singletonList("§7契約を解約します")));
+        gui.setItem(SLOT_CONFIRM_NO, GuiUtil.createButton(Material.RED_CONCRETE, "§c§lいいえ",
+                Collections.singletonList("§7解約をやめて契約一覧へ戻ります")));
+        decorate(gui);
+    }
+
+    private void decorate(Inventory gui) {
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = GuiUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = 0; i < SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    public void handleClick(Player player, HousingGUISession session, int slot, ClickType clickType) {
+        if (session.getType() == HousingGUISession.Type.CANCEL_CONFIRM) {
+            handleConfirmClick(player, session, slot);
+            return;
+        }
+        // MANAGE
+        switch (slot) {
+            case SLOT_EXTEND:
+                startExtend(player, session.getSelectedPropertyId());
+                break;
+            case SLOT_CANCEL:
+                openCancelConfirm(player, session.getSelectedPropertyId());
+                break;
+            case SLOT_BACK:
+                if (myRentalsGUI != null) myRentalsGUI.open(player);
+                break;
+            case SLOT_CLOSE:
+                player.closeInventory();
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void handleConfirmClick(Player player, HousingGUISession session, int slot) {
+        if (slot == SLOT_CONFIRM_YES) {
+            HousingRentalManager.RentalResult result =
+                    rentalManager.cancelRental(player.getUniqueId(), session.getSelectedPropertyId());
+            player.sendMessage((result.isSuccess() ? "§a" : "§c") + result.getMessage());
+            reopenHub(player);
+        } else if (slot == SLOT_CONFIRM_NO) {
+            if (myRentalsGUI != null) myRentalsGUI.open(player);
+        }
+    }
+
+    private void startExtend(Player player, int propertyId) {
+        player.closeInventory();
+        chatInput.prompt(player,
+                "§e延長する日数を入力してください。",
+                input -> {
+                    Integer days = parsePositiveInt(player, input);
+                    if (days == null) {
+                        reopenHub(player);
+                        return;
+                    }
+                    HousingRentalManager.RentalResult result =
+                            rentalManager.extendRental(player.getUniqueId(), propertyId, days);
+                    player.sendMessage((result.isSuccess() ? "§a" : "§c") + result.getMessage());
+                    reopenHub(player);
+                },
+                () -> reopenHub(player), INPUT_TIMEOUT_SECONDS);
+    }
+
+    private Integer parsePositiveInt(Player player, String input) {
+        int value;
+        try {
+            value = Integer.parseInt(input.trim());
+        } catch (NumberFormatException e) {
+            player.sendMessage(configManager.getMarketMessage("input_invalid_number"));
+            return null;
+        }
+        if (value <= 0) {
+            player.sendMessage(configManager.getMarketMessage("input_invalid_number"));
+            return null;
+        }
+        return value;
+    }
+
+    private void reopenHub(Player player) {
+        if (hubGUI != null) {
+            hubGUI.reopenLater(player);
+        }
+    }
+
+    private World resolveWorld() {
+        String worldName = plugin.getConfig().getString("housing_rental.world_name", "world");
+        return Bukkit.getWorld(worldName);
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/market/gui/MarketGUIUtil.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MarketGUIUtil.java
@@ -2,60 +2,30 @@ package org.tofu.tofunomics.market.gui;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
+import org.tofu.tofunomics.gui.GuiUtil;
 
 import java.util.List;
 
 /**
- * マーケット GUI 共通のヘルパー（ボタン生成・価格整形・Material 名整形）。
+ * マーケット GUI 共通ヘルパーの後方互換ラッパー。
+ *
+ * 実体は共通の {@link GuiUtil} に移動済み。market 既存コードからの呼び出しを維持するため委譲する。
+ * 新規コードは {@link GuiUtil} を直接利用すること。
  */
 public final class MarketGUIUtil {
 
     private MarketGUIUtil() {
     }
 
-    /**
-     * 表示用ボタン（クリックしても消費されない装飾/操作アイテム）を生成する。
-     */
     public static ItemStack createButton(Material material, String name, List<String> lore) {
-        ItemStack item = new ItemStack(material);
-        ItemMeta meta = item.getItemMeta();
-        if (meta != null) {
-            meta.setDisplayName(name);
-            meta.setLore(lore);
-            item.setItemMeta(meta);
-        }
-        return item;
+        return GuiUtil.createButton(material, name, lore);
     }
 
-    /**
-     * 価格を表示用文字列に整形する。整数値なら小数点を付けない。
-     */
     public static String formatPrice(double price) {
-        if (price == Math.floor(price) && !Double.isInfinite(price)) {
-            return String.valueOf((long) price);
-        }
-        return String.valueOf(price);
+        return GuiUtil.formatPrice(price);
     }
 
-    /**
-     * Material 名（例: DIAMOND_SWORD）を読みやすい表示名（Diamond Sword）に整形する。
-     */
     public static String prettifyMaterial(String material) {
-        if (material == null || material.isEmpty()) {
-            return "アイテム";
-        }
-        String[] parts = material.toLowerCase().split("_");
-        StringBuilder sb = new StringBuilder();
-        for (String part : parts) {
-            if (part.isEmpty()) {
-                continue;
-            }
-            if (sb.length() > 0) {
-                sb.append(" ");
-            }
-            sb.append(Character.toUpperCase(part.charAt(0))).append(part.substring(1));
-        }
-        return sb.length() > 0 ? sb.toString() : "アイテム";
+        return GuiUtil.prettifyMaterial(material);
     }
 }

--- a/src/main/java/org/tofu/tofunomics/market/gui/MarketHubGUI.java
+++ b/src/main/java/org/tofu/tofunomics/market/gui/MarketHubGUI.java
@@ -8,6 +8,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.tofu.tofunomics.TofuNomics;
 import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.gui.ChatInputManager;
 import org.tofu.tofunomics.market.MarketManager;
 import org.tofu.tofunomics.market.MarketMessages;
 import org.tofu.tofunomics.market.MarketResult;


### PR DESCRIPTION
## 概要
`/market` のGUIハブ化に続き、住居賃貸 `/housing` も統合ハブGUIに一本化。
`/housing`（無引数）で**ハブGUI**を開き、物件の閲覧→契約→延長/解約をGUIで完結できる。

> ⚠️ このPRは #59（market統合GUI）に**スタック**しています（ChatInputManager等の共通基盤を共有）。ベースは `feature/market-hub-gui`。#59 マージ後に main ベースへ切り替わります。

## 変更内容
### フェーズ0: GUI共通基盤の切り出し
- `ChatInputManager` を `market/gui` → `gui` パッケージへ移動（market/housing で共有、リスナーは1インスタンス）
- `MarketGUIUtil` の実体を `gui/GuiUtil` へ移動。`MarketGUIUtil` は委譲ラッパーとして残し market 側は無変更

### housing GUI（新規）
- `HousingGUISession` / `HousingGUIListener` — 集約セッション＋クリック振り分け
- `HousingHubGUI` — 入口（物件一覧 / 自分の契約 / ヘルプ / 閉じる）
- `HousingBrowseGUI` — 賃貸可能物件一覧（ページング）→ クリックで詳細
- `HousingDetailGUI` — 物件詳細。「日/週/月で借りる」ボタン→個数をチャット入力→契約
- `MyRentalsGUI` — 自分の契約一覧（残り時間・費用表示）→ クリックで管理
- `RentalManageGUI` — 延長（日数チャット入力）/ 解約（確認画面あり・不可逆操作）

### 変更
- `HousingCommand` — 無引数をハブ起動に変更（**既存サブコマンド・管理者系は全て維持**）
- `TofuNomics` — housing GUI群の生成・注入・イベント登録、onDisableで closeAll

## 設計判断
- 契約・延長・解約は既存 `HousingRentalManager` のメソッドをそのまま再利用（課金・WorldGuard連携はManager内で完結）
- **プレイヤー向けのみGUI化**。管理者系（register/setrent/remove等）は従来コマンド維持
- 借りる期間は日/週/月ボタン＋個数チャット入力（綴り誤りを避け直感的に）

## 動作確認
- `mvn clean compile` → BUILD SUCCESS
- `mvn test` → **285 tests, 0 failures**（リファクタのリグレッションなし）
- ゲーム内動作確認はデプロイ後に実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)