### PR TITLE
feat: /jobsコマンドをGUI化し職業ガイドブック入手ボタンを追加

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -135,6 +135,11 @@ public final class TofuNomics extends JavaPlugin {
     private org.tofu.tofunomics.market.gui.MarketGUIListener marketGUIListener;
     private org.tofu.tofunomics.market.gui.MarketHubGUI marketHubGUI;
     private org.tofu.tofunomics.gui.ChatInputManager chatInputManager;
+    private org.tofu.tofunomics.jobs.gui.JobsGUIListener jobsGUIListener;
+    private org.tofu.tofunomics.jobs.gui.JobsHubGUI jobsHubGUI;
+    private org.tofu.tofunomics.jobs.gui.JobDetailGUI jobDetailGUI;
+    private org.tofu.tofunomics.jobs.gui.JobStatsGUI jobStatsGUI;
+    private org.tofu.tofunomics.jobs.gui.JobConfirmGUI jobConfirmGUI;
     private org.tofu.tofunomics.market.MarketExpirationTask marketExpirationTask;
 
     @Override
@@ -278,6 +283,9 @@ public final class TofuNomics extends JavaPlugin {
         }
         if (marketGUIListener != null) {
             marketGUIListener.closeAll();
+        }
+        if (jobsGUIListener != null) {
+            jobsGUIListener.closeAll();
         }
         if (housingGUIListener != null) {
             housingGUIListener.closeAll();
@@ -427,6 +435,23 @@ public final class TofuNomics extends JavaPlugin {
             marketHubGUI.setGUIs(marketBrowseGUI, myListingsGUI, buyOrderBrowseGUI,
                 myBuyOrdersGUI, serviceBrowseGUI, myServicesGUI);
             marketGUIListener.setHubGUI(marketHubGUI);
+
+            // 職業GUI（ハブ・詳細・ステータス・確認）を配線する（Market と同型）
+            jobsGUIListener = new org.tofu.tofunomics.jobs.gui.JobsGUIListener(this);
+            jobDetailGUI = new org.tofu.tofunomics.jobs.gui.JobDetailGUI(
+                this, configManager, jobManager, jobsGUIListener);
+            jobStatsGUI = new org.tofu.tofunomics.jobs.gui.JobStatsGUI(
+                this, configManager, jobManager, jobsGUIListener);
+            jobConfirmGUI = new org.tofu.tofunomics.jobs.gui.JobConfirmGUI(
+                this, configManager, jobManager, jobsGUIListener);
+            jobsHubGUI = new org.tofu.tofunomics.jobs.gui.JobsHubGUI(
+                this, configManager, jobManager, jobsGUIListener);
+            jobsHubGUI.setGUIs(jobDetailGUI, jobStatsGUI);
+            jobDetailGUI.setGUIs(jobsHubGUI, jobConfirmGUI);
+            jobStatsGUI.setGUIs(jobsHubGUI);
+            jobConfirmGUI.setGUIs(jobsHubGUI, jobDetailGUI);
+            jobsGUIListener.setGUIs(jobsHubGUI, jobDetailGUI, jobStatsGUI, jobConfirmGUI);
+            getLogger().info("職業GUIシステムを初期化しました");
 
             // 期限切れ定期タスクの起動（expire_check_interval 秒 × 20 = ticks）
             long intervalTicks = Math.max(1L, (long) configManager.getMarketExpireCheckInterval() * 20L);
@@ -765,6 +790,12 @@ public final class TofuNomics extends JavaPlugin {
                 getLogger().info("マーケットGUIリスナーを登録しました");
             }
 
+            // 職業GUIリスナーの登録
+            if (jobsGUIListener != null) {
+                getServer().getPluginManager().registerEvents(jobsGUIListener, this);
+                getLogger().info("職業GUIリスナーを登録しました");
+            }
+
             getLogger().info("全てのイベントリスナーを登録しました");
         } catch (Exception e) {
             getLogger().severe("イベントリスナー登録中にエラーが発生しました: " + e.getMessage());
@@ -782,7 +813,7 @@ public final class TofuNomics extends JavaPlugin {
             getCommand("eco").setExecutor(new EcoCommand(configManager, currencyConverter, playerDAO));
             
             // 職業系コマンド
-            getCommand("jobs").setExecutor(new JobsCommand(configManager, jobManager, experienceManager));
+            getCommand("jobs").setExecutor(new JobsCommand(configManager, jobManager, experienceManager, jobsHubGUI));
             getCommand("jobstats").setExecutor(new JobStatsCommand(jobStatsManager));
             getCommand("quest").setExecutor(new JobQuestCommand(configManager, jobQuestManager));
             

--- a/src/main/java/org/tofu/tofunomics/commands/JobsCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/JobsCommand.java
@@ -8,19 +8,23 @@ import org.bukkit.entity.Player;
 import org.tofu.tofunomics.config.ConfigManager;
 import org.tofu.tofunomics.jobs.JobManager;
 import org.tofu.tofunomics.jobs.ExperienceManager;
+import org.tofu.tofunomics.jobs.gui.JobsHubGUI;
 import org.tofu.tofunomics.models.PlayerJob;
 import org.tofu.tofunomics.models.Job;
 
 public class JobsCommand implements CommandExecutor {
-    
+
     private final ConfigManager configManager;
     private final JobManager jobManager;
     private final ExperienceManager experienceManager;
-    
-    public JobsCommand(ConfigManager configManager, JobManager jobManager, ExperienceManager experienceManager) {
+    private final JobsHubGUI jobsHubGUI;
+
+    public JobsCommand(ConfigManager configManager, JobManager jobManager,
+                       ExperienceManager experienceManager, JobsHubGUI jobsHubGUI) {
         this.configManager = configManager;
         this.jobManager = jobManager;
         this.experienceManager = experienceManager;
+        this.jobsHubGUI = jobsHubGUI;
     }
 
     @Override
@@ -33,13 +37,21 @@ public class JobsCommand implements CommandExecutor {
         Player player = (Player) sender;
         
         if (args.length == 0) {
-            sendHelpMessage(player);
+            // 引数なしは GUI を開く。GUI 初期化失敗時は従来のヘルプにフォールバック。
+            if (jobsHubGUI != null) {
+                jobsHubGUI.open(player);
+            } else {
+                sendHelpMessage(player);
+            }
             return true;
         }
-        
+
         String subCommand = args[0].toLowerCase();
-        
+
         switch (subCommand) {
+            case "help":
+                sendHelpMessage(player);
+                return true;
             case "list":
                 return handleJobsList(player);
             case "join":

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -595,8 +595,25 @@ public class ConfigManager {
     public double getJobBaseSellBonus(String jobName) {
         return config.getDouble("jobs.job_settings." + jobName + ".base_sell_bonus", 0.05);
     }
-    
-    
+
+    // 職業ガイドブック設定
+    public boolean isJobGuideBookEnabled(String jobName) {
+        return config.getBoolean("jobs.job_settings." + jobName + ".guide_book.enabled", false);
+    }
+
+    public String getJobGuideBookTitle(String jobName) {
+        return config.getString("jobs.job_settings." + jobName + ".guide_book.title", jobName + "ガイドブック");
+    }
+
+    public String getJobGuideBookAuthor(String jobName) {
+        return config.getString("jobs.job_settings." + jobName + ".guide_book.author", "TofuNomics");
+    }
+
+    public java.util.List<String> getJobGuideBookPages(String jobName) {
+        return config.getStringList("jobs.job_settings." + jobName + ".guide_book.pages");
+    }
+
+
     // 土地保護設定
     public boolean isWorldGuardIntegration() {
         return config.getBoolean("land_protection.worldguard_integration", true);

--- a/src/main/java/org/tofu/tofunomics/gui/GuiUtil.java
+++ b/src/main/java/org/tofu/tofunomics/gui/GuiUtil.java
@@ -1,6 +1,7 @@
 package org.tofu.tofunomics.gui;
 
 import org.bukkit.Material;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -25,6 +26,12 @@ public final class GuiUtil {
         if (meta != null) {
             meta.setDisplayName(name);
             meta.setLore(lore);
+            // 道具・ブロックアイテムをアイコンに使った際、バニラの属性/耐久/エンチャント情報が
+            // lore に混入して見た目が崩れるのを防ぐ。
+            meta.addItemFlags(
+                    ItemFlag.HIDE_ATTRIBUTES,
+                    ItemFlag.HIDE_ENCHANTS,
+                    ItemFlag.HIDE_UNBREAKABLE);
             item.setItemMeta(meta);
         }
         return item;

--- a/src/main/java/org/tofu/tofunomics/jobs/gui/JobConfirmGUI.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/gui/JobConfirmGUI.java
@@ -1,0 +1,192 @@
+package org.tofu.tofunomics.jobs.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.gui.GuiUtil;
+import org.tofu.tofunomics.jobs.JobManager;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * 就職/辞職の確認ダイアログ GUI。
+ *
+ * 「はい」で {@link JobManager#joinJob} / {@link JobManager#leaveJob} を呼び、
+ * 結果に応じたメッセージを送ってハブへ戻す。「いいえ」で詳細画面へ戻す。
+ */
+public class JobConfirmGUI {
+
+    private static final int SIZE = 27;
+    private static final int SLOT_INFO = 13;
+    private static final int SLOT_YES = 11;
+    private static final int SLOT_NO = 15;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final JobManager jobManager;
+    private final JobsGUIListener listener;
+
+    private JobsHubGUI hubGUI;
+    private JobDetailGUI detailGUI;
+
+    public JobConfirmGUI(TofuNomics plugin, ConfigManager configManager,
+                         JobManager jobManager, JobsGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.jobManager = jobManager;
+        this.listener = listener;
+    }
+
+    public void setGUIs(JobsHubGUI hubGUI, JobDetailGUI detailGUI) {
+        this.hubGUI = hubGUI;
+        this.detailGUI = detailGUI;
+    }
+
+    /**
+     * 確認ダイアログを開く。
+     *
+     * @param type {@link JobsGUISession.Type#CONFIRM_JOIN} または {@link JobsGUISession.Type#CONFIRM_LEAVE}
+     */
+    public void open(Player player, String jobName, JobsGUISession.Type type) {
+        try {
+            boolean join = (type == JobsGUISession.Type.CONFIRM_JOIN);
+            String displayName = jobManager.getJobDisplayName(jobName);
+            Inventory gui = Bukkit.createInventory(null, SIZE,
+                    join ? "§6就職の確認" : "§6辞職の確認");
+            JobsGUISession session = new JobsGUISession(player.getUniqueId(), type, gui);
+            session.setTargetJobName(jobName);
+            render(gui, jobName, displayName, join);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("職業確認GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage(ChatColor.RED + "職業GUIの表示に失敗しました。");
+        }
+    }
+
+    private void render(Inventory gui, String jobName, String displayName, boolean join) {
+        String question = join
+                ? "§e本当に「" + ChatColor.stripColor(displayName) + "」に就職しますか？"
+                : "§e本当に「" + ChatColor.stripColor(displayName) + "」を辞職しますか？";
+        gui.setItem(SLOT_INFO, GuiUtil.createButton(JobsGUIIconMapper.getIcon(jobName),
+                "§f" + displayName,
+                join
+                        ? Arrays.asList(question, "§7※他の職業からの転職にはレベル50が必要です")
+                        : Arrays.asList(question, "§7※レベル50以上で辞職できます")));
+
+        gui.setItem(SLOT_YES, GuiUtil.createButton(Material.LIME_WOOL, "§a§lはい",
+                Collections.singletonList(join ? "§7就職を確定します" : "§7辞職を確定します")));
+        gui.setItem(SLOT_NO, GuiUtil.createButton(Material.RED_WOOL, "§c§lいいえ",
+                Collections.singletonList("§7前の画面へ戻ります")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = GuiUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = 0; i < SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    /**
+     * クリック処理（{@link JobsGUIListener} から呼ばれる）。
+     */
+    public void handleClick(Player player, JobsGUISession session, int slot) {
+        String jobName = session.getTargetJobName();
+        if (jobName == null) {
+            player.closeInventory();
+            return;
+        }
+
+        if (slot == SLOT_NO) {
+            // 詳細画面へ戻る
+            if (detailGUI != null) {
+                detailGUI.open(player, jobName);
+            } else {
+                player.closeInventory();
+            }
+            return;
+        }
+
+        if (slot == SLOT_YES) {
+            player.closeInventory();
+            if (session.getType() == JobsGUISession.Type.CONFIRM_JOIN) {
+                handleJoin(player, jobName);
+            } else {
+                handleLeave(player, jobName);
+            }
+            if (hubGUI != null) {
+                hubGUI.reopen(player);
+            }
+        }
+    }
+
+    private void handleJoin(Player player, String jobName) {
+        JobManager.JobJoinResult result = jobManager.joinJob(player, jobName);
+        switch (result) {
+            case SUCCESS:
+                String displayName = jobManager.getJobDisplayName(jobName);
+                String message = configManager.getMessage("jobs.job_joined", "job", displayName);
+                if (message.startsWith("メッセージが見つかりません:")) {
+                    message = "&a職業「" + displayName + "」に就職しました。";
+                }
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&',
+                        configManager.getMessagePrefix() + message));
+                break;
+            case ALREADY_HAS_JOB:
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&',
+                        configManager.getMessagePrefix() + configManager.getMessage("jobs.already_have_job")));
+                break;
+            case JOB_NOT_FOUND:
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&',
+                        configManager.getMessagePrefix() + configManager.getMessage("jobs.job_not_found")));
+                break;
+            case LEVEL_TOO_LOW:
+                player.sendMessage(ChatColor.RED + "転職するには現在の職業レベルが50以上必要です。");
+                break;
+            case MAX_JOBS_REACHED:
+                int maxJobs = configManager.getMaxJobsPerPlayer();
+                player.sendMessage(ChatColor.RED + "同時に就ける職業数の上限(" + maxJobs + ")に達しています。");
+                break;
+            case DATABASE_ERROR:
+            default:
+                player.sendMessage(ChatColor.RED + "データベースエラーが発生しました。しばらくしてから再度お試しください。");
+                break;
+        }
+    }
+
+    private void handleLeave(Player player, String jobName) {
+        // 就職状態の確認は leaveJob 内（NO_SUCH_JOB）に委ね、結果のみで分岐する
+        JobManager.JobLeaveResult result = jobManager.leaveJob(player, jobName);
+        switch (result) {
+            case SUCCESS:
+                String displayName = jobManager.getJobDisplayName(jobName);
+                String message = configManager.getMessage("jobs.job_left", "job", displayName);
+                if (message.startsWith("メッセージが見つかりません:")) {
+                    message = "&a職業「" + displayName + "」を辞職しました。";
+                }
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&',
+                        configManager.getMessagePrefix() + message));
+                break;
+            case LEVEL_TOO_LOW:
+                player.sendMessage(ChatColor.RED + "レベル50未満の職業は辞職できません。レベル50に達してから辞職してください。");
+                break;
+            case DAILY_LIMIT_EXCEEDED:
+                player.sendMessage(ChatColor.RED + "本日はすでに職業を変更しています。明日再度お試しください。");
+                break;
+            case NO_SUCH_JOB:
+            case DATABASE_ERROR:
+            default:
+                player.sendMessage(ChatColor.RED + "職業の辞職に失敗しました。");
+                break;
+        }
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/jobs/gui/JobDetailGUI.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/gui/JobDetailGUI.java
@@ -1,0 +1,230 @@
+package org.tofu.tofunomics.jobs.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.gui.GuiUtil;
+import org.tofu.tofunomics.jobs.JobManager;
+import org.tofu.tofunomics.models.PlayerJob;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 個別職業の詳細 GUI（list + info 統合）。
+ *
+ * 職業の説明・最大レベル・収入倍率・経験値倍率・自分のレベルを表示し、
+ * 未就職なら「就職する」、就職中なら「辞職する」ボタンを表示する。
+ * 就職/辞職は {@link JobConfirmGUI} の確認を経て {@link JobManager} を呼ぶ。
+ */
+public class JobDetailGUI {
+
+    private static final int SIZE = 27;
+    private static final int SLOT_INFO = 13;
+    private static final int SLOT_JOIN = 11;
+    private static final int SLOT_LEAVE = 15;
+    private static final int SLOT_GUIDE = 22;   // 就職中のみ表示（ガイドブック入手）
+    private static final int SLOT_BACK = 18;
+    private static final int SLOT_CLOSE = 26;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final JobManager jobManager;
+    private final JobsGUIListener listener;
+
+    private JobsHubGUI hubGUI;
+    private JobConfirmGUI confirmGUI;
+
+    public JobDetailGUI(TofuNomics plugin, ConfigManager configManager,
+                        JobManager jobManager, JobsGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.jobManager = jobManager;
+        this.listener = listener;
+    }
+
+    public void setGUIs(JobsHubGUI hubGUI, JobConfirmGUI confirmGUI) {
+        this.hubGUI = hubGUI;
+        this.confirmGUI = confirmGUI;
+    }
+
+    /**
+     * 指定職業の詳細 GUI を開く。
+     */
+    public void open(Player player, String jobName) {
+        try {
+            String displayName = jobManager.getJobDisplayName(jobName);
+            Inventory gui = Bukkit.createInventory(null, SIZE, "§6職業: " + ChatColor.stripColor(displayName));
+            JobsGUISession session = new JobsGUISession(
+                    player.getUniqueId(), JobsGUISession.Type.JOB_DETAIL, gui);
+            session.setTargetJobName(jobName);
+            render(player, gui, jobName);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("職業詳細GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage(ChatColor.RED + "職業GUIの表示に失敗しました。");
+        }
+    }
+
+    private void render(Player player, Inventory gui, String jobName) {
+        String displayName = jobManager.getJobDisplayName(jobName);
+        String description = configManager.getJobDescription(jobName);
+        int maxLevel = configManager.getJobMaxLevel(jobName);
+        double incomeMultiplier = configManager.getJobIncomeMultiplier(jobName);
+        double expMultiplier = configManager.getJobExpMultiplier(jobName);
+        boolean employed = jobManager.hasJob(player, jobName);
+
+        // 詳細アイコン
+        List<String> infoLore = new ArrayList<>();
+        if (description != null && !description.isEmpty()) {
+            infoLore.add("§7" + description);
+        }
+        infoLore.add("");
+        infoLore.add("§b最大レベル: §f" + maxLevel);
+        infoLore.add("§b収入倍率: §f" + String.format("%.1f", incomeMultiplier) + "x");
+        infoLore.add("§b経験値倍率: §f" + String.format("%.1f", expMultiplier) + "x");
+        if (employed) {
+            PlayerJob playerJob = jobManager.getPlayerJob(player, jobName);
+            if (playerJob != null) {
+                int level = playerJob.getLevel();
+                double experience = playerJob.getExperience();
+                int requiredExp = configManager.calculateRequiredExperience(level + 1);
+                infoLore.add("");
+                infoLore.add("§a現在のレベル: §f" + level + " §7(経験値: " + (int) experience + "/" + requiredExp + ")");
+            }
+        }
+        gui.setItem(SLOT_INFO, GuiUtil.createButton(JobsGUIIconMapper.getIcon(jobName),
+                (employed ? "§a§l" : "§f§l") + displayName + " §7(" + jobName + ")", infoLore));
+
+        // 就職/辞職ボタン
+        if (employed) {
+            gui.setItem(SLOT_LEAVE, GuiUtil.createButton(Material.RED_BED, "§c§l辞職する",
+                    java.util.Arrays.asList(
+                            "§7この職業を辞職します",
+                            "§7※レベル50以上で辞職できます",
+                            "§eクリックで確認画面へ")));
+            // 就職中のみ、ガイドブックが用意されていれば入手ボタンを表示
+            if (configManager.isJobGuideBookEnabled(jobName)
+                    && !configManager.getJobGuideBookPages(jobName).isEmpty()) {
+                gui.setItem(SLOT_GUIDE, GuiUtil.createButton(Material.WRITTEN_BOOK, "§6§lガイドブックを入手",
+                        java.util.Arrays.asList(
+                                "§7この職業のガイドブックを受け取ります",
+                                "§7仕事内容・稼ぎ方・経験値の上げ方を確認できます",
+                                "§eクリックで入手")));
+            }
+        } else {
+            gui.setItem(SLOT_JOIN, GuiUtil.createButton(Material.LIME_DYE, "§a§l就職する",
+                    java.util.Arrays.asList(
+                            "§7この職業に就職します",
+                            "§7※他の職業からの転職にはレベル50が必要です",
+                            "§eクリックで確認画面へ")));
+        }
+
+        // 戻る・閉じる
+        gui.setItem(SLOT_BACK, GuiUtil.createButton(Material.ARROW, "§e戻る",
+                Collections.singletonList("§7職業一覧へ戻ります")));
+        gui.setItem(SLOT_CLOSE, GuiUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = GuiUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = 0; i < SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    /**
+     * クリック処理（{@link JobsGUIListener} から呼ばれる）。
+     */
+    public void handleClick(Player player, JobsGUISession session, int slot) {
+        String jobName = session.getTargetJobName();
+        switch (slot) {
+            case SLOT_JOIN:
+                // 未就職時のみ就職ボタンを表示しているが、状態をここでも再確認する
+                if (jobName != null && confirmGUI != null && !jobManager.hasJob(player, jobName)) {
+                    confirmGUI.open(player, jobName, JobsGUISession.Type.CONFIRM_JOIN);
+                }
+                break;
+            case SLOT_LEAVE:
+                // 就職中のみ辞職ボタンを表示しているが、状態をここでも再確認する
+                if (jobName != null && confirmGUI != null && jobManager.hasJob(player, jobName)) {
+                    confirmGUI.open(player, jobName, JobsGUISession.Type.CONFIRM_LEAVE);
+                }
+                break;
+            case SLOT_GUIDE:
+                // 就職中の職業のガイドブックのみ入手可能
+                if (jobName != null && jobManager.hasJob(player, jobName)
+                        && configManager.isJobGuideBookEnabled(jobName)) {
+                    giveGuideBook(player, jobName);
+                }
+                break;
+            case SLOT_BACK:
+                if (hubGUI != null) {
+                    hubGUI.open(player);
+                }
+                break;
+            case SLOT_CLOSE:
+                player.closeInventory();
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * 指定職業のガイドブックを生成してプレイヤーに渡す。
+     * インベントリに空きがなければドロップせず警告する。
+     */
+    private void giveGuideBook(Player player, String jobName) {
+        List<String> pageContents = configManager.getJobGuideBookPages(jobName);
+        if (pageContents.isEmpty()) {
+            player.sendMessage(ChatColor.RED + "この職業のガイドブックは用意されていません。");
+            return;
+        }
+
+        ItemStack book = createGuideBook(jobName, pageContents);
+        java.util.Map<Integer, ItemStack> leftover = player.getInventory().addItem(book);
+        if (!leftover.isEmpty()) {
+            player.sendMessage(ChatColor.RED + "インベントリに空きがありません。整理してから再度お試しください。");
+            return;
+        }
+
+        String displayName = jobManager.getJobDisplayName(jobName);
+        player.closeInventory();
+        player.sendMessage(ChatColor.GREEN + "「" + ChatColor.stripColor(displayName)
+                + "」のガイドブックを入手しました。右クリックで読めます。");
+    }
+
+    /**
+     * config の guide_book 設定から WRITTEN_BOOK を生成する。色コード（&）は変換する。
+     */
+    private ItemStack createGuideBook(String jobName, List<String> pageContents) {
+        ItemStack book = new ItemStack(Material.WRITTEN_BOOK);
+        BookMeta meta = (BookMeta) book.getItemMeta();
+        if (meta != null) {
+            meta.setTitle(ChatColor.translateAlternateColorCodes('&',
+                    configManager.getJobGuideBookTitle(jobName)));
+            meta.setAuthor(ChatColor.translateAlternateColorCodes('&',
+                    configManager.getJobGuideBookAuthor(jobName)));
+            List<String> pages = new ArrayList<>();
+            for (String page : pageContents) {
+                pages.add(ChatColor.translateAlternateColorCodes('&', page));
+            }
+            meta.setPages(pages);
+            book.setItemMeta(meta);
+        }
+        return book;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/jobs/gui/JobStatsGUI.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/gui/JobStatsGUI.java
@@ -1,0 +1,158 @@
+package org.tofu.tofunomics.jobs.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.gui.GuiUtil;
+import org.tofu.tofunomics.jobs.JobManager;
+import org.tofu.tofunomics.models.Job;
+import org.tofu.tofunomics.models.PlayerJob;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 自分の職業ステータス GUI。
+ *
+ * 就職中の各職業について、レベル・経験値・次レベルまでの必要経験値・進捗バーを表示する。
+ */
+public class JobStatsGUI {
+
+    private static final int SIZE = 27;
+    private static final int SLOT_JOB_START = 9;
+    private static final int SLOT_JOB_END = 16;
+    private static final int SLOT_INFO = 4;  // 就職していない場合の案内表示にのみ使用
+    private static final int SLOT_BACK = 18;
+    private static final int SLOT_CLOSE = 26;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final JobManager jobManager;
+    private final JobsGUIListener listener;
+
+    private JobsHubGUI hubGUI;
+
+    public JobStatsGUI(TofuNomics plugin, ConfigManager configManager,
+                       JobManager jobManager, JobsGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.jobManager = jobManager;
+        this.listener = listener;
+    }
+
+    public void setGUIs(JobsHubGUI hubGUI) {
+        this.hubGUI = hubGUI;
+    }
+
+    /**
+     * ステータス GUI を開く。
+     */
+    public void open(Player player) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, SIZE, "§6職業ステータス");
+            JobsGUISession session = new JobsGUISession(
+                    player.getUniqueId(), JobsGUISession.Type.STATS, gui);
+            render(player, gui);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("職業ステータスGUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage(ChatColor.RED + "職業GUIの表示に失敗しました。");
+        }
+    }
+
+    private void render(Player player, Inventory gui) {
+        List<PlayerJob> playerJobs = jobManager.getPlayerJobs(player);
+
+        if (playerJobs.isEmpty()) {
+            gui.setItem(SLOT_INFO, GuiUtil.createButton(Material.PAPER, "§7現在就職していません",
+                    Collections.singletonList("§7職業一覧から就職してください")));
+        } else {
+            int slot = SLOT_JOB_START;
+            for (PlayerJob playerJob : playerJobs) {
+                if (slot > SLOT_JOB_END) {
+                    break;
+                }
+                Job job = jobManager.getJobById(playerJob.getJobId());
+                if (job == null) {
+                    continue;
+                }
+                gui.setItem(slot, buildStatsIcon(job, playerJob));
+                slot++;
+            }
+        }
+
+        gui.setItem(SLOT_BACK, GuiUtil.createButton(Material.ARROW, "§e戻る",
+                Collections.singletonList("§7職業一覧へ戻ります")));
+        gui.setItem(SLOT_CLOSE, GuiUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = GuiUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = 0; i < SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    private ItemStack buildStatsIcon(Job job, PlayerJob playerJob) {
+        String jobName = job.getName();
+        String displayName = job.getDisplayName();
+        int level = playerJob.getLevel();
+        double experience = playerJob.getExperience();
+        int requiredExp = configManager.calculateRequiredExperience(level + 1);
+
+        List<String> lore = new ArrayList<>();
+        lore.add("§bレベル: §f" + level);
+        lore.add("§b経験値: §f" + (int) experience + " / " + requiredExp);
+        lore.add("§7" + buildProgressBar(experience, requiredExp));
+
+        return GuiUtil.createButton(JobsGUIIconMapper.getIcon(jobName),
+                "§a§l" + displayName + " §7(" + jobName + ")", lore);
+    }
+
+    /**
+     * 経験値の進捗バーを生成する（20 マス）。
+     */
+    private String buildProgressBar(double experience, int requiredExp) {
+        int total = 20;
+        double ratio = requiredExp > 0 ? Math.min(1.0, experience / requiredExp) : 0.0;
+        int filled = (int) Math.round(ratio * total);
+        StringBuilder sb = new StringBuilder("§a");
+        for (int i = 0; i < total; i++) {
+            if (i == filled) {
+                sb.append("§7");
+            }
+            sb.append("■");
+        }
+        sb.append(" §f").append((int) Math.round(ratio * 100)).append("%");
+        return sb.toString();
+    }
+
+    /**
+     * クリック処理（{@link JobsGUIListener} から呼ばれる）。
+     */
+    public void handleClick(Player player, JobsGUISession session, int slot) {
+        switch (slot) {
+            case SLOT_BACK:
+                if (hubGUI != null) {
+                    hubGUI.open(player);
+                }
+                break;
+            case SLOT_CLOSE:
+                player.closeInventory();
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/jobs/gui/JobsGUIIconMapper.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/gui/JobsGUIIconMapper.java
@@ -1,0 +1,35 @@
+package org.tofu.tofunomics.jobs.gui;
+
+import org.bukkit.Material;
+
+/**
+ * 職業名 → 表示アイコン（Material）のマッピング。
+ *
+ * Jobs GUI で各職業を表すアイコンを決定する。職業の種類は固定的なため
+ * {@code JobManager#getJobTitle} と同様にハードコードの switch で対応する。
+ */
+public final class JobsGUIIconMapper {
+
+    private JobsGUIIconMapper() {
+    }
+
+    /**
+     * 職業名に対応するアイコン Material を返す。未知の職業は {@link Material#BOOK} を返す。
+     */
+    public static Material getIcon(String jobName) {
+        if (jobName == null) {
+            return Material.BOOK;
+        }
+        switch (jobName.toLowerCase()) {
+            case "miner":      return Material.DIAMOND_PICKAXE;
+            case "woodcutter": return Material.IRON_AXE;
+            case "farmer":     return Material.WHEAT;
+            case "fisherman":  return Material.FISHING_ROD;
+            case "blacksmith": return Material.ANVIL;
+            case "alchemist":  return Material.BREWING_STAND;
+            case "enchanter":  return Material.ENCHANTING_TABLE;
+            case "architect":  return Material.BRICKS;
+            default:           return Material.BOOK;
+        }
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/jobs/gui/JobsGUIListener.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/gui/JobsGUIListener.java
@@ -1,0 +1,141 @@
+package org.tofu.tofunomics.jobs.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Jobs GUI（ハブ・詳細・ステータス・確認）のクリック/クローズイベントを集約して処理するリスナー。
+ *
+ * 開いている GUI のセッションを {@link ConcurrentHashMap} で管理し、
+ * セッション種別に応じて各 GUI のクリック処理へ振り分ける。
+ *
+ * 配線順: 本リスナーを生成 → 各 GUI を生成（コンストラクタに本リスナーを渡す）
+ * → {@link #setGUIs} で GUI 参照を注入 → registerEvents。
+ */
+public class JobsGUIListener implements Listener {
+
+    private final TofuNomics plugin;
+    private final Map<UUID, JobsGUISession> sessions = new ConcurrentHashMap<>();
+
+    private JobsHubGUI hubGUI;
+    private JobDetailGUI detailGUI;
+    private JobStatsGUI statsGUI;
+    private JobConfirmGUI confirmGUI;
+
+    public JobsGUIListener(TofuNomics plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * GUI 参照を注入する（循環依存を避けるためセッターで後から設定）。
+     */
+    public void setGUIs(JobsHubGUI hubGUI, JobDetailGUI detailGUI,
+                        JobStatsGUI statsGUI, JobConfirmGUI confirmGUI) {
+        this.hubGUI = hubGUI;
+        this.detailGUI = detailGUI;
+        this.statsGUI = statsGUI;
+        this.confirmGUI = confirmGUI;
+    }
+
+    /**
+     * GUI を開いた際にセッションを登録する。
+     */
+    public void registerSession(UUID playerId, JobsGUISession session) {
+        sessions.put(playerId, session);
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) {
+            return;
+        }
+        Player player = (Player) event.getWhoClicked();
+        JobsGUISession session = sessions.get(player.getUniqueId());
+        if (session == null || !session.getInventory().equals(event.getInventory())) {
+            return;
+        }
+
+        // GUI 内のクリックは全てキャンセル（アイテムの持ち出し防止）
+        event.setCancelled(true);
+
+        // クリック対象スロットが GUI の範囲外（プレイヤーインベントリ等）の場合は無視
+        if (event.getRawSlot() < 0 || event.getRawSlot() >= session.getInventory().getSize()) {
+            return;
+        }
+
+        ItemStack clicked = event.getCurrentItem();
+        if (clicked == null || clicked.getType() == Material.AIR) {
+            return;
+        }
+
+        try {
+            dispatchClick(player, session, event.getSlot());
+        } catch (Exception e) {
+            plugin.getLogger().severe("職業GUIクリック処理中にエラーが発生しました: " + e.getMessage());
+        }
+    }
+
+    private void dispatchClick(Player player, JobsGUISession session, int slot) {
+        switch (session.getType()) {
+            case HUB:
+                if (hubGUI != null) {
+                    hubGUI.handleClick(player, session, slot);
+                }
+                break;
+            case JOB_DETAIL:
+                if (detailGUI != null) {
+                    detailGUI.handleClick(player, session, slot);
+                }
+                break;
+            case STATS:
+                if (statsGUI != null) {
+                    statsGUI.handleClick(player, session, slot);
+                }
+                break;
+            case CONFIRM_JOIN:
+            case CONFIRM_LEAVE:
+                if (confirmGUI != null) {
+                    confirmGUI.handleClick(player, session, slot);
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player)) {
+            return;
+        }
+        Player player = (Player) event.getPlayer();
+        JobsGUISession session = sessions.get(player.getUniqueId());
+        if (session != null && session.getInventory().equals(event.getInventory())) {
+            sessions.remove(player.getUniqueId());
+        }
+    }
+
+    /**
+     * 開いている全 Jobs GUI を閉じる（プラグイン無効化時用）。
+     */
+    public void closeAll() {
+        for (JobsGUISession session : sessions.values()) {
+            Player player = Bukkit.getPlayer(session.getPlayerId());
+            if (player != null && player.isOnline()) {
+                player.closeInventory();
+            }
+        }
+        sessions.clear();
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/jobs/gui/JobsGUISession.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/gui/JobsGUISession.java
@@ -1,0 +1,79 @@
+package org.tofu.tofunomics.jobs.gui;
+
+import org.bukkit.inventory.Inventory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Jobs GUI（職業ハブ・詳細・ステータス・確認）の開いている状態を保持するセッション。
+ *
+ * どの種類の GUI が開いているか、各スロットに対応する職業名、確認/詳細対象の職業名を保持し、
+ * クリック時にスロットから職業を解決できるようにする。
+ */
+public class JobsGUISession {
+
+    /** GUI の種別 */
+    public enum Type {
+        HUB,            // 職業ハブ（職業アイコングリッド＋ステータス）
+        JOB_DETAIL,     // 個別職業の詳細（就職/辞職ボタン付き）
+        STATS,          // 自分の職業ステータス（レベル・経験値・進捗）
+        CONFIRM_JOIN,   // 就職確認ダイアログ
+        CONFIRM_LEAVE   // 辞職確認ダイアログ
+    }
+
+    private final UUID playerId;
+    private final Type type;
+    private final Inventory inventory;
+
+    // スロット番号 → そのスロットに表示している職業名（HUB/STATS で使用）
+    private final Map<Integer, String> slotJobNames = new HashMap<>();
+
+    // 詳細/確認画面で対象としている職業名
+    private String targetJobName;
+
+    public JobsGUISession(UUID playerId, Type type, Inventory inventory) {
+        this.playerId = playerId;
+        this.type = type;
+        this.inventory = inventory;
+    }
+
+    public UUID getPlayerId() {
+        return playerId;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    /**
+     * 描画時にスロット→職業名のマッピングをクリアする。
+     */
+    public void clearSlotJobNames() {
+        slotJobNames.clear();
+    }
+
+    public void putSlotJobName(int slot, String jobName) {
+        slotJobNames.put(slot, jobName);
+    }
+
+    /**
+     * クリックされたスロットに対応する職業名を取得する（無ければ null）。
+     */
+    public String getJobNameAtSlot(int slot) {
+        return slotJobNames.get(slot);
+    }
+
+    public String getTargetJobName() {
+        return targetJobName;
+    }
+
+    public void setTargetJobName(String targetJobName) {
+        this.targetJobName = targetJobName;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/jobs/gui/JobsHubGUI.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/gui/JobsHubGUI.java
@@ -1,0 +1,166 @@
+package org.tofu.tofunomics.jobs.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.gui.GuiUtil;
+import org.tofu.tofunomics.jobs.JobManager;
+import org.tofu.tofunomics.models.PlayerJob;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 職業の統合ハブ GUI。
+ *
+ * {@code /jobs}（無引数）で開く入口。職業アイコンをグリッド状に並べ、クリックで詳細（就職/辞職）へ遷移する。
+ * 最下段に自分のステータス・閉じるボタンを配置する。
+ */
+public class JobsHubGUI {
+
+    private static final int SIZE = 27;
+    private static final int SLOT_JOB_START = 9;   // 9..16 に職業アイコンを配置
+    private static final int SLOT_JOB_END = 16;
+    private static final int SLOT_STATS = 22;
+    private static final int SLOT_CLOSE = 26;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final JobManager jobManager;
+    private final JobsGUIListener listener;
+
+    // 遷移先 GUI（循環依存回避のためセッターで後注入）
+    private JobDetailGUI detailGUI;
+    private JobStatsGUI statsGUI;
+
+    public JobsHubGUI(TofuNomics plugin, ConfigManager configManager,
+                      JobManager jobManager, JobsGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.jobManager = jobManager;
+        this.listener = listener;
+    }
+
+    public void setGUIs(JobDetailGUI detailGUI, JobStatsGUI statsGUI) {
+        this.detailGUI = detailGUI;
+        this.statsGUI = statsGUI;
+    }
+
+    /**
+     * ハブ GUI を開く。
+     */
+    public void open(Player player) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, SIZE, "§6職業");
+            JobsGUISession session = new JobsGUISession(
+                    player.getUniqueId(), JobsGUISession.Type.HUB, gui);
+            render(player, session, gui);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("職業ハブGUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage(ChatColor.RED + "職業GUIの表示に失敗しました。");
+        }
+    }
+
+    private void render(Player player, JobsGUISession session, Inventory gui) {
+        gui.clear();
+        session.clearSlotJobNames();
+
+        String[] jobNames = jobManager.getJobNames();
+        int slot = SLOT_JOB_START;
+        for (String jobName : jobNames) {
+            if (slot > SLOT_JOB_END) {
+                break; // 8 枠を超える職業は表示しない（想定外）
+            }
+            gui.setItem(slot, buildJobIcon(player, jobName));
+            session.putSlotJobName(slot, jobName);
+            slot++;
+        }
+
+        // 最下段: ステータス・閉じる
+        gui.setItem(SLOT_STATS, GuiUtil.createButton(Material.WRITABLE_BOOK, "§b§l自分のステータス",
+                java.util.Arrays.asList("§7就職中の職業のレベル・経験値を確認します", "§eクリックで開く")));
+        gui.setItem(SLOT_CLOSE, GuiUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = GuiUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = 0; i < SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    /**
+     * ハブに並べる職業アイコンを生成する。就職中ならレベルを表示する。
+     */
+    private ItemStack buildJobIcon(Player player, String jobName) {
+        String displayName = jobManager.getJobDisplayName(jobName);
+        String description = configManager.getJobDescription(jobName);
+        int maxLevel = configManager.getJobMaxLevel(jobName);
+        double incomeMultiplier = configManager.getJobIncomeMultiplier(jobName);
+        boolean employed = jobManager.hasJob(player, jobName);
+
+        List<String> lore = new ArrayList<>();
+        if (description != null && !description.isEmpty()) {
+            lore.add("§7" + description);
+        }
+        lore.add("§b最大レベル: §f" + maxLevel);
+        lore.add("§b収入倍率: §f" + String.format("%.1f", incomeMultiplier) + "x");
+        lore.add("");
+        if (employed) {
+            PlayerJob playerJob = jobManager.getPlayerJob(player, jobName);
+            int currentLevel = playerJob != null ? playerJob.getLevel() : 0;
+            lore.add("§a現在就職中 Lv." + currentLevel);
+            lore.add("§eクリックで詳細・辞職");
+        } else {
+            lore.add("§eクリックで詳細・就職");
+            lore.add("§7※転職にはレベル50が必要です");
+        }
+
+        String name = (employed ? "§a§l" : "§f§l") + displayName + " §7(" + jobName + ")";
+        return GuiUtil.createButton(JobsGUIIconMapper.getIcon(jobName), name, lore);
+    }
+
+    /**
+     * クリック処理（{@link JobsGUIListener} から呼ばれる）。
+     */
+    public void handleClick(Player player, JobsGUISession session, int slot) {
+        if (slot == SLOT_CLOSE) {
+            player.closeInventory();
+            return;
+        }
+        if (slot == SLOT_STATS) {
+            if (statsGUI != null) {
+                statsGUI.open(player);
+            }
+            return;
+        }
+        // 職業アイコン
+        String jobName = session.getJobNameAtSlot(slot);
+        if (jobName != null && detailGUI != null) {
+            detailGUI.open(player, jobName);
+        }
+    }
+
+    /**
+     * 1 tick 後にハブ GUI を再表示する（closeInventory 直後の再 open を避ける）。
+     */
+    public void reopen(Player player) {
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (player.isOnline()) {
+                open(player);
+            }
+        }, 1L);
+    }
+}


### PR DESCRIPTION
## 概要

`/jobs` を初見プレイヤーにも分かりやすくするため、Market/Housing と同じGUIハブパターンを踏襲して `/jobs`（無引数）でGUIを開くようにしました。職業名を正確に打たなくても、クリック操作で閲覧・就職・辞職・ステータス確認が完結します。

あわせて、config.ymlに**定義済みだが未使用だった** `jobs.job_settings.<職業>.guide_book` を活用し、就職中の職業のガイドブックを入手できるボタンを追加しました。

## 主な変更

- **`/jobs`（無引数）で職業ハブGUIを開く**。GUI初期化失敗時は従来のヘルプにフォールバック
- **職業ハブ**: 8職業をアイコングリッドで表示、最下段に「自分のステータス」「閉じる」
- **職業詳細**（list+info統合）: 説明・最大Lv・収入/経験値倍率・自分のLvを表示。就職/辞職ボタン＋就職中はガイドブック入手ボタン
- **ステータス**: 就職中の職業のレベル・経験値・進捗バー
- **就職/辞職は確認ダイアログ**（はい/いいえ）経由。転職Lv50・辞職Lv50制約をloreで明示
- **ガイドブック入手**: 就職中の職業のみ、`guide_book` から `WRITTEN_BOOK` を生成して付与（インベントリ満杯時は警告）
- **後方互換**: debug/admin と既存サブコマンド（join/leave/stats/info/list）は維持。`/jobs help` を追加

## 実装メモ

- `org.tofu.tofunomics.jobs.gui` に7クラス新規追加（Hub/Detail/Stats/Confirm/Listener/Session/IconMapper）。配線は `TofuNomics.java` に Market と同型で追加
- `ConfigManager` に guide_book 用アクセサを追加
- `GuiUtil.createButton` に `HIDE_ATTRIBUTES` 等の ItemFlag を付与し、道具アイコン（釣り竿・金床等）の属性テキスト混入を防止（market/housing 含む全GUIの改善）
- minecraft-plugin-qa でレビュー済み（ItemFlag・状態ガード・結果ハンドリングの指摘を反映）

## 動作確認

- lobby-1.21 にデプロイしゲーム内で確認済み（ハブ→詳細→就職/辞職の確認フロー、ステータス表示、就職中職業のガイドブック入手、未就職職業ではボタン非表示、既存サブコマンドの後方互換）
- `mvn clean package` BUILD SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)