### PR TITLE
feat: 全職業の経験値バランスを改善（鍛冶屋の経験値偏り解消）

### DIFF
--- a/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
+++ b/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
@@ -9,6 +9,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
+import org.bukkit.event.inventory.SmithItemEvent;
 import org.bukkit.event.inventory.BrewEvent;
 import org.bukkit.event.enchantment.EnchantItemEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
@@ -104,6 +105,7 @@ public class JobExperienceManager implements Listener {
         miningExperience.put(Material.NETHER_QUARTZ_ORE, 6.0);
         miningExperience.put(Material.COPPER_ORE, 5.0);  // 1.17追加。鉄鉱石相当
         miningExperience.put(Material.ANCIENT_DEBRIS, 50.0);
+        miningExperience.put(Material.NETHER_GOLD_ORE, 6.0);  // 1.16追加。金鉱石相当
         // STONE: 自然生成のみ経験値獲得（プレイヤー設置はUnifiedEventHandlerで除外）
         miningExperience.put(Material.STONE, 5.0);  // 0.5 → 5.0（メッセージ表示のため）
         // COBBLESTONE: 経験値なし（設置→採掘での無限経験値防止）
@@ -130,6 +132,10 @@ public class JobExperienceManager implements Listener {
         farmingExperience.put(Material.SUGAR_CANE, 1.0);
         farmingExperience.put(Material.COCOA_BEANS, 2.5);
         farmingExperience.put(Material.NETHER_WART, 3.0);
+        farmingExperience.put(Material.BAMBOO, 0.5);
+        farmingExperience.put(Material.CACTUS, 1.0);
+        farmingExperience.put(Material.BROWN_MUSHROOM, 1.5);
+        farmingExperience.put(Material.RED_MUSHROOM, 1.5);
         
         // 釣り経験値テーブル
         fishingExperience.put(PlayerFishEvent.State.CAUGHT_FISH, 5.0);
@@ -137,19 +143,84 @@ public class JobExperienceManager implements Listener {
         fishingExperience.put(PlayerFishEvent.State.IN_GROUND, 1.0);
         
         // 製作経験値テーブル（鍛冶屋）
+        // インゴット精錬
         craftingExperience.put(Material.IRON_INGOT, 3.0);
         craftingExperience.put(Material.GOLD_INGOT, 5.0);
-        craftingExperience.put(Material.IRON_SWORD, 8.0);
-        craftingExperience.put(Material.IRON_PICKAXE, 10.0);
-        craftingExperience.put(Material.IRON_AXE, 10.0);
-        craftingExperience.put(Material.IRON_SHOVEL, 6.0);
-        craftingExperience.put(Material.DIAMOND_SWORD, 20.0);
-        craftingExperience.put(Material.DIAMOND_PICKAXE, 25.0);
-        craftingExperience.put(Material.DIAMOND_AXE, 25.0);
         craftingExperience.put(Material.NETHERITE_INGOT, 50.0);
+        craftingExperience.put(Material.NETHERITE_SCRAP, 15.0);
+        // 剣
+        craftingExperience.put(Material.WOODEN_SWORD, 2.0);
+        craftingExperience.put(Material.STONE_SWORD, 3.0);
+        craftingExperience.put(Material.IRON_SWORD, 8.0);
+        craftingExperience.put(Material.GOLDEN_SWORD, 8.0);
+        craftingExperience.put(Material.DIAMOND_SWORD, 20.0);
+        craftingExperience.put(Material.NETHERITE_SWORD, 60.0);
+        // ツルハシ
+        craftingExperience.put(Material.WOODEN_PICKAXE, 2.0);
+        craftingExperience.put(Material.STONE_PICKAXE, 3.0);
+        craftingExperience.put(Material.IRON_PICKAXE, 10.0);
+        craftingExperience.put(Material.GOLDEN_PICKAXE, 10.0);
+        craftingExperience.put(Material.DIAMOND_PICKAXE, 25.0);
+        craftingExperience.put(Material.NETHERITE_PICKAXE, 70.0);
+        // 斧
+        craftingExperience.put(Material.WOODEN_AXE, 2.0);
+        craftingExperience.put(Material.STONE_AXE, 3.0);
+        craftingExperience.put(Material.IRON_AXE, 10.0);
+        craftingExperience.put(Material.GOLDEN_AXE, 10.0);
+        craftingExperience.put(Material.DIAMOND_AXE, 25.0);
+        craftingExperience.put(Material.NETHERITE_AXE, 70.0);
+        // シャベル
+        craftingExperience.put(Material.WOODEN_SHOVEL, 1.5);
+        craftingExperience.put(Material.STONE_SHOVEL, 2.0);
+        craftingExperience.put(Material.IRON_SHOVEL, 6.0);
+        craftingExperience.put(Material.GOLDEN_SHOVEL, 6.0);
+        craftingExperience.put(Material.DIAMOND_SHOVEL, 15.0);
+        craftingExperience.put(Material.NETHERITE_SHOVEL, 45.0);
+        // クワ
+        craftingExperience.put(Material.WOODEN_HOE, 1.5);
+        craftingExperience.put(Material.STONE_HOE, 2.0);
+        craftingExperience.put(Material.IRON_HOE, 6.0);
+        craftingExperience.put(Material.GOLDEN_HOE, 6.0);
+        craftingExperience.put(Material.DIAMOND_HOE, 15.0);
+        craftingExperience.put(Material.NETHERITE_HOE, 45.0);
+        // ヘルメット
+        craftingExperience.put(Material.LEATHER_HELMET, 2.0);
+        craftingExperience.put(Material.CHAINMAIL_HELMET, 12.0);
+        craftingExperience.put(Material.IRON_HELMET, 9.0);
+        craftingExperience.put(Material.GOLDEN_HELMET, 9.0);
+        craftingExperience.put(Material.DIAMOND_HELMET, 22.0);
+        craftingExperience.put(Material.NETHERITE_HELMET, 65.0);
+        // チェストプレート
+        craftingExperience.put(Material.LEATHER_CHESTPLATE, 3.0);
+        craftingExperience.put(Material.CHAINMAIL_CHESTPLATE, 18.0);
+        craftingExperience.put(Material.IRON_CHESTPLATE, 14.0);
+        craftingExperience.put(Material.GOLDEN_CHESTPLATE, 14.0);
+        craftingExperience.put(Material.DIAMOND_CHESTPLATE, 35.0);
+        craftingExperience.put(Material.NETHERITE_CHESTPLATE, 100.0);
+        // レギンス
+        craftingExperience.put(Material.LEATHER_LEGGINGS, 2.5);
+        craftingExperience.put(Material.CHAINMAIL_LEGGINGS, 16.0);
+        craftingExperience.put(Material.IRON_LEGGINGS, 12.0);
+        craftingExperience.put(Material.GOLDEN_LEGGINGS, 12.0);
+        craftingExperience.put(Material.DIAMOND_LEGGINGS, 30.0);
+        craftingExperience.put(Material.NETHERITE_LEGGINGS, 85.0);
+        // ブーツ
+        craftingExperience.put(Material.LEATHER_BOOTS, 2.0);
+        craftingExperience.put(Material.CHAINMAIL_BOOTS, 12.0);
+        craftingExperience.put(Material.IRON_BOOTS, 9.0);
+        craftingExperience.put(Material.GOLDEN_BOOTS, 9.0);
+        craftingExperience.put(Material.DIAMOND_BOOTS, 22.0);
+        craftingExperience.put(Material.NETHERITE_BOOTS, 65.0);
+        // その他装備
+        craftingExperience.put(Material.SHIELD, 10.0);
+        craftingExperience.put(Material.BOW, 8.0);
+        craftingExperience.put(Material.CROSSBOW, 10.0);
+        craftingExperience.put(Material.SHEARS, 5.0);
+        craftingExperience.put(Material.FLINT_AND_STEEL, 4.0);
+        craftingExperience.put(Material.FISHING_ROD, 6.0);
         
         // 醸造経験値テーブル
-        brewingExperience.put(Material.POTION, 5.0);
+        brewingExperience.put(Material.POTION, 8.0);
         brewingExperience.put(Material.SPLASH_POTION, 8.0);
         brewingExperience.put(Material.LINGERING_POTION, 12.0);
         
@@ -161,13 +232,41 @@ public class JobExperienceManager implements Listener {
         enchantingExperience.put(5, 50.0);
         
         // 建築経験値テーブル
-        buildingExperience.put(Material.STONE, 0.2);
-        buildingExperience.put(Material.COBBLESTONE, 0.1);
-        buildingExperience.put(Material.STONE_BRICKS, 0.5);
-        buildingExperience.put(Material.QUARTZ_BLOCK, 1.0);
+        // 石材・加工系（建築の主役）
+        buildingExperience.put(Material.STONE, 0.5);
+        buildingExperience.put(Material.SMOOTH_STONE, 1.0);
+        buildingExperience.put(Material.STONE_BRICKS, 1.0);
+        buildingExperience.put(Material.CHISELED_STONE_BRICKS, 1.5);
+        buildingExperience.put(Material.QUARTZ_BLOCK, 1.5);
+        buildingExperience.put(Material.QUARTZ_PILLAR, 1.5);
+        buildingExperience.put(Material.CHISELED_QUARTZ_BLOCK, 2.0);
         buildingExperience.put(Material.PRISMARINE, 1.5);
+        buildingExperience.put(Material.PRISMARINE_BRICKS, 2.0);
+        buildingExperience.put(Material.DARK_PRISMARINE, 2.0);
         buildingExperience.put(Material.PURPUR_BLOCK, 2.0);
+        buildingExperience.put(Material.PURPUR_PILLAR, 2.0);
         buildingExperience.put(Material.END_STONE_BRICKS, 2.5);
+        // レンガ・テラコッタ系
+        buildingExperience.put(Material.BRICKS, 1.5);
+        buildingExperience.put(Material.TERRACOTTA, 1.0);
+        buildingExperience.put(Material.WHITE_TERRACOTTA, 1.2);
+        buildingExperience.put(Material.NETHER_BRICKS, 1.5);
+        buildingExperience.put(Material.RED_NETHER_BRICKS, 2.0);
+        // 銅系
+        buildingExperience.put(Material.COPPER_BLOCK, 1.5);
+        // 木材・装飾系
+        buildingExperience.put(Material.OAK_PLANKS, 0.5);
+        buildingExperience.put(Material.SPRUCE_PLANKS, 0.5);
+        buildingExperience.put(Material.BIRCH_PLANKS, 0.5);
+        buildingExperience.put(Material.BOOKSHELF, 2.0);
+        // ガラス系
+        buildingExperience.put(Material.GLASS, 0.8);
+        buildingExperience.put(Material.WHITE_STAINED_GLASS, 1.0);
+        // 高級建材
+        buildingExperience.put(Material.SEA_LANTERN, 3.0);
+        buildingExperience.put(Material.GLOWSTONE, 2.5);
+        // 安価ブロック（設置→破壊ループ濫用防止のため低値据え置き）
+        buildingExperience.put(Material.COBBLESTONE, 0.1);
     }
     
     @EventHandler
@@ -226,6 +325,22 @@ public class JobExperienceManager implements Listener {
         }
     }
     
+    @EventHandler
+    public void onSmithItem(SmithItemEvent event) {
+        // 鍛冶テーブルでの製作（ネザライト装備のアップグレード等）に対応
+        if (!(event.getWhoClicked() instanceof Player)) return;
+
+        Player player = (Player) event.getWhoClicked();
+        if (event.getCurrentItem() == null) return;
+        Material smithedItem = event.getCurrentItem().getType();
+
+        if (jobManager.hasJob(player, "blacksmith") && craftingExperience.containsKey(smithedItem)) {
+            double baseExp = craftingExperience.get(smithedItem);
+            double multipliedExp = applyJobMultiplier(player, "blacksmith", baseExp);
+            giveJobExperience(player, "blacksmith", multipliedExp);
+        }
+    }
+
     @EventHandler
     public void onBrew(BrewEvent event) {
         // 醸造台の使用者を特定する必要がある（近くのプレイヤーをチェック）

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2637,9 +2637,10 @@ leveling:
   # 経験値計算設定
   experience:
     # 必要経験値計算式: base_multiplier * ((level - 1) ^ exponent)
-    base_multiplier: 100
-    # リリース前バランス調整: 旧2.2(ハードコード) → 1.9 に緩和しLv100到達を現実的に
-    exponent: 1.9
+    # バランス調整(案1): 100→80。全体の必要経験値を約20%緩和しレベルを上げやすく
+    base_multiplier: 80
+    # バランス調整(案1): 1.9→1.7。高レベルの必要経験値の急騰を緩和
+    exponent: 1.7
 
     # 高レベル時の経験値獲得ペナルティ（実効 = max(minimum, 1.0 - level * factor)）
     # リリース前バランス調整: factor 0.01→0.005, minimum 0.1→0.4 に緩和


### PR DESCRIPTION
## 背景
プレイヤーから「鍛冶屋で剣をクラフトした時しか職業経験値が入らず、レベルが上げづらい」報告があった。調査の結果、`JobExperienceManager.initializeExperienceTables()` で各職業の経験値対象がハードコードされ対象が極端に少ないことに起因する全職業共通の問題と判明。

## 変更内容（`JobExperienceManager.java`）
- **鍛冶屋 `craftingExperience` 拡充**: 全ティアの剣/ツルハシ/斧/シャベル/クワ、全種防具（革・鎖・鉄・金・ダイヤ・ネザライト）、盾・弓・クロスボウ・ハサミ・火打石・釣竿、ネザライトスクラップを追加（10種→約60種）
- **SmithItemEvent ハンドラ新設**: ネザライト装備は鍛冶テーブル製作で `CraftItemEvent` が発火しないため `onSmithItem` を追加
- **建築家 `buildingExperience` 拡充**: 石材/レンガ/銅/木材/ガラス/高級建材を追加・値底上げ。丸石は低値据え置きで設置→破壊ループ濫用を防止
- **農家 `farmingExperience`**: 竹・サボテン・茶/赤キノコを追加
- **鉱夫 `miningExperience`**: ネザー金鉱石を追加
- **醸造**: ポーション基礎経験値を 5.0→8.0 に底上げ

## 未対応（サーバー側で別途対応）
- **必要経験値カーブの緩和（案1: base_multiplier 100→80, exponent 1.9→1.7）**: `leveling.experience` はサーバー上 config.yml の手動編集が必須（jar同梱configはサーバーを上書きしない運用）。デプロイ時に適用予定。

## 検証
- `mvn clean compile` → **BUILD SUCCESS** 確認済み

## 動作確認（マージ後の手動テスト推奨）
- 鍛冶屋: 鉄/ダイヤ防具・盾・各ツール・ネザライト装備（鍛冶テーブル）で経験値が入るか
- 建築家: 各種建材で付与され、丸石ループで異常稼ぎにならないか
- 農家: 竹・サボテン・キノコで付与されるか
- 回帰: 既存（剣・ツルハシ等）の付与継続、food buff倍率

🤖 Generated with [Claude Code](https://claude.com/claude-code)