### PR TITLE
WIP: チュートリアル機能とtohu-app API連携

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,5 +141,17 @@
           <version>2.3.232</version>
           <scope>test</scope>
       </dependency>
+
+      <!-- tohu-app API連携用 -->
+      <dependency>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+          <version>2.10.1</version>
+      </dependency>
+      <dependency>
+          <groupId>com.squareup.okhttp3</groupId>
+          <artifactId>okhttp</artifactId>
+          <version>4.12.0</version>
+      </dependency>
   </dependencies>
 </project>

--- a/scripts/deploy_plugin.sh
+++ b/scripts/deploy_plugin.sh
@@ -74,18 +74,6 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
 fi
 
 echo ""
-echo -e "${YELLOW}サーバー側のファイルをバックアップしています...${NC}"
-
-# サーバー側のバックアップ
-BACKUP_NAME="$(basename ${SERVER_PLUGIN_PATH}).backup.$(date +%Y%m%d_%H%M%S)"
-if [ -f "${SSH_KEY}" ]; then
-    ssh -i "${SSH_KEY}" "${SERVER_USER}@${SERVER_HOST}" \
-        "cp ${SERVER_PLUGIN_PATH} ${SERVER_PLUGIN_PATH}.backup.\$(date +%Y%m%d_%H%M%S) 2>/dev/null || echo 'バックアップをスキップ（既存ファイルなし）'"
-else
-    ssh "${SERVER_USER}@${SERVER_HOST}" \
-        "cp ${SERVER_PLUGIN_PATH} ${SERVER_PLUGIN_PATH}.backup.\$(date +%Y%m%d_%H%M%S) 2>/dev/null || echo 'バックアップをスキップ（既存ファイルなし）'"
-fi
-
 echo -e "${YELLOW}JARファイルをアップロードしています...${NC}"
 
 # SCPでアップロード

--- a/scripts/download_config.sh
+++ b/scripts/download_config.sh
@@ -49,9 +49,9 @@ echo "  サーバー: ${SERVER_USER}@${SERVER_HOST}"
 echo "  リモートパス: ${SERVER_CONFIG_PATH}"
 echo "  ローカルパス: ${LOCAL_CONFIG_PATH}"
 
-# 既存ファイルがある場合はバックアップ
+# 既存ファイルがある場合はバックアップ（固定名で上書き）
 if [ -f "${PROJECT_ROOT}/${LOCAL_CONFIG_PATH}" ]; then
-    BACKUP_PATH="${PROJECT_ROOT}/${LOCAL_CONFIG_PATH}.backup.$(date +%Y%m%d_%H%M%S)"
+    BACKUP_PATH="${PROJECT_ROOT}/${LOCAL_CONFIG_PATH}.backup"
     echo -e "${YELLOW}既存ファイルをバックアップしています: ${BACKUP_PATH}${NC}"
     cp "${PROJECT_ROOT}/${LOCAL_CONFIG_PATH}" "${BACKUP_PATH}"
 fi

--- a/scripts/upload_config.sh
+++ b/scripts/upload_config.sh
@@ -64,12 +64,11 @@ fi
 
 echo -e "${YELLOW}サーバー側のファイルをバックアップしています...${NC}"
 
-# サーバー側のバックアップ
-BACKUP_NAME="config.yml.backup.$(date +%Y%m%d_%H%M%S)"
+# サーバー側のバックアップ（固定名で上書き）
 if [ -f "${SSH_KEY}" ]; then
-    ssh -i "${SSH_KEY}" "${SERVER_USER}@${SERVER_HOST}" "cp ${SERVER_CONFIG_PATH} ${SERVER_CONFIG_PATH}.backup.$(date +%Y%m%d_%H%M%S) 2>/dev/null || true"
+    ssh -i "${SSH_KEY}" "${SERVER_USER}@${SERVER_HOST}" "cp ${SERVER_CONFIG_PATH} ${SERVER_CONFIG_PATH}.backup 2>/dev/null || true"
 else
-    ssh "${SERVER_USER}@${SERVER_HOST}" "cp ${SERVER_CONFIG_PATH} ${SERVER_CONFIG_PATH}.backup.$(date +%Y%m%d_%H%M%S) 2>/dev/null || true"
+    ssh "${SERVER_USER}@${SERVER_HOST}" "cp ${SERVER_CONFIG_PATH} ${SERVER_CONFIG_PATH}.backup 2>/dev/null || true"
 fi
 
 echo -e "${YELLOW}ファイルをアップロードしています...${NC}"

--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -20,7 +20,13 @@ import org.tofu.tofunomics.experience.JobExperienceManager;
 import org.tofu.tofunomics.income.JobIncomeManager;
 import org.tofu.tofunomics.quests.JobQuestManager;
 import org.tofu.tofunomics.rewards.JobLevelRewardManager;
+import org.tofu.tofunomics.rewards.JobGuideBookManager;
 import org.tofu.tofunomics.stats.JobStatsManager;
+import org.tofu.tofunomics.events.BankBalanceUpdateNotifier;
+import org.tofu.tofunomics.tutorial.TutorialManager;
+import org.tofu.tofunomics.tutorial.TutorialProgressDAO;
+import org.tofu.tofunomics.tutorial.TutorialEventListener;
+import org.tofu.tofunomics.tutorial.TutorialCommand;
 
 import java.io.File;
 
@@ -47,6 +53,7 @@ public final class TofuNomics extends JavaPlugin {
     // private JobIncomeManager jobIncomeManager;
     private JobQuestManager jobQuestManager;
     private JobLevelRewardManager jobLevelRewardManager;
+    private JobGuideBookManager jobGuideBookManager;
     private JobStatsManager jobStatsManager;
     private org.tofu.tofunomics.jobs.JobBlockPermissionManager jobBlockPermissionManager;
     
@@ -70,6 +77,7 @@ public final class TofuNomics extends JavaPlugin {
     private org.tofu.tofunomics.trade.TradeChestListener tradeChestListener;
     
     // Phase 5 統合イベントシステム
+    private org.tofu.tofunomics.events.AsyncEventUpdater asyncEventUpdater;
     private org.tofu.tofunomics.events.UnifiedEventHandler unifiedEventHandler;
     
     // Phase 6 クラフト制限専用イベントハンドラー（緊急対応）
@@ -110,6 +118,14 @@ public final class TofuNomics extends JavaPlugin {
     
     // ルール確認システム
     private org.tofu.tofunomics.rules.RulesManager rulesManager;
+
+    // チュートリアルシステム
+    private TutorialManager tutorialManager;
+    private TutorialProgressDAO tutorialProgressDAO;
+    private TutorialEventListener tutorialEventListener;
+
+    // tohu-app API連携（イベント駆動型）
+    private BankBalanceUpdateNotifier bankBalanceNotifier;
 
     @Override
     public void onEnable() {
@@ -156,7 +172,10 @@ public final class TofuNomics extends JavaPlugin {
         
         // ルール確認システムの初期化（PlayerJoinHandlerの前に初期化）
         initializeRulesSystem();
-        
+
+        // チュートリアルシステムの初期化
+        initializeTutorialSystem();
+
         // プレイヤー参加時処理の初期化
         initializePlayerJoinHandler();
         
@@ -180,7 +199,13 @@ public final class TofuNomics extends JavaPlugin {
         
         // コマンドハンドラーの登録
         registerCommands();
-        
+
+        // tohu-app API連携の初期化（イベント駆動型）
+        if (getConfig().getBoolean("api.tohu_app.enabled", false)) {
+            this.bankBalanceNotifier = new BankBalanceUpdateNotifier(this);
+            getLogger().info("tohu-app API連携を初期化しました（イベント駆動型）");
+        }
+
         getLogger().info("TofuNomicsプラグインが正常に有効化されました！");
     }
 
@@ -224,6 +249,12 @@ public final class TofuNomics extends JavaPlugin {
         // 時計アイテムシステムのクリーンアップ
         if (clockItemManager != null) {
             clockItemManager.stopActionBarTask();
+        }
+
+        // tohu-app API連携のクリーンアップ
+        if (bankBalanceNotifier != null) {
+            bankBalanceNotifier.shutdown();
+            getLogger().info("tohu-app API連携をシャットダウンしました");
         }
 
         // データベース接続を閉じる
@@ -321,6 +352,13 @@ public final class TofuNomics extends JavaPlugin {
             // JobLevelRewardManagerの初期化
             jobLevelRewardManager = new JobLevelRewardManager(configManager, playerDAO);
             
+            // JobGuideBookManagerの初期化
+            jobGuideBookManager = new JobGuideBookManager(configManager);
+            getLogger().info("職業ガイドブックシステムを初期化しました。");
+            
+            // AsyncEventUpdaterの初期化（JobExperienceManagerで使用）
+            asyncEventUpdater = new org.tofu.tofunomics.events.AsyncEventUpdater(this, playerDAO, playerJobDAO);
+            
             // JobExperienceManagerの初期化
             jobExperienceManager = new JobExperienceManager(
                 configManager, 
@@ -328,7 +366,8 @@ public final class TofuNomics extends JavaPlugin {
                 jobDAO, 
                 jobManager, 
                 jobToolManager,
-                experienceManager
+                experienceManager,
+                asyncEventUpdater
             );
             
             // 収入システムは無効化: JobIncomeManagerの初期化はコメントアウト
@@ -479,7 +518,8 @@ public final class TofuNomics extends JavaPlugin {
                     jobManager,
                     jobExperienceManager,
                     jobQuestManager,
-                    jobBlockPermissionManager
+                    jobBlockPermissionManager,
+                    asyncEventUpdater
                 );
                 getLogger().info("UnifiedEventHandler初期化完了");
             } catch (Exception e) {
@@ -628,7 +668,9 @@ public final class TofuNomics extends JavaPlugin {
             getCommand("eco").setExecutor(new EcoCommand(configManager, currencyConverter, playerDAO));
             
             // 職業系コマンド
-            getCommand("jobs").setExecutor(new JobsCommand(configManager, jobManager, experienceManager));
+            JobsCommand jobsCommand = new JobsCommand(configManager, jobManager, experienceManager, playerJobDAO);
+            getCommand("jobs").setExecutor(jobsCommand);
+            getCommand("jobs").setTabCompleter(jobsCommand);
             getCommand("jobstats").setExecutor(new JobStatsCommand(jobStatsManager));
             getCommand("quest").setExecutor(new JobQuestCommand(configManager, jobQuestManager));
             
@@ -690,10 +732,17 @@ public final class TofuNomics extends JavaPlugin {
             getCommand("rules").setExecutor(rulesCommand);
             
             // 中心都市マップ配布コマンド
-            org.tofu.tofunomics.commands.CityMapCommand cityMapCommand = 
+            org.tofu.tofunomics.commands.CityMapCommand cityMapCommand =
                 new org.tofu.tofunomics.commands.CityMapCommand(configManager);
             getCommand("citymap").setExecutor(cityMapCommand);
-            
+
+            // チュートリアルコマンド
+            if (tutorialManager != null) {
+                TutorialCommand tutorialCommand = new TutorialCommand(this, tutorialManager, configManager);
+                getCommand("tutorial").setExecutor(tutorialCommand);
+                getCommand("tutorial").setTabCompleter(tutorialCommand);
+            }
+
             getLogger().info("コマンドハンドラーを登録しました");
         } catch (Exception e) {
             getLogger().severe("コマンド登録中にエラーが発生しました: " + e.getMessage());
@@ -878,7 +927,8 @@ public final class TofuNomics extends JavaPlugin {
                 tradingModeSelectionGUI = new org.tofu.tofunomics.npc.gui.TradingModeSelectionGUI(
                     this,
                     configManager,
-                    tradingGUI
+                    tradingGUI,
+                    tradingNPCManager
                 );
                 getLogger().info("TradingModeSelectionGUIインスタンス作成完了: " + (tradingModeSelectionGUI != null ? "成功" : "失敗"));
             } catch (Exception e) {
@@ -1297,6 +1347,14 @@ public final class TofuNomics extends JavaPlugin {
      */
     private void initializeRulesSystem() {
         try {
+            // ルールシステムが無効または同意不要の場合はスキップ
+            if (!configManager.isRulesEnabled() || !configManager.isRulesRequireAgreement()) {
+                getLogger().info("ルール確認システムは無効化されています (rules.enabled=" + 
+                    configManager.isRulesEnabled() + ", rules.require_agreement=" + 
+                    configManager.isRulesRequireAgreement() + ")");
+                return;
+            }
+            
             getLogger().info("ルール確認システムを初期化しています...");
             
             // RulesManagerの初期化
@@ -1340,6 +1398,49 @@ public final class TofuNomics extends JavaPlugin {
     }
 
     /**
+     * チュートリアルシステムの初期化
+     */
+    private void initializeTutorialSystem() {
+        try {
+            getLogger().info("チュートリアルシステムを初期化しています...");
+
+            // TutorialProgressDAOの初期化
+            tutorialProgressDAO = new TutorialProgressDAO(databaseManager.getConnection());
+
+            // TutorialManagerの初期化
+            tutorialManager = new TutorialManager(this, configManager, tutorialProgressDAO);
+
+            // TutorialEventListenerの初期化と登録
+            tutorialEventListener = new TutorialEventListener(this, tutorialManager);
+            getServer().getPluginManager().registerEvents(tutorialEventListener, this);
+
+            if (tutorialManager.isEnabled()) {
+                getLogger().info("チュートリアルシステムの初期化が完了しました");
+            } else {
+                getLogger().info("チュートリアルシステムは無効化されています");
+            }
+
+        } catch (Exception e) {
+            getLogger().severe("チュートリアルシステムの初期化に失敗しました: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * TutorialManagerの取得
+     */
+    public TutorialManager getTutorialManager() {
+        return tutorialManager;
+    }
+
+    /**
+     * TutorialEventListenerの取得
+     */
+    public TutorialEventListener getTutorialEventListener() {
+        return tutorialEventListener;
+    }
+
+    /**
      * TestModeManagerの取得
      */
     public org.tofu.tofunomics.testing.TestModeManager getTestModeManager() {
@@ -1359,5 +1460,19 @@ public final class TofuNomics extends JavaPlugin {
      */
     public org.tofu.tofunomics.integration.WorldGuardIntegration getWorldGuardIntegration() {
         return worldGuardIntegration;
+    }
+
+    /**
+     * BankBalanceUpdateNotifierを取得
+     */
+    public BankBalanceUpdateNotifier getBankBalanceUpdateNotifier() {
+        return bankBalanceNotifier;
+    }
+
+    /**
+     * JobGuideBookManagerを取得
+     */
+    public JobGuideBookManager getJobGuideBookManager() {
+        return jobGuideBookManager;
     }
 }

--- a/src/main/java/org/tofu/tofunomics/announcement/TimeAnnouncementSystem.java
+++ b/src/main/java/org/tofu/tofunomics/announcement/TimeAnnouncementSystem.java
@@ -102,11 +102,15 @@ public class TimeAnnouncementSystem {
     }
     
     /**
-     * 全プレイヤーにメッセージを放送
+     * 対象ワールドのプレイヤーにメッセージを放送
+     * ワールド制限: enabled_worldsが未設定の場合、スコアボードと同じ設定を使用
      */
     private void broadcastMessage(String message) {
         for (Player player : Bukkit.getOnlinePlayers()) {
-            player.sendMessage(message);
+            // ワールド制限チェック
+            if (configManager.isAnnouncementEnabledInWorld(player.getWorld().getName())) {
+                player.sendMessage(message);
+            }
         }
     }
     

--- a/src/main/java/org/tofu/tofunomics/api/client/TohuAppApiClient.java
+++ b/src/main/java/org/tofu/tofunomics/api/client/TohuAppApiClient.java
@@ -1,0 +1,154 @@
+package org.tofu.tofunomics.api.client;
+
+import com.google.gson.Gson;
+import okhttp3.*;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.api.model.PlayerStatsData;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * tohu-app APIとの通信を担当するクライアント
+ * POST /api/mc/stats エンドポイントを使用
+ */
+public class TohuAppApiClient {
+    private final TofuNomics plugin;
+    private final OkHttpClient httpClient;
+    private final Gson gson;
+    private final String apiBaseUrl;
+    private final String apiToken;
+    private final int maxRetryAttempts;
+    private final int initialRetryDelay;
+
+    public TohuAppApiClient(TofuNomics plugin) {
+        this.plugin = plugin;
+        this.apiBaseUrl = plugin.getConfig().getString("api.tohu_app.base_url");
+        this.apiToken = plugin.getConfig().getString("api.tohu_app.token", "");
+        this.maxRetryAttempts = plugin.getConfig().getInt("api.tohu_app.retry.max_attempts", 3);
+        this.initialRetryDelay = plugin.getConfig().getInt("api.tohu_app.retry.initial_delay_seconds", 5);
+
+        // OkHttpClientの初期化（タイムアウト設定）
+        this.httpClient = new OkHttpClient.Builder()
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .build();
+
+        this.gson = new Gson();
+    }
+
+    /**
+     * 単一の統計データを送信
+     *
+     * @param data 送信する統計データ
+     * @return 送信成功時true、失敗時false
+     */
+    public boolean submitStats(PlayerStatsData data) {
+        try {
+            return executeWithRetry(() -> sendStatsRequest(data));
+        } catch (Exception e) {
+            plugin.getLogger().severe("統計データ送信に失敗しました: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 実際のHTTPリクエストを送信
+     */
+    private boolean sendStatsRequest(PlayerStatsData data) throws IOException {
+        // リクエストボディをJSON化
+        String json = gson.toJson(data);
+
+        // デバッグモード時はデータをログ出力
+        if (plugin.getConfig().getBoolean("api.tohu_app.debug", false)) {
+            plugin.getLogger().info("送信データ: " + json);
+        }
+
+        RequestBody body = RequestBody.create(
+                json,
+                MediaType.parse("application/json; charset=utf-8")
+        );
+
+        // HTTPリクエストを構築
+        Request.Builder requestBuilder = new Request.Builder()
+                .url(apiBaseUrl + "/api/mc/stats")
+                .post(body);
+
+        // 認証トークンが設定されている場合はヘッダーに追加
+        if (apiToken != null && !apiToken.isEmpty()) {
+            requestBuilder.header("X-API-Key", apiToken);
+        }
+
+        Request request = requestBuilder.build();
+
+        // リクエスト送信
+        try (Response response = httpClient.newCall(request).execute()) {
+            if (response.isSuccessful()) {
+                plugin.getLogger().fine("統計データ送信成功: " + data.getPlayer_name());
+                return true;
+            } else {
+                // HTTP 4xxエラー（クライアントエラー）の場合はリトライしない
+                if (response.code() >= 400 && response.code() < 500) {
+                    plugin.getLogger().warning(String.format(
+                            "統計データ送信失敗（クライアントエラー）: HTTP %d - %s",
+                            response.code(), data.getPlayer_name()
+                    ));
+                    return false;
+                }
+
+                // HTTP 5xxエラー（サーバーエラー）の場合は例外をスロー（リトライ対象）
+                throw new IOException("サーバーエラー: HTTP " + response.code());
+            }
+        }
+    }
+
+    /**
+     * リトライ処理を含むリクエスト実行
+     * ネットワークエラー、タイムアウト、HTTP 5xxエラーの場合にリトライ
+     */
+    private boolean executeWithRetry(IOOperation operation) throws Exception {
+        int delaySeconds = initialRetryDelay;
+
+        for (int attempt = 1; attempt <= maxRetryAttempts; attempt++) {
+            try {
+                return operation.execute();
+            } catch (IOException e) {
+                if (attempt == maxRetryAttempts) {
+                    // 最終試行で失敗した場合は例外をスロー
+                    throw e;
+                }
+
+                plugin.getLogger().warning(String.format(
+                        "API送信失敗（%d/%d回目）、%d秒後にリトライします: %s",
+                        attempt, maxRetryAttempts, delaySeconds, e.getMessage()
+                ));
+
+                // 指数バックオフ（待機時間を2倍にする）
+                Thread.sleep(delaySeconds * 1000L);
+                delaySeconds *= 2;
+            }
+        }
+
+        throw new RuntimeException("リトライ処理が異常終了しました");
+    }
+
+    /**
+     * IO操作を表す関数型インターフェース
+     */
+    @FunctionalInterface
+    private interface IOOperation {
+        boolean execute() throws IOException;
+    }
+
+    /**
+     * クライアントのクリーンアップ
+     */
+    public void shutdown() {
+        if (httpClient != null) {
+            httpClient.dispatcher().executorService().shutdown();
+            httpClient.connectionPool().evictAll();
+        }
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/api/model/PlayerStatsData.java
+++ b/src/main/java/org/tofu/tofunomics/api/model/PlayerStatsData.java
@@ -1,0 +1,96 @@
+package org.tofu.tofunomics.api.model;
+
+/**
+ * tohu-app API送信用のプレイヤー統計データモデル
+ * PUT /api/mc/stats/upsert のリクエストボディに対応
+ */
+public class PlayerStatsData {
+    // フィールド名はAPI仕様に合わせてスネークケース
+    private String player_uuid;
+    private String player_name;
+    private int world_id;
+    private String stat_type;
+    private String stat_date;
+    private long value;
+
+    /**
+     * デフォルトコンストラクタ
+     */
+    public PlayerStatsData() {
+    }
+
+    /**
+     * 全フィールドを指定するコンストラクタ
+     */
+    public PlayerStatsData(String playerUuid, String playerName, int worldId,
+                           String statType, String statDate, long value) {
+        this.player_uuid = playerUuid;
+        this.player_name = playerName;
+        this.world_id = worldId;
+        this.stat_type = statType;
+        this.stat_date = statDate;
+        this.value = value;
+    }
+
+    // ゲッター・セッター
+
+    public String getPlayer_uuid() {
+        return player_uuid;
+    }
+
+    public void setPlayer_uuid(String player_uuid) {
+        this.player_uuid = player_uuid;
+    }
+
+    public String getPlayer_name() {
+        return player_name;
+    }
+
+    public void setPlayer_name(String player_name) {
+        this.player_name = player_name;
+    }
+
+    public int getWorld_id() {
+        return world_id;
+    }
+
+    public void setWorld_id(int world_id) {
+        this.world_id = world_id;
+    }
+
+    public String getStat_type() {
+        return stat_type;
+    }
+
+    public void setStat_type(String stat_type) {
+        this.stat_type = stat_type;
+    }
+
+    public String getStat_date() {
+        return stat_date;
+    }
+
+    public void setStat_date(String stat_date) {
+        this.stat_date = stat_date;
+    }
+
+    public long getValue() {
+        return value;
+    }
+
+    public void setValue(long value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "PlayerStatsData{" +
+                "player_uuid='" + player_uuid + '\'' +
+                ", player_name='" + player_name + '\'' +
+                ", world_id=" + world_id +
+                ", stat_type='" + stat_type + '\'' +
+                ", stat_date='" + stat_date + '\'' +
+                ", value=" + value +
+                '}';
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/commands/JobsCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/JobsCommand.java
@@ -10,17 +10,29 @@ import org.tofu.tofunomics.jobs.JobManager;
 import org.tofu.tofunomics.jobs.ExperienceManager;
 import org.tofu.tofunomics.models.PlayerJob;
 import org.tofu.tofunomics.models.Job;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.tutorial.TutorialEventListener;
+import org.tofu.tofunomics.dao.PlayerJobDAO;
+import org.tofu.tofunomics.rewards.JobGuideBookManager;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.Bukkit;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.Arrays;
 
-public class JobsCommand implements CommandExecutor {
+public class JobsCommand implements CommandExecutor, TabCompleter {
     
     private final ConfigManager configManager;
     private final JobManager jobManager;
     private final ExperienceManager experienceManager;
+    private final PlayerJobDAO playerJobDAO;
     
-    public JobsCommand(ConfigManager configManager, JobManager jobManager, ExperienceManager experienceManager) {
+    public JobsCommand(ConfigManager configManager, JobManager jobManager, ExperienceManager experienceManager, PlayerJobDAO playerJobDAO) {
         this.configManager = configManager;
         this.jobManager = jobManager;
         this.experienceManager = experienceManager;
+        this.playerJobDAO = playerJobDAO;
     }
 
     @Override
@@ -54,6 +66,8 @@ public class JobsCommand implements CommandExecutor {
                 return handleJobDebug(player);
             case "admin":
                 return handleJobAdmin(sender, args);
+            case "guide":
+                return handleJobGuide(player, args);
             default:
                 sendHelpMessage(player);
                 return true;
@@ -115,14 +129,26 @@ public class JobsCommand implements CommandExecutor {
             case SUCCESS:
                 String displayName = jobManager.getJobDisplayName(jobName);
                 String message = configManager.getMessage("jobs.job_joined", "job", displayName);
-                
+
                 // メッセージが見つからない場合のフォールバック
                 if (message.startsWith("メッセージが見つかりません:")) {
                     message = "&a職業「" + displayName + "」に就職しました。";
                 }
-                
-                player.sendMessage(ChatColor.translateAlternateColorCodes('&', 
+
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&',
                     configManager.getMessagePrefix() + message));
+
+                // チュートリアル進捗: ステップ1（職業就職）完了チェック
+                TutorialEventListener tutorialListener = TofuNomics.getInstance().getTutorialEventListener();
+                if (tutorialListener != null) {
+                    tutorialListener.onJobJoined(player);
+                }
+                
+                // ガイドブックを配布
+                JobGuideBookManager guideBookManager = TofuNomics.getInstance().getJobGuideBookManager();
+                if (guideBookManager != null) {
+                    guideBookManager.giveGuideBook(player, jobName);
+                }
                 break;
                 
             case ALREADY_HAS_JOB:
@@ -322,7 +348,12 @@ public class JobsCommand implements CommandExecutor {
         
         if (args.length < 2) {
             sender.sendMessage(ChatColor.RED + "使用法: /jobs admin <サブコマンド>");
-            sender.sendMessage(ChatColor.YELLOW + "  forceleave <player> <jobName> - プレイヤーを強制的に辞職させる");
+            sender.sendMessage(ChatColor.YELLOW + "  forceleave <player> <job> - プレイヤーを強制辞職させる");
+            sender.sendMessage(ChatColor.YELLOW + "  forcejoin <player> <job> - プレイヤーを強制就職させる");
+            sender.sendMessage(ChatColor.YELLOW + "  setlevel <player> <job|all> <level> - レベルを設定");
+            sender.sendMessage(ChatColor.YELLOW + "  addexp <player> <job|all> <amount> - 経験値を追加");
+            sender.sendMessage(ChatColor.YELLOW + "  setexp <player> <job|all> <amount> - 経験値を設定");
+            sender.sendMessage(ChatColor.YELLOW + "  reset <player> <job|all> - 職業をリセット");
             return true;
         }
         
@@ -331,8 +362,19 @@ public class JobsCommand implements CommandExecutor {
         switch (subCommand) {
             case "forceleave":
                 return handleJobAdminForceLeave(sender, args);
+            case "setlevel":
+                return handleJobAdminSetLevel(sender, args);
+            case "addexp":
+                return handleJobAdminAddExp(sender, args);
+            case "setexp":
+                return handleJobAdminSetExp(sender, args);
+            case "forcejoin":
+                return handleJobAdminForceJoin(sender, args);
+            case "reset":
+                return handleJobAdminReset(sender, args);
             default:
                 sender.sendMessage(ChatColor.RED + "不明なサブコマンド: " + subCommand);
+                sender.sendMessage(ChatColor.YELLOW + "利用可能なサブコマンド: forceleave, setlevel, addexp, setexp, forcejoin, reset");
                 return true;
         }
     }
@@ -383,6 +425,365 @@ public class JobsCommand implements CommandExecutor {
         return true;
     }
     
+    /**
+     * 管理者によるレベル設定コマンド
+     */
+    private boolean handleJobAdminSetLevel(CommandSender sender, String[] args) {
+        if (args.length != 5) {
+            sender.sendMessage(ChatColor.RED + "使用法: /jobs admin setlevel <player> <job|all> <level>");
+            return true;
+        }
+        
+        String playerName = args[2];
+        String jobName = args[3].toLowerCase();
+        int level;
+        
+        try {
+            level = Integer.parseInt(args[4]);
+        } catch (NumberFormatException e) {
+            sender.sendMessage(ChatColor.RED + "レベルは数値で指定してください。");
+            return true;
+        }
+        
+        if (level < 1) {
+            sender.sendMessage(ChatColor.RED + "レベルは1以上で指定してください。");
+            return true;
+        }
+        
+        Player targetPlayer = Bukkit.getPlayer(playerName);
+        if (targetPlayer == null) {
+            sender.sendMessage(ChatColor.RED + "プレイヤーが見つかりません: " + playerName);
+            return true;
+        }
+        
+        if (jobName.equals("all")) {
+            // 全職業にレベルを設定
+            List<PlayerJob> jobs = jobManager.getPlayerJobs(targetPlayer);
+            if (jobs.isEmpty()) {
+                sender.sendMessage(ChatColor.RED + "そのプレイヤーは職業に就いていません。");
+                return true;
+            }
+            for (PlayerJob pj : jobs) {
+                Job job = jobManager.getJobById(pj.getJobId());
+                if (job != null) {
+                    experienceManager.setLevel(pj, job.getName(), level);
+                }
+            }
+            sender.sendMessage(ChatColor.GREEN + playerName + " の全職業レベルを " + level + " に設定しました。");
+            targetPlayer.sendMessage(ChatColor.YELLOW + "管理者により全職業レベルが " + level + " に設定されました。");
+        } else {
+            PlayerJob playerJob = jobManager.getPlayerJob(targetPlayer, jobName);
+            if (playerJob == null) {
+                sender.sendMessage(ChatColor.RED + "そのプレイヤーはその職業に就いていません: " + jobName);
+                return true;
+            }
+            if (experienceManager.setLevel(playerJob, jobName, level)) {
+                String displayName = jobManager.getJobDisplayName(jobName);
+                sender.sendMessage(ChatColor.GREEN + playerName + " の職業「" + displayName + "」レベルを " + level + " に設定しました。");
+                targetPlayer.sendMessage(ChatColor.YELLOW + "管理者により職業「" + displayName + "」のレベルが " + level + " に設定されました。");
+            } else {
+                sender.sendMessage(ChatColor.RED + "レベルの設定に失敗しました。");
+            }
+        }
+        
+        return true;
+    }
+    
+    /**
+     * 管理者による経験値追加コマンド
+     */
+    private boolean handleJobAdminAddExp(CommandSender sender, String[] args) {
+        if (args.length != 5) {
+            sender.sendMessage(ChatColor.RED + "使用法: /jobs admin addexp <player> <job|all> <amount>");
+            return true;
+        }
+        
+        String playerName = args[2];
+        String jobName = args[3].toLowerCase();
+        double amount;
+        
+        try {
+            amount = Double.parseDouble(args[4]);
+        } catch (NumberFormatException e) {
+            sender.sendMessage(ChatColor.RED + "経験値は数値で指定してください。");
+            return true;
+        }
+        
+        if (amount <= 0) {
+            sender.sendMessage(ChatColor.RED + "経験値は正の数で指定してください。");
+            return true;
+        }
+        
+        Player targetPlayer = Bukkit.getPlayer(playerName);
+        if (targetPlayer == null) {
+            sender.sendMessage(ChatColor.RED + "プレイヤーが見つかりません: " + playerName);
+            return true;
+        }
+        
+        if (jobName.equals("all")) {
+            List<PlayerJob> jobs = jobManager.getPlayerJobs(targetPlayer);
+            if (jobs.isEmpty()) {
+                sender.sendMessage(ChatColor.RED + "そのプレイヤーは職業に就いていません。");
+                return true;
+            }
+            for (PlayerJob pj : jobs) {
+                Job job = jobManager.getJobById(pj.getJobId());
+                if (job != null) {
+                    experienceManager.addExperience(pj, job.getName(), amount);
+                }
+            }
+            sender.sendMessage(ChatColor.GREEN + playerName + " の全職業に経験値 " + amount + " を追加しました。");
+            targetPlayer.sendMessage(ChatColor.YELLOW + "管理者により全職業に経験値 " + amount + " が追加されました。");
+        } else {
+            PlayerJob playerJob = jobManager.getPlayerJob(targetPlayer, jobName);
+            if (playerJob == null) {
+                sender.sendMessage(ChatColor.RED + "そのプレイヤーはその職業に就いていません: " + jobName);
+                return true;
+            }
+            ExperienceManager.ExperienceAddResult result = experienceManager.addExperience(playerJob, jobName, amount);
+            String displayName = jobManager.getJobDisplayName(jobName);
+            switch (result) {
+                case SUCCESS:
+                case LEVEL_UP:
+                    sender.sendMessage(ChatColor.GREEN + playerName + " の職業「" + displayName + "」に経験値 " + amount + " を追加しました。");
+                    targetPlayer.sendMessage(ChatColor.YELLOW + "管理者により職業「" + displayName + "」に経験値 " + amount + " が追加されました。");
+                    break;
+                case MAX_LEVEL_REACHED:
+                    sender.sendMessage(ChatColor.YELLOW + playerName + " は職業「" + displayName + "」で最大レベルに達しています。");
+                    break;
+                default:
+                    sender.sendMessage(ChatColor.RED + "経験値の追加に失敗しました。");
+                    break;
+            }
+        }
+        
+        return true;
+    }
+    
+    /**
+     * 管理者による経験値直接設定コマンド
+     */
+    private boolean handleJobAdminSetExp(CommandSender sender, String[] args) {
+        if (args.length != 5) {
+            sender.sendMessage(ChatColor.RED + "使用法: /jobs admin setexp <player> <job|all> <amount>");
+            return true;
+        }
+        
+        String playerName = args[2];
+        String jobName = args[3].toLowerCase();
+        double amount;
+        
+        try {
+            amount = Double.parseDouble(args[4]);
+        } catch (NumberFormatException e) {
+            sender.sendMessage(ChatColor.RED + "経験値は数値で指定してください。");
+            return true;
+        }
+        
+        if (amount < 0) {
+            sender.sendMessage(ChatColor.RED + "経験値は0以上で指定してください。");
+            return true;
+        }
+        
+        Player targetPlayer = Bukkit.getPlayer(playerName);
+        if (targetPlayer == null) {
+            sender.sendMessage(ChatColor.RED + "プレイヤーが見つかりません: " + playerName);
+            return true;
+        }
+        
+        if (jobName.equals("all")) {
+            List<PlayerJob> jobs = jobManager.getPlayerJobs(targetPlayer);
+            if (jobs.isEmpty()) {
+                sender.sendMessage(ChatColor.RED + "そのプレイヤーは職業に就いていません。");
+                return true;
+            }
+            for (PlayerJob pj : jobs) {
+                Job job = jobManager.getJobById(pj.getJobId());
+                if (job != null) {
+                    experienceManager.setExperience(pj, job.getName(), amount);
+                }
+            }
+            sender.sendMessage(ChatColor.GREEN + playerName + " の全職業の経験値を " + amount + " に設定しました。");
+            targetPlayer.sendMessage(ChatColor.YELLOW + "管理者により全職業の経験値が " + amount + " に設定されました。");
+        } else {
+            PlayerJob playerJob = jobManager.getPlayerJob(targetPlayer, jobName);
+            if (playerJob == null) {
+                sender.sendMessage(ChatColor.RED + "そのプレイヤーはその職業に就いていません: " + jobName);
+                return true;
+            }
+            if (experienceManager.setExperience(playerJob, jobName, amount)) {
+                String displayName = jobManager.getJobDisplayName(jobName);
+                sender.sendMessage(ChatColor.GREEN + playerName + " の職業「" + displayName + "」の経験値を " + amount + " に設定しました。");
+                targetPlayer.sendMessage(ChatColor.YELLOW + "管理者により職業「" + displayName + "」の経験値が " + amount + " に設定されました。");
+            } else {
+                sender.sendMessage(ChatColor.RED + "経験値の設定に失敗しました。");
+            }
+        }
+        
+        return true;
+    }
+    
+    /**
+     * 管理者による強制就職コマンド（レベル50制限なし）
+     */
+    private boolean handleJobAdminForceJoin(CommandSender sender, String[] args) {
+        if (args.length != 4) {
+            sender.sendMessage(ChatColor.RED + "使用法: /jobs admin forcejoin <player> <job>");
+            return true;
+        }
+        
+        String playerName = args[2];
+        String jobName = args[3].toLowerCase();
+        
+        Player targetPlayer = Bukkit.getPlayer(playerName);
+        if (targetPlayer == null) {
+            sender.sendMessage(ChatColor.RED + "プレイヤーが見つかりません: " + playerName);
+            return true;
+        }
+        
+        JobManager.JobJoinResult result = jobManager.forceJoinJob(targetPlayer, jobName);
+        
+        switch (result) {
+            case SUCCESS:
+                String displayName = jobManager.getJobDisplayName(jobName);
+                sender.sendMessage(ChatColor.GREEN + playerName + " を職業「" + displayName + "」に強制就職させました。");
+                targetPlayer.sendMessage(ChatColor.YELLOW + "管理者により職業「" + displayName + "」に就職しました。");
+                break;
+            case JOB_NOT_FOUND:
+                sender.sendMessage(ChatColor.RED + "職業が見つかりません: " + jobName);
+                break;
+            case ALREADY_HAS_JOB:
+                sender.sendMessage(ChatColor.RED + "そのプレイヤーは既にその職業に就いています。");
+                break;
+            case MAX_JOBS_REACHED:
+                sender.sendMessage(ChatColor.RED + "そのプレイヤーは最大職業数に達しています。");
+                break;
+            default:
+                sender.sendMessage(ChatColor.RED + "強制就職に失敗しました。");
+                break;
+        }
+        
+        return true;
+    }
+    
+    /**
+     * 管理者による職業リセットコマンド
+     */
+    private boolean handleJobAdminReset(CommandSender sender, String[] args) {
+        if (args.length != 4) {
+            sender.sendMessage(ChatColor.RED + "使用法: /jobs admin reset <player> <job|all>");
+            return true;
+        }
+        
+        String playerName = args[2];
+        String jobName = args[3].toLowerCase();
+        
+        Player targetPlayer = Bukkit.getPlayer(playerName);
+        if (targetPlayer == null) {
+            sender.sendMessage(ChatColor.RED + "プレイヤーが見つかりません: " + playerName);
+            return true;
+        }
+        
+        if (jobName.equals("all")) {
+            List<PlayerJob> jobs = jobManager.getPlayerJobs(targetPlayer);
+            if (jobs.isEmpty()) {
+                sender.sendMessage(ChatColor.RED + "そのプレイヤーは職業に就いていません。");
+                return true;
+            }
+            for (PlayerJob pj : jobs) {
+                pj.setLevel(1);
+                pj.setExperience(0.0);
+                playerJobDAO.updatePlayerJobData(pj);
+            }
+            sender.sendMessage(ChatColor.GREEN + playerName + " の全職業をリセットしました（レベル1・経験値0）。");
+            targetPlayer.sendMessage(ChatColor.YELLOW + "管理者により全職業がリセットされました（レベル1・経験値0）。");
+        } else {
+            PlayerJob playerJob = jobManager.getPlayerJob(targetPlayer, jobName);
+            if (playerJob == null) {
+                sender.sendMessage(ChatColor.RED + "そのプレイヤーはその職業に就いていません: " + jobName);
+                return true;
+            }
+            playerJob.setLevel(1);
+            playerJob.setExperience(0.0);
+            if (playerJobDAO.updatePlayerJobData(playerJob)) {
+                String displayName = jobManager.getJobDisplayName(jobName);
+                sender.sendMessage(ChatColor.GREEN + playerName + " の職業「" + displayName + "」をリセットしました（レベル1・経験値0）。");
+                targetPlayer.sendMessage(ChatColor.YELLOW + "管理者により職業「" + displayName + "」がリセットされました（レベル1・経験値0）。");
+            } else {
+                sender.sendMessage(ChatColor.RED + "リセットに失敗しました。");
+            }
+        }
+        
+        return true;
+    }
+    
+    /**
+     * /jobs guide コマンド - ガイドブックを取得
+     */
+    private boolean handleJobGuide(Player player, String[] args) {
+        JobGuideBookManager guideBookManager = TofuNomics.getInstance().getJobGuideBookManager();
+        if (guideBookManager == null || !guideBookManager.isEnabled()) {
+            player.sendMessage(ChatColor.RED + "ガイドブック機能は現在無効です。");
+            return true;
+        }
+        
+        // 現在の職業を取得
+        List<PlayerJob> playerJobs = jobManager.getPlayerJobs(player);
+        if (playerJobs == null || playerJobs.isEmpty()) {
+            player.sendMessage(ChatColor.RED + "職業に就いていないため、ガイドブックを取得できません。");
+            player.sendMessage(ChatColor.YELLOW + "まずは /jobs join <職業名> で職業に就いてください。");
+            return true;
+        }
+        
+        String targetJob;
+        
+        if (args.length >= 2) {
+            // 指定された職業のガイドブックを取得
+            targetJob = args[1].toLowerCase();
+            
+            // その職業に就いているか確認
+            boolean hasJob = playerJobs.stream()
+                .anyMatch(pj -> {
+                    Job job = jobManager.getJobById(pj.getJobId());
+                    return job != null && job.getName().equalsIgnoreCase(targetJob);
+                });
+            
+            if (!hasJob) {
+                String displayName = jobManager.getJobDisplayName(targetJob);
+                if (displayName == null) {
+                    player.sendMessage(ChatColor.RED + "存在しない職業です: " + targetJob);
+                    return true;
+                }
+                player.sendMessage(ChatColor.RED + "あなたは「" + displayName + "」に就いていないため、");
+                player.sendMessage(ChatColor.RED + "そのガイドブックを取得できません。");
+                return true;
+            }
+        } else {
+            // 最初の職業のガイドブックを取得（複数職業の場合）
+            Job firstJob = jobManager.getJobById(playerJobs.get(0).getJobId());
+            targetJob = (firstJob != null) ? firstJob.getName() : null;
+            
+            if (targetJob == null) {
+                player.sendMessage(ChatColor.RED + "職業情報の取得に失敗しました。");
+                return true;
+            }
+            
+            if (playerJobs.size() > 1) {
+                player.sendMessage(ChatColor.YELLOW + "複数の職業に就いています。特定の職業のガイドブックが欲しい場合は:");
+                player.sendMessage(ChatColor.YELLOW + "/jobs guide <職業名> を使用してください。");
+                player.sendMessage("");
+            }
+        }
+        
+        // ガイドブックを配布
+        String displayName = jobManager.getJobDisplayName(targetJob);
+        if (guideBookManager.giveGuideBookForced(player, targetJob)) {
+            // メッセージはgiveGuideBookForcedで送信済み
+        }
+        
+        return true;
+    }
+
     private void sendHelpMessage(Player player) {
         player.sendMessage(ChatColor.GOLD + "=== Jobs コマンドヘルプ ===");
         player.sendMessage(ChatColor.YELLOW + "/jobs list " + ChatColor.WHITE + "- 利用可能な職業一覧を表示");
@@ -390,6 +791,95 @@ public class JobsCommand implements CommandExecutor {
         player.sendMessage(ChatColor.YELLOW + "/jobs leave <職業名> " + ChatColor.WHITE + "- 指定した職業を辞める");
         player.sendMessage(ChatColor.YELLOW + "/jobs stats [職業名] " + ChatColor.WHITE + "- 職業の統計を表示");
         player.sendMessage(ChatColor.YELLOW + "/jobs info <職業名> " + ChatColor.WHITE + "- 職業の詳細情報を表示");
+        player.sendMessage(ChatColor.YELLOW + "/jobs guide [職業名] " + ChatColor.WHITE + "- 職業ガイドブックを取得");
         player.sendMessage(ChatColor.YELLOW + "/jobs debug " + ChatColor.WHITE + "- 職業の詳細デバッグ情報を表示");
+        
+        // 管理者向けヘルプ
+        if (player.hasPermission("tofunomics.jobs.admin")) {
+            player.sendMessage(ChatColor.GOLD + "=== 管理者コマンド ===");
+            player.sendMessage(ChatColor.YELLOW + "/jobs admin forceleave <player> <job>" + ChatColor.WHITE + " - 強制辞職");
+            player.sendMessage(ChatColor.YELLOW + "/jobs admin forcejoin <player> <job>" + ChatColor.WHITE + " - 強制就職");
+            player.sendMessage(ChatColor.YELLOW + "/jobs admin setlevel <player> <job|all> <level>" + ChatColor.WHITE + " - レベル設定");
+            player.sendMessage(ChatColor.YELLOW + "/jobs admin addexp <player> <job|all> <amount>" + ChatColor.WHITE + " - 経験値追加");
+            player.sendMessage(ChatColor.YELLOW + "/jobs admin setexp <player> <job|all> <amount>" + ChatColor.WHITE + " - 経験値設定");
+            player.sendMessage(ChatColor.YELLOW + "/jobs admin reset <player> <job|all>" + ChatColor.WHITE + " - 職業リセット");
+        }
+    }
+    
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> completions = new ArrayList<>();
+        
+        if (args.length == 1) {
+            // サブコマンド補完
+            List<String> subCommands = new ArrayList<>();
+            subCommands.add("list");
+            subCommands.add("join");
+            subCommands.add("leave");
+            subCommands.add("stats");
+            subCommands.add("info");
+            subCommands.add("guide");
+            subCommands.add("debug");
+            if (sender.hasPermission("tofunomics.jobs.admin")) {
+                subCommands.add("admin");
+            }
+            String input = args[0].toLowerCase();
+            completions = subCommands.stream()
+                    .filter(s -> s.startsWith(input))
+                    .collect(Collectors.toList());
+        } else if (args.length == 2) {
+            String subCommand = args[0].toLowerCase();
+            if (subCommand.equals("join") || subCommand.equals("leave") || 
+                subCommand.equals("stats") || subCommand.equals("info") ||
+                subCommand.equals("guide")) {
+                // 職業名補完
+                String input = args[1].toLowerCase();
+                completions = Arrays.stream(jobManager.getJobNames())
+                        .filter(s -> s.toLowerCase().startsWith(input))
+                        .collect(Collectors.toList());
+            } else if (subCommand.equals("admin") && sender.hasPermission("tofunomics.jobs.admin")) {
+                // 管理者サブコマンド補完
+                List<String> adminSubCommands = new ArrayList<>();
+                adminSubCommands.add("forceleave");
+                adminSubCommands.add("forcejoin");
+                adminSubCommands.add("setlevel");
+                adminSubCommands.add("addexp");
+                adminSubCommands.add("setexp");
+                adminSubCommands.add("reset");
+                String input = args[1].toLowerCase();
+                completions = adminSubCommands.stream()
+                        .filter(s -> s.startsWith(input))
+                        .collect(Collectors.toList());
+            }
+        } else if (args.length == 3 && args[0].equalsIgnoreCase("admin") && 
+                   sender.hasPermission("tofunomics.jobs.admin")) {
+            // プレイヤー名補完
+            String input = args[2].toLowerCase();
+            completions = Bukkit.getOnlinePlayers().stream()
+                    .map(Player::getName)
+                    .filter(s -> s.toLowerCase().startsWith(input))
+                    .collect(Collectors.toList());
+        } else if (args.length == 4 && args[0].equalsIgnoreCase("admin") && 
+                   sender.hasPermission("tofunomics.jobs.admin")) {
+            String adminSubCommand = args[1].toLowerCase();
+            String input = args[3].toLowerCase();
+            
+            // 職業名 + all 補完
+            if (adminSubCommand.equals("setlevel") || adminSubCommand.equals("addexp") || 
+                adminSubCommand.equals("setexp") || adminSubCommand.equals("reset")) {
+                List<String> options = new ArrayList<>(Arrays.asList(jobManager.getJobNames()));
+                options.add("all");
+                completions = options.stream()
+                        .filter(s -> s.toLowerCase().startsWith(input))
+                        .collect(Collectors.toList());
+            } else if (adminSubCommand.equals("forceleave") || adminSubCommand.equals("forcejoin")) {
+                // 職業名のみ
+                completions = Arrays.stream(jobManager.getJobNames())
+                        .filter(s -> s.toLowerCase().startsWith(input))
+                        .collect(Collectors.toList());
+            }
+        }
+        
+        return completions;
     }
 }

--- a/src/main/java/org/tofu/tofunomics/commands/NPCCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/NPCCommand.java
@@ -250,11 +250,14 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
     }
     
     private boolean handleSpawnBanker(Player player, String[] args, Location spawnLocation) {
-        String npcName = args.length > 2 ? 
-            String.join(" ", Arrays.copyOfRange(args, 2, args.length)) : 
+        String npcName = args.length > 2 ?
+            String.join(" ", Arrays.copyOfRange(args, 2, args.length)) :
             "§6銀行員";
-            
+
         try {
+            // 同じ座標の既存NPCを削除
+            removeDuplicateNPCsAtLocation(spawnLocation);
+
             // 銀行NPCを作成
             Villager npc = npcManager.createNPC(spawnLocation, "banker", npcName);
             boolean success = (npc != null);
@@ -285,7 +288,23 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
             return true;
         }
     }
-    
+
+    /**
+     * 指定座標の周辺にある重複NPCを削除
+     */
+    private void removeDuplicateNPCsAtLocation(Location location) {
+        double radius = 1.0; // 1ブロック以内のNPCを削除
+        Collection<NPCManager.NPCData> allNPCs = npcManager.getAllNPCs();
+
+        for (NPCManager.NPCData npcData : allNPCs) {
+            if (npcData.getLocation().getWorld().equals(location.getWorld()) &&
+                npcData.getLocation().distance(location) < radius) {
+                plugin.getLogger().info("重複NPC削除: " + npcData.getName() + " at " + formatLocation(npcData.getLocation()));
+                npcManager.removeNPC(npcData.getEntityId());
+            }
+        }
+    }
+
     private boolean handleSpawnFoodMerchant(Player player, String[] args, Location spawnLocation) {
         // 使用法: /npc spawn food_merchant [NPC名] [タイプ]
         String npcName;

--- a/src/main/java/org/tofu/tofunomics/commands/TofuNomicsCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/TofuNomicsCommand.java
@@ -43,6 +43,8 @@ public class TofuNomicsCommand implements CommandExecutor, TabCompleter {
                 return handleStatusCommand(sender);
             case "version":
                 return handleVersionCommand(sender);
+            case "recalcexp":
+                return handleRecalcExpCommand(sender);
             case "config":
                 // configサブコマンドに処理を委譲
                 return handleConfigCommand(sender, args);
@@ -66,20 +68,72 @@ public class TofuNomicsCommand implements CommandExecutor, TabCompleter {
         sender.sendMessage("§eTofuNomicsプラグインをリロード中...");
         
         try {
-            // 設定リロード
-            plugin.reloadConfig();
-            
+            // 設定リロード（ConfigManager内部のconfigフィールドも更新する）
+            configManager.reloadConfig();
+
             sender.sendMessage("§aTofuNomicsプラグインのリロードが完了しました。");
-            sender.sendMessage("§e注意: 完全なリロードにはプラグインの再起動が推奨されます。");
+            sender.sendMessage("§e注意: NPC関連の設定変更は /tofunomics npc reload も実行してください。");
             plugin.getLogger().info("プラグインがリロードされました（実行者: " + sender.getName() + "）");
         } catch (Exception e) {
             sender.sendMessage("§cリロード中にエラーが発生しました: " + e.getMessage());
             plugin.getLogger().severe("リロード中にエラーが発生: " + e.getMessage());
         }
-        
+
         return true;
     }
-    
+
+    /**
+     * 経験値曲線の変更に伴い、全プレイヤーの職業経験値を再スケールする。
+     * 各レコードのレベルは維持し、経験値を新しい曲線でのそのレベルの下限値に再設定する。
+     * （リリース前の経験値曲線緩和に伴うワンショット移行用。ツール配布は行わない）
+     */
+    private boolean handleRecalcExpCommand(CommandSender sender) {
+        if (!sender.hasPermission("tofunomics.admin")) {
+            sender.sendMessage(configManager.getMessage("no_permission"));
+            return true;
+        }
+
+        sender.sendMessage("§e経験値曲線の変更に伴い、全プレイヤーの職業経験値を再スケール中...");
+
+        org.tofu.tofunomics.jobs.ExperienceManager experienceManager = plugin.getExperienceManager();
+        org.tofu.tofunomics.dao.PlayerJobDAO playerJobDAO = plugin.getPlayerJobDAO();
+
+        if (experienceManager == null || playerJobDAO == null) {
+            sender.sendMessage("§c必要なマネージャが初期化されていません。");
+            return true;
+        }
+
+        int updated = 0;
+        int failed = 0;
+        try {
+            java.util.List<org.tofu.tofunomics.models.PlayerJob> allPlayerJobs = playerJobDAO.getAllPlayerJobs();
+            for (org.tofu.tofunomics.models.PlayerJob playerJob : allPlayerJobs) {
+                int level = playerJob.getLevel();
+                if (level < 1) {
+                    level = 1;
+                }
+                // 現在のレベルを維持し、経験値を新しい経験値曲線でのそのレベルの下限値に再設定
+                double newExperience = experienceManager.calculateRequiredExperience(level);
+                playerJob.setLevel(level);
+                playerJob.setExperience(newExperience);
+                if (playerJobDAO.updatePlayerJobData(playerJob)) {
+                    updated++;
+                } else {
+                    failed++;
+                }
+            }
+        } catch (java.sql.SQLException e) {
+            sender.sendMessage("§c再スケール中にデータベースエラーが発生しました: " + e.getMessage());
+            plugin.getLogger().severe("recalcexp 失敗: " + e.getMessage());
+            return true;
+        }
+
+        sender.sendMessage("§a経験値の再スケールが完了しました。更新: " + updated + " 件 / 失敗: " + failed + " 件");
+        sender.sendMessage("§eレベルは維持され、各職業の経験値は現在レベルの下限値に再設定されました。");
+        plugin.getLogger().info("recalcexp 実行（実行者: " + sender.getName() + "）更新: " + updated + ", 失敗: " + failed);
+        return true;
+    }
+
     private boolean handleStatusCommand(CommandSender sender) {
         if (!sender.hasPermission("tofunomics.admin")) {
             sender.sendMessage(configManager.getMessage("no_permission"));
@@ -353,6 +407,7 @@ public class TofuNomicsCommand implements CommandExecutor, TabCompleter {
         sender.sendMessage("§f/tofunomics reload §7- プラグイン設定をリロード");
         sender.sendMessage("§f/tofunomics status §7- プラグイン状態を表示");
         sender.sendMessage("§f/tofunomics version §7- バージョン情報を表示");
+        sender.sendMessage("§f/tofunomics recalcexp §7- 経験値曲線変更後の全プレイヤー経験値を再スケール");
         sender.sendMessage("§f/tofunomics config <サブコマンド> §7- 設定管理機能");
         sender.sendMessage("§f/tofunomics npc <サブコマンド> §7- NPC管理機能");
         sender.sendMessage("§7使用可能なconfigサブコマンド:");
@@ -364,7 +419,7 @@ public class TofuNomicsCommand implements CommandExecutor, TabCompleter {
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (args.length == 1) {
-            return Arrays.asList("reload", "status", "version", "config", "npc");
+            return Arrays.asList("reload", "status", "version", "recalcexp", "config", "npc");
         } else if (args.length == 2) {
             if ("config".equals(args[0].toLowerCase())) {
                 return Arrays.asList("generate", "fix", "validate", "backup", "messages");

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -884,9 +884,24 @@ public class ConfigManager {
      * 経験値計算指数を取得
      */
     public double getExperienceExponent() {
-        return config.getDouble("leveling.experience.exponent", 2.0);
+        return config.getDouble("leveling.experience.exponent", 1.9);
     }
-    
+
+    /**
+     * 高レベル時の経験値獲得ペナルティ係数を取得
+     * 実効ペナルティ = max(minimum, 1.0 - level * factor)
+     */
+    public double getLevelPenaltyFactor() {
+        return config.getDouble("leveling.experience.level_penalty.factor", 0.005);
+    }
+
+    /**
+     * 高レベル時の経験値獲得ペナルティ下限値を取得
+     */
+    public double getLevelPenaltyMinimum() {
+        return config.getDouble("leveling.experience.level_penalty.minimum", 0.4);
+    }
+
     /**
      * レベル範囲別倍率を取得
      */
@@ -1825,9 +1840,48 @@ public class ConfigManager {
      */
     public boolean isScoreboardEnabledInWorld(String worldName) {
         java.util.List<String> enabledWorlds = getScoreboardEnabledWorlds();
-        return enabledWorlds.contains(worldName);
+        return enabledWorlds.stream()
+            .anyMatch(w -> w.equalsIgnoreCase(worldName));
+    }
+
+    /**
+     * 営業時間放送対象ワールド一覧を取得
+     */
+    public java.util.List<String> getAnnouncementEnabledWorlds() {
+        return config.getStringList("time_announcement.enabled_worlds");
     }
     
+    /**
+     * 指定されたワールドで営業時間放送を行うかどうか
+     * enabled_worldsが未設定の場合、スコアボードと同じ設定を使用
+     */
+    public boolean isAnnouncementEnabledInWorld(String worldName) {
+        java.util.List<String> enabledWorlds = getAnnouncementEnabledWorlds();
+        if (enabledWorlds.isEmpty()) {
+            // enabled_worldsが未設定の場合、スコアボードと同じ設定を使用
+            enabledWorlds = getScoreboardEnabledWorlds();
+        }
+        return enabledWorlds.stream()
+            .anyMatch(w -> w.equalsIgnoreCase(worldName));
+    }
+    
+    // ========== ルールシステム設定 ==========
+    
+    /**
+     * ルールシステムが有効かどうかを確認
+     */
+    public boolean isRulesEnabled() {
+        return config.getBoolean("rules.enabled", false);
+    }
+    
+    /**
+     * ルール同意が必須かどうかを確認
+     */
+    public boolean isRulesRequireAgreement() {
+        return config.getBoolean("rules.require_agreement", false);
+    }
+    
+
     /**
      * 職業の最大レベルを取得
      */

--- a/src/main/java/org/tofu/tofunomics/dao/PlayerJobDAO.java
+++ b/src/main/java/org/tofu/tofunomics/dao/PlayerJobDAO.java
@@ -159,6 +159,20 @@ public class PlayerJobDAO {
         return topPlayers;
     }
 
+    public List<PlayerJob> getAllPlayerJobs() throws SQLException {
+        String query = "SELECT * FROM player_jobs";
+        List<PlayerJob> allPlayerJobs = new ArrayList<>();
+
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            ResultSet resultSet = statement.executeQuery();
+
+            while (resultSet.next()) {
+                allPlayerJobs.add(mapResultSetToPlayerJob(resultSet));
+            }
+        }
+        return allPlayerJobs;
+    }
+
     private PlayerJob mapResultSetToPlayerJob(ResultSet resultSet) throws SQLException {
         PlayerJob playerJob = new PlayerJob();
         playerJob.setUuid(UUID.fromString(resultSet.getString("uuid")));

--- a/src/main/java/org/tofu/tofunomics/database/HikariDatabaseManager.java
+++ b/src/main/java/org/tofu/tofunomics/database/HikariDatabaseManager.java
@@ -227,7 +227,22 @@ public class HikariDatabaseManager {
                 "stat_value REAL NOT NULL," +
                 "recorded_at DATETIME DEFAULT CURRENT_TIMESTAMP" +
                 ")";
-            
+
+            // チュートリアル進捗テーブル
+            String createTutorialProgressTable = "CREATE TABLE IF NOT EXISTS tutorial_progress (" +
+                "uuid TEXT PRIMARY KEY," +
+                "current_step INTEGER NOT NULL DEFAULT 0," +
+                "step1_completed_at TIMESTAMP," +
+                "step2_completed_at TIMESTAMP," +
+                "step3_completed_at TIMESTAMP," +
+                "step4_completed_at TIMESTAMP," +
+                "tutorial_completed BOOLEAN DEFAULT FALSE," +
+                "tutorial_skipped BOOLEAN DEFAULT FALSE," +
+                "started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP," +
+                "completed_at TIMESTAMP," +
+                "FOREIGN KEY (uuid) REFERENCES players(uuid) ON DELETE CASCADE" +
+                ")";
+
             // インデックスの作成
             String[] indexes = {
                 "CREATE INDEX IF NOT EXISTS idx_player_jobs_uuid ON player_jobs(uuid)",
@@ -250,7 +265,8 @@ public class HikariDatabaseManager {
                 stmt.execute(createTradeChestsTable);
                 stmt.execute(createPlayerTradeHistoryTable);
                 stmt.execute(createPerformanceStatsTable);
-                
+                stmt.execute(createTutorialProgressTable);
+
                 // インデックス作成
                 for (String indexSql : indexes) {
                     stmt.execute(indexSql);

--- a/src/main/java/org/tofu/tofunomics/economy/CurrencyConverter.java
+++ b/src/main/java/org/tofu/tofunomics/economy/CurrencyConverter.java
@@ -57,18 +57,26 @@ public class CurrencyConverter {
         double bankAmount = convertNuggetsToBalance(nuggetAmount);
         
         org.tofu.tofunomics.models.Player tofuPlayer = playerDAO.getPlayerByUUID(player.getUniqueId().toString());
+        boolean success;
         if (tofuPlayer == null) {
             tofuPlayer = new org.tofu.tofunomics.models.Player();
             tofuPlayer.setUuid(player.getUniqueId().toString());
             tofuPlayer.setBalance(0.0); // 現金は0
             tofuPlayer.setBankBalance(bankAmount); // 銀行預金に追加
-            return playerDAO.insertPlayer(tofuPlayer);
+            success = playerDAO.insertPlayer(tofuPlayer);
         } else {
             tofuPlayer.addBankBalance(bankAmount); // 銀行預金に追加
-            return playerDAO.updatePlayerData(tofuPlayer);
+            success = playerDAO.updatePlayerData(tofuPlayer);
         }
+        
+        // DB更新成功時、tohu-app APIに通知（入金額を送信）
+        if (success) {
+            notifyBankBalanceChange(player, bankAmount);
+        }
+
+        return success;
     }
-    
+
     public boolean depositAllGoldNuggets(Player player) {
         int availableNuggets = itemManager.countGoldNuggetsInInventory(player);
         return availableNuggets > 0 && depositGoldNuggets(player, availableNuggets);
@@ -109,7 +117,10 @@ public class CurrencyConverter {
             playerDAO.updatePlayerData(tofuPlayer);
             return WithdrawResult.INSUFFICIENT_INVENTORY_SPACE;
         }
-        
+
+        // tohu-app APIに預金残高を通知（出金額を負の値で送信）
+        notifyBankBalanceChange(player, -exactAmount);
+
         return WithdrawResult.SUCCESS;
     }
     
@@ -222,24 +233,44 @@ public class CurrencyConverter {
         
         double newBalance = tofuPlayer.getBankBalance() + amount;
         tofuPlayer.setBankBalance(newBalance);
-        return playerDAO.updatePlayerData(tofuPlayer);
+        boolean success = playerDAO.updatePlayerData(tofuPlayer);
+        
+        // DB更新成功時、プレイヤーがオンラインならtohu-app APIに通知（入金額を送信）
+        if (success) {
+            Player onlinePlayer = org.bukkit.Bukkit.getPlayer(uuid);
+            if (onlinePlayer != null && onlinePlayer.isOnline()) {
+                notifyBankBalanceChange(onlinePlayer, amount);
+            }
+        }
+
+        return success;
     }
-    
+
     public boolean subtractBalance(java.util.UUID uuid, double amount) {
         if (amount <= 0) {
             return false;
         }
-        
+
         org.tofu.tofunomics.models.Player tofuPlayer = playerDAO.getPlayerByUUID(uuid.toString());
         if (tofuPlayer == null || tofuPlayer.getBankBalance() < amount) {
             return false;
         }
-        
+
         double newBalance = tofuPlayer.getBankBalance() - amount;
         tofuPlayer.setBankBalance(newBalance);
-        return playerDAO.updatePlayerData(tofuPlayer);
+        boolean success = playerDAO.updatePlayerData(tofuPlayer);
+
+        // tohu-app APIに預金残高を通知（出金額を負の値で送信）
+        if (success) {
+            org.bukkit.entity.Player player = org.bukkit.Bukkit.getPlayer(uuid);
+            if (player != null) {
+                notifyBankBalanceChange(player, -amount);
+            }
+        }
+
+        return success;
     }
-    
+
     // 所持金での支払い処理（金塊をインベントリから削除）
     public boolean payWithCash(Player player, double amount) {
         if (amount <= 0) {
@@ -310,5 +341,25 @@ public class CurrencyConverter {
         
         int requiredNuggets = convertBalanceToNuggets(amount);
         return hasEnoughGoldNuggets(player, requiredNuggets);
+    }
+    
+    /**
+     * 預金残高の変化量をtohu-app APIに通知するヘルパーメソッド（差分送信方式）
+     *
+     * @param player 入出金したプレイヤー
+     * @param changeAmount 変化量（入金時は正、出金時は負）
+     */
+    private void notifyBankBalanceChange(Player player, double changeAmount) {
+        try {
+            org.tofu.tofunomics.TofuNomics plugin = org.tofu.tofunomics.TofuNomics.getInstance();
+            if (plugin != null && plugin.getBankBalanceUpdateNotifier() != null) {
+                plugin.getBankBalanceUpdateNotifier().notifyBankBalanceChange(player, changeAmount);
+            }
+        } catch (Exception e) {
+            // 通知失敗は入出金処理に影響させない
+            org.bukkit.Bukkit.getLogger().warning(
+                "[CurrencyConverter] 預金残高通知に失敗しました: " + e.getMessage()
+            );
+        }
     }
 }

--- a/src/main/java/org/tofu/tofunomics/events/AsyncEventUpdater.java
+++ b/src/main/java/org/tofu/tofunomics/events/AsyncEventUpdater.java
@@ -243,7 +243,7 @@ public class AsyncEventUpdater {
         switch (jobType.toLowerCase()) {
             case "farmer": return 1;
             case "miner": return 2;
-            case "builder": return 3;
+            case "architect": return 3;
             case "hunter": return 4;
             case "fisher": return 5;
             case "trader": return 6;

--- a/src/main/java/org/tofu/tofunomics/events/BankBalanceUpdateNotifier.java
+++ b/src/main/java/org/tofu/tofunomics/events/BankBalanceUpdateNotifier.java
@@ -1,0 +1,99 @@
+package org.tofu.tofunomics.events;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.api.client.TohuAppApiClient;
+import org.tofu.tofunomics.api.model.PlayerStatsData;
+
+import java.time.LocalDate;
+
+/**
+ * 銀行入出金時にtohu-app APIへ変化量を通知するクラス
+ * イベント駆動型でAPI送信を行う（差分送信方式）
+ */
+public class BankBalanceUpdateNotifier {
+    private final TofuNomics plugin;
+    private final TohuAppApiClient apiClient;
+    private final int worldId;
+    private final boolean debugMode;
+
+    public BankBalanceUpdateNotifier(TofuNomics plugin) {
+        this.plugin = plugin;
+        this.apiClient = new TohuAppApiClient(plugin);
+        this.worldId = plugin.getConfig().getInt("api.tohu_app.world_id", 1);
+        this.debugMode = plugin.getConfig().getBoolean("api.tohu_app.debug", false);
+    }
+
+    /**
+     * 預金残高の変化量をtohu-app APIに通知（差分送信方式）
+     *
+     * @param player 入出金したプレイヤー
+     * @param changeAmount 変化量（入金時は正、出金時は負）
+     */
+    public void notifyBankBalanceChange(Player player, double changeAmount) {
+        // 機能が無効の場合はスキップ
+        if (!plugin.getConfig().getBoolean("api.tohu_app.enabled", false)) {
+            return;
+        }
+
+        // 変化量が0の場合は送信しない
+        if (changeAmount == 0) {
+            return;
+        }
+
+        // 今日の日付（YYYY-MM-DD形式）
+        String today = LocalDate.now().toString();
+
+        // 統計データを作成（変化量を送信）
+        PlayerStatsData data = new PlayerStatsData(
+                player.getUniqueId().toString(),
+                player.getName(),
+                worldId,
+                "bank_balance",
+                today,
+                (long) changeAmount
+        );
+
+        // デバッグモード時はデータをログ出力
+        if (debugMode) {
+            String operation = changeAmount > 0 ? "入金" : "出金";
+            plugin.getLogger().info(String.format(
+                    "[tohu-app API] 預金残高%s送信: %s = %+d",
+                    operation, player.getName(), (long) changeAmount
+            ));
+        }
+
+        // 非同期でAPI送信（入出金処理をブロックしない）
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                boolean success = apiClient.submitStats(data);
+                if (success && debugMode) {
+                    plugin.getLogger().info(String.format(
+                            "[tohu-app API] 預金残高送信成功: %s = %+d",
+                            player.getName(), (long) changeAmount
+                    ));
+                } else if (!success) {
+                    plugin.getLogger().warning(String.format(
+                            "[tohu-app API] 預金残高送信失敗: %s",
+                            player.getName()
+                    ));
+                }
+            } catch (Exception e) {
+                plugin.getLogger().warning(String.format(
+                        "[tohu-app API] 預金残高送信中に例外が発生しました: %s - %s",
+                        player.getName(), e.getMessage()
+                ));
+            }
+        });
+    }
+
+    /**
+     * APIクライアントのクリーンアップ
+     */
+    public void shutdown() {
+        if (apiClient != null) {
+            apiClient.shutdown();
+        }
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/events/EventProcessor.java
+++ b/src/main/java/org/tofu/tofunomics/events/EventProcessor.java
@@ -77,34 +77,44 @@ public class EventProcessor {
     public boolean shouldProcessEvent(Event event) {
         Player player = extractPlayer(event);
         if (player == null) {
+            System.out.println("[EventProcessor] プレイヤー抽出失敗");
             return false;
         }
         
         // プレイヤーの基本チェック
         if (!isValidPlayer(player)) {
+            System.out.println("[EventProcessor] isValidPlayer=false: " + player.getName());
             return false;
         }
         
         // ワールドチェック
+        String worldName = player.getWorld().getName();
+        System.out.println("[EventProcessor] ワールドチェック: " + worldName + ", excludedWorlds=" + excludedWorlds);
         if (!isValidWorld(player.getWorld())) {
+            System.out.println("[EventProcessor] isValidWorld=false: " + worldName);
             return false;
         }
         
         // ゲームモードチェック
+        System.out.println("[EventProcessor] ゲームモードチェック: " + player.getGameMode() + ", excludedGameModes=" + excludedGameModes);
         if (!isValidGameMode(player.getGameMode())) {
+            System.out.println("[EventProcessor] isValidGameMode=false: " + player.getGameMode());
             return false;
         }
         
         // 権限チェック
         if (!hasRequiredPermission(player, event)) {
+            System.out.println("[EventProcessor] hasRequiredPermission=false");
             return false;
         }
         
         // 職業チェック
         if (!hasValidJob(player, event)) {
+            System.out.println("[EventProcessor] hasValidJob=false");
             return false;
         }
         
+        System.out.println("[EventProcessor] すべてのチェックをパス");
         return true;
     }
     

--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -3,6 +3,7 @@ package org.tofu.tofunomics.events;
 import org.bukkit.Material;
 import org.bukkit.Location;
 import org.bukkit.ChatColor;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import java.util.HashSet;
 import java.util.Set;
@@ -18,6 +19,7 @@ import org.bukkit.event.entity.EntityBreedEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.inventory.BrewEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
+import org.bukkit.event.inventory.FurnaceExtractEvent;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.tofu.tofunomics.config.ConfigManager;
@@ -71,7 +73,8 @@ public class UnifiedEventHandler implements Listener {
                               JobManager jobManager,
                               org.tofu.tofunomics.experience.JobExperienceManager experienceManager,
                               org.tofu.tofunomics.quests.JobQuestManager questManager,
-                              org.tofu.tofunomics.jobs.JobBlockPermissionManager blockPermissionManager) {
+                              org.tofu.tofunomics.jobs.JobBlockPermissionManager blockPermissionManager,
+                              AsyncEventUpdater asyncUpdater) {
         this.plugin = plugin;
         this.configManager = configManager;
         this.playerDAO = playerDAO;
@@ -89,7 +92,7 @@ public class UnifiedEventHandler implements Listener {
         // サブシステムの初期化
         this.eventCache = new EventCache(plugin);
         this.eventProcessor = new EventProcessor(configManager, jobManager);
-        this.asyncUpdater = new AsyncEventUpdater(plugin, playerDAO, playerJobDAO);
+        this.asyncUpdater = asyncUpdater;
         
         // 個別ハンドラの初期化
         this.brewingHandler = new org.tofu.tofunomics.events.handlers.BrewingEventHandler(
@@ -162,6 +165,36 @@ public class UnifiedEventHandler implements Listener {
         // プレイヤーが設置したブロックの場合は経験値を付与しない
         if (!isPlayerPlaced) {
             experienceManager.onBlockBreak(event);
+            
+            // エンチャンターのラピス採掘ボーナス
+            if (blockType == Material.LAPIS_ORE || blockType.name().equals("DEEPSLATE_LAPIS_ORE")) {
+                if (jobManager.hasJob(player, "enchanter")) {
+                    PlayerJob enchanterJob = jobManager.getPlayerJob(player, "enchanter");
+                    if (enchanterJob != null && enchanterJob.isActive()) {
+                        double lapisExp = 8.0;  // ラピス採掘ボーナス
+                        double lapisIncome = 5.0;  // ラピス採掘収入
+                        String playerUUID = player.getUniqueId().toString();
+                        asyncUpdater.updateJobExperience(playerUUID, "enchanter", lapisExp);
+                        asyncUpdater.updatePlayerBalance(playerUUID, lapisIncome, "エンチャンターラピス採掘報酬");
+                        player.sendMessage("§d§l[エンチャント] §bラピス採掘ボーナス! §a+" + lapisExp + "経験値 §6+" + lapisIncome + "金塊");
+                    }
+                }
+            }
+            
+            // 調合師のネザーウォート収穫ボーナス
+            if (blockType == Material.NETHER_WART) {
+                if (jobManager.hasJob(player, "alchemist")) {
+                    PlayerJob alchemistJob = jobManager.getPlayerJob(player, "alchemist");
+                    if (alchemistJob != null && alchemistJob.isActive()) {
+                        double wartExp = 5.0;  // ネザーウォート収穫ボーナス
+                        double wartIncome = 3.0;  // ネザーウォート収穫収入
+                        String playerUUID = player.getUniqueId().toString();
+                        asyncUpdater.updateJobExperience(playerUUID, "alchemist", wartExp);
+                        asyncUpdater.updatePlayerBalance(playerUUID, wartIncome, "調合師ネザーウォート収穫報酬");
+                        player.sendMessage("§5§l[調合] §dネザーウォート収穫ボーナス! §a+" + wartExp + "経験値 §6+" + wartIncome + "金塊");
+                    }
+                }
+            }
         } else {
             System.out.println("プレイヤー設置ブロックのため経験値なし");
         }
@@ -185,7 +218,9 @@ public class UnifiedEventHandler implements Listener {
             return;
         }
         
-        if (!shouldProcessEvent(event)) return;
+        if (!shouldProcessEvent(event)) {
+            return;
+        }
         
         // プレイヤーが設置したブロックを記録（メモリ内追跡）
         // STONE, COBBLESTONEなど経験値対象ブロックのみ追跡（鉱石は除外）
@@ -208,7 +243,9 @@ public class UnifiedEventHandler implements Listener {
     
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockGrow(BlockGrowEvent event) {
-        if (!shouldProcessEvent(event)) return;
+        if (!shouldProcessEvent(event)) {
+            return;
+        }
         
         // 農家の作物成長処理
         growthHandler.handleBlockGrow(event);
@@ -219,7 +256,9 @@ public class UnifiedEventHandler implements Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onCraftItem(CraftItemEvent event) {
         plugin.getLogger().info("=== onCraftItem メソッド開始 ===");
-        if (!shouldProcessEvent(event)) return;
+        if (!shouldProcessEvent(event)) {
+            return;
+        }
         if (!(event.getWhoClicked() instanceof Player)) return;
         
         Player player = (Player) event.getWhoClicked();
@@ -259,13 +298,42 @@ public class UnifiedEventHandler implements Listener {
         experienceManager.onCraftItem(event);
         questManager.onCraftItem(event);
         
+        // エンチャンターの本棚クラフトボーナス
+        if (craftedItem == Material.BOOKSHELF || craftedItem == Material.ENCHANTING_TABLE) {
+            if (jobManager.hasJob(player, "enchanter")) {
+                PlayerJob enchanterJob = jobManager.getPlayerJob(player, "enchanter");
+                if (enchanterJob != null && enchanterJob.isActive()) {
+                    double craftExp = (craftedItem == Material.ENCHANTING_TABLE) ? 15.0 : 5.0;
+                    double craftIncome = (craftedItem == Material.ENCHANTING_TABLE) ? 5.0 : 3.0;
+                    String playerUUID = player.getUniqueId().toString();
+                    asyncUpdater.updateJobExperience(playerUUID, "enchanter", craftExp);
+                    asyncUpdater.updatePlayerBalance(playerUUID, craftIncome, "エンチャンタークラフト報酬");
+                    String itemName = (craftedItem == Material.ENCHANTING_TABLE) ? "エンチャントテーブル" : "本棚";
+                    player.sendMessage("§d§l[エンチャント] §b" + itemName + "クラフトボーナス! §a+" + craftExp + "経験値 §6+" + craftIncome + "金塊");
+                }
+            }
+        }
+        
+        // 鍛冶屋のクラフト収入
+        if (jobManager.hasJob(player, "blacksmith")) {
+            PlayerJob blacksmithJob = jobManager.getPlayerJob(player, "blacksmith");
+            if (blacksmithJob != null && blacksmithJob.isActive()) {
+                double craftIncome = getBlacksmithCraftIncome(craftedItem);
+                if (craftIncome > 0) {
+                    asyncUpdater.updatePlayerBalance(player.getUniqueId().toString(), craftIncome, "鍛冶屋クラフト報酬");
+                }
+            }
+        }
+        
         // キャッシュに記録
         eventCache.markAsProcessed(player, "craft_item");
     }
     
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBrew(BrewEvent event) {
-        if (!shouldProcessEvent(event)) return;
+        if (!shouldProcessEvent(event)) {
+            return;
+        }
         
         // 調合師専用処理
         brewingHandler.handleBrew(event);
@@ -273,7 +341,9 @@ public class UnifiedEventHandler implements Listener {
     
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEnchantItem(EnchantItemEvent event) {
-        if (!shouldProcessEvent(event)) return;
+        if (!shouldProcessEvent(event)) {
+            return;
+        }
         
         Player player = event.getEnchanter();
         
@@ -288,15 +358,67 @@ public class UnifiedEventHandler implements Listener {
         // 魔術師専用処理
         enchantmentHandler.handleEnchantment(event);
         
+        // エンチャンターの収入付与
+        if (jobManager.hasJob(player, "enchanter")) {
+            PlayerJob enchanterJob = jobManager.getPlayerJob(player, "enchanter");
+            if (enchanterJob != null && enchanterJob.isActive()) {
+                int expLevelCost = event.getExpLevelCost();
+                double enchantIncome = getEnchantmentIncome(expLevelCost);
+                if (enchantIncome > 0) {
+                    asyncUpdater.updatePlayerBalance(player.getUniqueId().toString(), enchantIncome, "エンチャント報酬");
+                }
+            }
+        }
+        
         // キャッシュに記録
         eventCache.markAsProcessed(player, "enchant_item");
+    }
+    
+    // ========== 精錬関連イベント ==========
+    
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onFurnaceExtract(FurnaceExtractEvent event) {
+        Player player = event.getPlayer();
+        Material extractedItem = event.getItemType();
+        int amount = event.getItemAmount();
+        
+        // 鍛冶屋の精錬完了ボーナス（鉄・金インゴット精錬時）
+        if (jobManager.hasJob(player, "blacksmith")) {
+            PlayerJob blacksmithJob = jobManager.getPlayerJob(player, "blacksmith");
+            if (blacksmithJob != null && blacksmithJob.isActive()) {
+                double smeltExp = 0.0;
+                String itemName = null;
+                
+                if (extractedItem == Material.IRON_INGOT) {
+                    smeltExp = 3.0;
+                    itemName = "鉄インゴット";
+                } else if (extractedItem == Material.GOLD_INGOT) {
+                    smeltExp = 4.0;
+                    itemName = "金インゴット";
+                } else if (extractedItem == Material.NETHERITE_SCRAP) {
+                    smeltExp = 10.0;
+                    itemName = "ネザライトスクラップ";
+                }
+                
+                if (smeltExp > 0) {
+                    double totalExp = smeltExp * amount;
+                    double smeltIncome = 2.0 * amount;  // 精錬収入: 1個あたり2.0金塊
+                    String playerUUID = player.getUniqueId().toString();
+                    asyncUpdater.updateJobExperience(playerUUID, "blacksmith", totalExp);
+                    asyncUpdater.updatePlayerBalance(playerUUID, smeltIncome, "鍛冶屋精錬報酬");
+                    player.sendMessage("§6§l[鍛冶] §e" + itemName + "精錬ボーナス! §a+" + totalExp + "経験値 §6+" + smeltIncome + "金塊 §7(x" + amount + ")");
+                }
+            }
+        }
     }
     
     // ========== エンティティ関連イベント ==========
     
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEntityDeath(EntityDeathEvent event) {
-        if (!shouldProcessEvent(event)) return;
+        if (!shouldProcessEvent(event)) {
+            return;
+        }
         if (event.getEntity().getKiller() == null) return;
         
         Player player = event.getEntity().getKiller();
@@ -304,6 +426,52 @@ public class UnifiedEventHandler implements Listener {
         // キャッシュチェック
         if (eventCache.isRecentlyProcessed(player, "entity_death", 100)) {
             return;
+        }
+        
+        // 調合師のモンスター素材採取ボーナス
+        Entity entity = event.getEntity();
+        if (jobManager.hasJob(player, "alchemist")) {
+            PlayerJob alchemistJob = jobManager.getPlayerJob(player, "alchemist");
+            if (alchemistJob != null && alchemistJob.isActive()) {
+                double materialExp = 0.0;
+                String materialName = null;
+                
+                // ブレイズ討伐 → ブレイズロッド
+                if (entity.getType() == org.bukkit.entity.EntityType.BLAZE) {
+                    materialExp = 8.0;
+                    materialName = "ブレイズロッド";
+                }
+                // ガスト討伐 → ガストの涙
+                else if (entity.getType() == org.bukkit.entity.EntityType.GHAST) {
+                    materialExp = 10.0;
+                    materialName = "ガストの涙";
+                }
+                // ファントム討伐 → ファントムの皮膜
+                else if (entity.getType() == org.bukkit.entity.EntityType.PHANTOM) {
+                    materialExp = 6.0;
+                    materialName = "ファントムの皮膜";
+                }
+                // マグマキューブ討伐 → マグマクリーム
+                else if (entity.getType() == org.bukkit.entity.EntityType.MAGMA_CUBE) {
+                    materialExp = 5.0;
+                    materialName = "マグマクリーム";
+                }
+                // ウサギ討伐 → ウサギの足（希少）
+                else if (entity.getType() == org.bukkit.entity.EntityType.RABBIT) {
+                    materialExp = 3.0;  // ドロップ率が低いので基本経験値は低め
+                    materialName = "ウサギ素材";
+                }
+                
+                if (materialExp > 0) {
+                    double materialIncome = getMaterialIncomeForEntity(entity);
+                    String playerUUID = player.getUniqueId().toString();
+                    asyncUpdater.updateJobExperience(playerUUID, "alchemist", materialExp);
+                    if (materialIncome > 0) {
+                        asyncUpdater.updatePlayerBalance(playerUUID, materialIncome, "調合師素材採取報酬");
+                    }
+                    player.sendMessage("§5§l[調合] §d" + materialName + "素材ボーナス! §a+" + materialExp + "経験値 §6+" + materialIncome + "金塊");
+                }
+            }
         }
         
         // エンティティ討伐による基本的な報酬処理（将来実装）
@@ -315,7 +483,9 @@ public class UnifiedEventHandler implements Listener {
     
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEntityBreed(EntityBreedEvent event) {
-        if (!shouldProcessEvent(event)) return;
+        if (!shouldProcessEvent(event)) {
+            return;
+        }
         if (!(event.getBreeder() instanceof Player)) return;
         
         Player player = (Player) event.getBreeder();
@@ -336,7 +506,9 @@ public class UnifiedEventHandler implements Listener {
     
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerFish(PlayerFishEvent event) {
-        if (!shouldProcessEvent(event)) return;
+        if (!shouldProcessEvent(event)) {
+            return;
+        }
         if (event.getState() != PlayerFishEvent.State.CAUGHT_FISH) return;
         
         Player player = event.getPlayer();
@@ -571,6 +743,135 @@ public class UnifiedEventHandler implements Listener {
         }
     }
     
+
+    /**
+     * 鍛冶屋のクラフト収入を取得
+     */
+    private double getBlacksmithCraftIncome(Material material) {
+        switch (material) {
+            // 鉄ツール
+            case IRON_SWORD:
+                return 8.0;
+            case IRON_PICKAXE:
+                return 10.0;
+            case IRON_AXE:
+                return 10.0;
+            case IRON_SHOVEL:
+                return 6.0;
+            case IRON_HOE:
+                return 6.0;
+            // ダイヤツール
+            case DIAMOND_SWORD:
+                return 25.0;
+            case DIAMOND_PICKAXE:
+                return 30.0;
+            case DIAMOND_AXE:
+                return 30.0;
+            case DIAMOND_SHOVEL:
+                return 20.0;
+            case DIAMOND_HOE:
+                return 20.0;
+            // ネザライトツール
+            case NETHERITE_SWORD:
+                return 50.0;
+            case NETHERITE_PICKAXE:
+                return 60.0;
+            case NETHERITE_AXE:
+                return 60.0;
+            case NETHERITE_SHOVEL:
+                return 40.0;
+            case NETHERITE_HOE:
+                return 40.0;
+            // 鉄防具
+            case IRON_HELMET:
+                return 8.0;
+            case IRON_CHESTPLATE:
+                return 12.0;
+            case IRON_LEGGINGS:
+                return 10.0;
+            case IRON_BOOTS:
+                return 8.0;
+            // ダイヤ防具
+            case DIAMOND_HELMET:
+                return 20.0;
+            case DIAMOND_CHESTPLATE:
+                return 30.0;
+            case DIAMOND_LEGGINGS:
+                return 25.0;
+            case DIAMOND_BOOTS:
+                return 20.0;
+            // ネザライト防具
+            case NETHERITE_HELMET:
+                return 40.0;
+            case NETHERITE_CHESTPLATE:
+                return 60.0;
+            case NETHERITE_LEGGINGS:
+                return 50.0;
+            case NETHERITE_BOOTS:
+                return 40.0;
+            // その他
+            case SHIELD:
+                return 10.0;
+            case CHAINMAIL_HELMET:
+            case CHAINMAIL_CHESTPLATE:
+            case CHAINMAIL_LEGGINGS:
+            case CHAINMAIL_BOOTS:
+                return 15.0;
+            case ANVIL:
+                return 20.0;
+            case IRON_BLOCK:
+                return 5.0;
+            case GOLD_BLOCK:
+                return 8.0;
+            case DIAMOND_BLOCK:
+                return 25.0;
+            case NETHERITE_BLOCK:
+                return 100.0;
+            default:
+                return 0.0;
+        }
+    }
+
+
+    /**
+     * エンチャントレベルに応じた収入を取得
+     */
+    private double getEnchantmentIncome(int expLevelCost) {
+        if (expLevelCost >= 30) {
+            return 65.0;  // Lv5相当
+        } else if (expLevelCost >= 24) {
+            return 45.0;  // Lv4相当
+        } else if (expLevelCost >= 18) {
+            return 30.0;  // Lv3相当
+        } else if (expLevelCost >= 12) {
+            return 18.0;  // Lv2相当
+        } else if (expLevelCost >= 1) {
+            return 10.0;  // Lv1相当
+        }
+        return 0.0;
+    }
+
+
+    /**
+     * 調合師の素材採取収入を取得
+     */
+    private double getMaterialIncomeForEntity(org.bukkit.entity.Entity entity) {
+        switch (entity.getType()) {
+            case BLAZE:
+                return 5.0;  // ブレイズロッド
+            case GHAST:
+                return 8.0;  // ガストの涙
+            case PHANTOM:
+                return 5.0;  // ファントムの皮膜
+            case MAGMA_CUBE:
+                return 4.0;  // マグマクリーム
+            case RABBIT:
+                return 3.0;  // ウサギの足
+            default:
+                return 0.0;
+        }
+    }
+
     /**
      * イベント統計クラス
      */

--- a/src/main/java/org/tofu/tofunomics/events/handlers/BrewingEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/handlers/BrewingEventHandler.java
@@ -52,18 +52,27 @@ public class BrewingEventHandler {
      * ポーション報酬テーブルの初期化
      */
     private void initializePotionRewards() {
-        // 通常ポーション
-        potionRewards.put(Material.POTION, new PotionReward(2.0, 3.0));
+        // 通常ポーション（上方修正版）
+        potionRewards.put(Material.POTION, new PotionReward(5.0, 6.0));               // 2.0→5.0 (+150%)
         
-        // スプラッシュポーション
-        potionRewards.put(Material.SPLASH_POTION, new PotionReward(3.0, 5.0));
+        // スプラッシュポーション（上方修正版）
+        potionRewards.put(Material.SPLASH_POTION, new PotionReward(8.0, 10.0));       // 3.0→8.0 (+167%)
         
-        // 残留ポーション
-        potionRewards.put(Material.LINGERING_POTION, new PotionReward(5.0, 8.0));
+        // 残留ポーション（上方修正版）
+        potionRewards.put(Material.LINGERING_POTION, new PotionReward(12.0, 16.0));   // 5.0→12.0 (+140%)
         
-        // 特殊アイテム（ブレイズパウダー製作など）
-        potionRewards.put(Material.BLAZE_POWDER, new PotionReward(1.0, 2.0));
-        potionRewards.put(Material.MAGMA_CREAM, new PotionReward(2.0, 3.0));
+        // 特殊アイテム（ブレイズパウダー製作など）- 上方修正版
+        potionRewards.put(Material.BLAZE_POWDER, new PotionReward(3.0, 4.0));         // 1.0→3.0 (+200%)
+        potionRewards.put(Material.MAGMA_CREAM, new PotionReward(5.0, 6.0));          // 2.0→5.0 (+150%)
+        
+        // 新規追加：素材採取ボーナス用アイテム
+        potionRewards.put(Material.NETHER_WART, new PotionReward(5.0, 3.0));          // ネザーウォート収穫
+        potionRewards.put(Material.BLAZE_ROD, new PotionReward(8.0, 5.0));            // ブレイズロッド入手
+        potionRewards.put(Material.GHAST_TEAR, new PotionReward(10.0, 8.0));          // ガストの涙
+        potionRewards.put(Material.PHANTOM_MEMBRANE, new PotionReward(6.0, 5.0));     // ファントムの皮膜
+        potionRewards.put(Material.FERMENTED_SPIDER_EYE, new PotionReward(4.0, 3.0)); // 発酵した蜘蛛の目
+        potionRewards.put(Material.RABBIT_FOOT, new PotionReward(7.0, 5.0));          // ウサギの足
+        potionRewards.put(Material.GLISTERING_MELON_SLICE, new PotionReward(4.0, 3.0)); // きらめくスイカ
     }
     
     /**
@@ -146,8 +155,13 @@ public class BrewingEventHandler {
                              double income, int potionCount) {
         String playerUUID = player.getUniqueId().toString();
         
-        // 非同期で経験値を更新（収入システムは無効化）
+        // 非同期で経験値と収入を更新
         asyncUpdater.updateJobExperience(playerUUID, "alchemist", experience);
+        
+        // 収入を銀行預金に加算
+        if (income > 0) {
+            asyncUpdater.updatePlayerBalance(playerUUID, income, "調合報酬");
+        }
         
         // メッセージ表示
         String message = String.format(

--- a/src/main/java/org/tofu/tofunomics/events/handlers/BuildingEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/handlers/BuildingEventHandler.java
@@ -1,5 +1,6 @@
 package org.tofu.tofunomics.events.handlers;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -56,49 +57,53 @@ public class BuildingEventHandler {
      * 建築報酬テーブルの初期化
      */
     private void initializeBuildingRewards() {
-        // 基本建築材料
-        buildingRewards.put(Material.STONE, new BuildingReward(0.5, 1.0, "石"));
-        buildingRewards.put(Material.COBBLESTONE, new BuildingReward(0.3, 0.8, "丸石"));
-        buildingRewards.put(Material.STONE_BRICKS, new BuildingReward(1.0, 2.0, "石レンガ"));
+        // 基本建築材料（上方修正版）
+        buildingRewards.put(Material.STONE, new BuildingReward(2.0, 1.0, "石"));                     // 0.5→2.0 (+300%)
+        buildingRewards.put(Material.COBBLESTONE, new BuildingReward(1.5, 0.8, "丸石"));             // 0.3→1.5 (+400%)
+        buildingRewards.put(Material.STONE_BRICKS, new BuildingReward(3.0, 2.0, "石レンガ"));        // 1.0→3.0 (+200%)
         
-        // 木材系
-        buildingRewards.put(Material.OAK_PLANKS, new BuildingReward(0.8, 1.5, "オークの板材"));
-        buildingRewards.put(Material.BIRCH_PLANKS, new BuildingReward(0.8, 1.5, "シラカバの板材"));
-        buildingRewards.put(Material.SPRUCE_PLANKS, new BuildingReward(0.8, 1.5, "トウヒの板材"));
-        buildingRewards.put(Material.JUNGLE_PLANKS, new BuildingReward(1.0, 2.0, "ジャングルの板材"));
-        buildingRewards.put(Material.ACACIA_PLANKS, new BuildingReward(1.0, 2.0, "アカシアの板材"));
-        buildingRewards.put(Material.DARK_OAK_PLANKS, new BuildingReward(1.0, 2.0, "ダークオークの板材"));
+        // 木材系（上方修正版）
+        buildingRewards.put(Material.OAK_PLANKS, new BuildingReward(2.0, 1.5, "オークの板材"));      // 0.8→2.0 (+150%)
+        buildingRewards.put(Material.BIRCH_PLANKS, new BuildingReward(2.0, 1.5, "シラカバの板材"));  // 0.8→2.0 (+150%)
+        buildingRewards.put(Material.SPRUCE_PLANKS, new BuildingReward(2.0, 1.5, "トウヒの板材"));   // 0.8→2.0 (+150%)
+        buildingRewards.put(Material.JUNGLE_PLANKS, new BuildingReward(2.5, 2.0, "ジャングルの板材"));
+        buildingRewards.put(Material.ACACIA_PLANKS, new BuildingReward(2.5, 2.0, "アカシアの板材"));
+        buildingRewards.put(Material.DARK_OAK_PLANKS, new BuildingReward(2.5, 2.0, "ダークオークの板材"));
         
-        // レンガ系
-        buildingRewards.put(Material.BRICKS, new BuildingReward(2.0, 4.0, "レンガ"));
-        buildingRewards.put(Material.NETHER_BRICKS, new BuildingReward(3.0, 6.0, "ネザーレンガ"));
-        buildingRewards.put(Material.RED_NETHER_BRICKS, new BuildingReward(3.5, 7.0, "赤いネザーレンガ"));
+        // レンガ系（上方修正版）
+        buildingRewards.put(Material.BRICKS, new BuildingReward(5.0, 4.0, "レンガ"));                // 2.0→5.0 (+150%)
+        buildingRewards.put(Material.NETHER_BRICKS, new BuildingReward(7.0, 6.0, "ネザーレンガ"));   // 3.0→7.0 (+133%)
+        buildingRewards.put(Material.RED_NETHER_BRICKS, new BuildingReward(8.0, 7.0, "赤いネザーレンガ"));
         
-        // 高級建築材料
-        buildingRewards.put(Material.QUARTZ_BLOCK, new BuildingReward(5.0, 10.0, "クォーツブロック"));
-        buildingRewards.put(Material.CHISELED_QUARTZ_BLOCK, new BuildingReward(6.0, 12.0, "模様入りクォーツ"));
-        buildingRewards.put(Material.QUARTZ_PILLAR, new BuildingReward(6.0, 12.0, "クォーツの柱"));
+        // 高級建築材料（上方修正版）
+        buildingRewards.put(Material.QUARTZ_BLOCK, new BuildingReward(10.0, 10.0, "クォーツブロック"));        // 5.0→10.0 (+100%)
+        buildingRewards.put(Material.CHISELED_QUARTZ_BLOCK, new BuildingReward(12.0, 12.0, "模様入りクォーツ"));
+        buildingRewards.put(Material.QUARTZ_PILLAR, new BuildingReward(12.0, 12.0, "クォーツの柱"));
         
-        // 特殊ブロック
-        buildingRewards.put(Material.OBSIDIAN, new BuildingReward(10.0, 20.0, "黒曜石"));
-        buildingRewards.put(Material.END_STONE, new BuildingReward(8.0, 15.0, "エンドストーン"));
-        buildingRewards.put(Material.PURPUR_BLOCK, new BuildingReward(7.0, 14.0, "プルプァブロック"));
+        // 特殊ブロック（上方修正版）
+        buildingRewards.put(Material.OBSIDIAN, new BuildingReward(15.0, 20.0, "黒曜石"));            // 10.0→15.0 (+50%)
+        buildingRewards.put(Material.END_STONE, new BuildingReward(12.0, 15.0, "エンドストーン"));   // 8.0→12.0 (+50%)
+        buildingRewards.put(Material.PURPUR_BLOCK, new BuildingReward(12.0, 14.0, "プルプァブロック")); // 7.0→12.0 (+71%)
+        buildingRewards.put(Material.END_STONE_BRICKS, new BuildingReward(15.0, 16.0, "エンドストーンレンガ")); // 新規追加
+        buildingRewards.put(Material.PRISMARINE, new BuildingReward(10.0, 12.0, "プリズマリン"));    // 新規追加
+        buildingRewards.put(Material.PRISMARINE_BRICKS, new BuildingReward(12.0, 14.0, "プリズマリンレンガ")); // 新規追加
+        buildingRewards.put(Material.DARK_PRISMARINE, new BuildingReward(14.0, 16.0, "ダークプリズマリン")); // 新規追加
         
-        // 装飾ブロック
-        buildingRewards.put(Material.CHISELED_STONE_BRICKS, new BuildingReward(3.0, 6.0, "模様入り石レンガ"));
-        buildingRewards.put(Material.MOSSY_STONE_BRICKS, new BuildingReward(2.5, 5.0, "苔石レンガ"));
-        buildingRewards.put(Material.CRACKED_STONE_BRICKS, new BuildingReward(2.0, 4.0, "ひび入り石レンガ"));
+        // 装飾ブロック（上方修正版）
+        buildingRewards.put(Material.CHISELED_STONE_BRICKS, new BuildingReward(6.0, 6.0, "模様入り石レンガ"));
+        buildingRewards.put(Material.MOSSY_STONE_BRICKS, new BuildingReward(5.0, 5.0, "苔石レンガ"));
+        buildingRewards.put(Material.CRACKED_STONE_BRICKS, new BuildingReward(4.0, 4.0, "ひび入り石レンガ"));
         
-        // ガラス系
-        buildingRewards.put(Material.GLASS, new BuildingReward(1.5, 3.0, "ガラス"));
-        buildingRewards.put(Material.WHITE_STAINED_GLASS, new BuildingReward(2.0, 4.0, "白色のガラス"));
-        buildingRewards.put(Material.BLUE_STAINED_GLASS, new BuildingReward(2.0, 4.0, "青色のガラス"));
+        // ガラス系（上方修正版）
+        buildingRewards.put(Material.GLASS, new BuildingReward(3.0, 3.0, "ガラス"));                 // 1.5→3.0 (+100%)
+        buildingRewards.put(Material.WHITE_STAINED_GLASS, new BuildingReward(4.0, 4.0, "白色のガラス"));
+        buildingRewards.put(Material.BLUE_STAINED_GLASS, new BuildingReward(4.0, 4.0, "青色のガラス"));
         // 他の色ガラスも同様に設定...
         
-        // 1.16以降のブロック
-        buildingRewards.put(Material.BLACKSTONE, new BuildingReward(1.0, 2.0, "ブラックストーン"));
-        buildingRewards.put(Material.POLISHED_BLACKSTONE, new BuildingReward(2.0, 4.0, "磨かれたブラックストーン"));
-        buildingRewards.put(Material.CHISELED_POLISHED_BLACKSTONE, new BuildingReward(3.0, 6.0, "模様入り磨かれたブラックストーン"));
+        // 1.16以降のブロック（上方修正版）
+        buildingRewards.put(Material.BLACKSTONE, new BuildingReward(3.0, 2.0, "ブラックストーン"));
+        buildingRewards.put(Material.POLISHED_BLACKSTONE, new BuildingReward(5.0, 4.0, "磨かれたブラックストーン"));
+        buildingRewards.put(Material.CHISELED_POLISHED_BLACKSTONE, new BuildingReward(7.0, 6.0, "模様入り磨かれたブラックストーン"));
     }
     
     /**
@@ -134,7 +139,7 @@ public class BuildingEventHandler {
         Material material = block.getType();
         
         // 建築家の職業チェック
-        PlayerJob builderJob = jobManager.getPlayerJob(player, "builder");
+        PlayerJob builderJob = jobManager.getPlayerJob(player, "architect");
         if (builderJob == null || !builderJob.isActive()) {
             // 建築家でない場合は装飾ブロック制限をチェック
             if (decorativeBlocks.contains(material) && !hasDecorativePermission(player, material)) {
@@ -174,14 +179,25 @@ public class BuildingEventHandler {
         double finalExperience = reward.getExperience() * levelMultiplier;
         double finalIncome = reward.getIncome() * levelMultiplier;
         
+        // 高所設置ボーナス (+30%) - Y座標100以上
+        if (location.getY() >= 100) {
+            finalExperience *= 1.30;
+            finalIncome *= 1.30;
+        }
+        
         // 建築プロジェクトボーナスをチェック
         double projectBonus = checkBuildingProjectBonus(player, location, material);
         finalExperience *= projectBonus;
         finalIncome *= projectBonus;
         
-        // 非同期で経験値を付与（収入システムは無効化）
+        // 非同期で経験値と収入を付与
         String playerUUID = player.getUniqueId().toString();
-        asyncUpdater.updateJobExperience(playerUUID, "builder", finalExperience);
+        asyncUpdater.updateJobExperience(playerUUID, "architect", finalExperience);
+        
+        // 収入を銀行預金に加算
+        if (finalIncome > 0) {
+            asyncUpdater.updatePlayerBalance(playerUUID, finalIncome, "建築報酬: " + reward.getDisplayName());
+        }
         
         // 建築スキル発動チェック
         checkBuildingSkills(player, builderJob, material, location);
@@ -217,14 +233,16 @@ public class BuildingEventHandler {
         if (project.isRelatedBlock(location, material)) {
             project.addBlock(location, material);
             
-            // プロジェクト規模によるボーナス
+            // プロジェクト規模によるボーナス（閾値緩和版）
             int blockCount = project.getBlockCount();
             if (blockCount >= 100) {
                 return 2.0; // 大規模建築：100%ボーナス
             } else if (blockCount >= 50) {
                 return 1.5; // 中規模建築：50%ボーナス
-            } else if (blockCount >= 20) {
-                return 1.2; // 小規模建築：20%ボーナス
+            } else if (blockCount >= 25) {
+                return 1.3; // 小規模建築：30%ボーナス（新規追加）
+            } else if (blockCount >= 10) {  // 20→10に緩和
+                return 1.2; // 超小規模建築：20%ボーナス
             }
         } else {
             // 新しいプロジェクト開始

--- a/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
+++ b/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
@@ -21,6 +21,8 @@ import org.tofu.tofunomics.jobs.ExperienceManager;
 import org.tofu.tofunomics.models.PlayerJob;
 import org.tofu.tofunomics.models.Job;
 import org.tofu.tofunomics.tools.JobToolManager;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.tutorial.TutorialEventListener;
 
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +39,7 @@ public class JobExperienceManager implements Listener {
     private final JobManager jobManager;
     private final JobToolManager jobToolManager;
     private final ExperienceManager experienceManager;
+    private final org.tofu.tofunomics.events.AsyncEventUpdater asyncUpdater;
     
     // 経験値テーブル
     private final Map<Material, Double> miningExperience;
@@ -50,13 +53,15 @@ public class JobExperienceManager implements Listener {
     
     public JobExperienceManager(ConfigManager configManager, PlayerJobDAO playerJobDAO, 
                                JobDAO jobDAO, JobManager jobManager, JobToolManager jobToolManager,
-                               ExperienceManager experienceManager) {
+                               ExperienceManager experienceManager,
+                               org.tofu.tofunomics.events.AsyncEventUpdater asyncUpdater) {
         this.configManager = configManager;
         this.playerJobDAO = playerJobDAO;
         this.jobDAO = jobDAO;
         this.jobManager = jobManager;
         this.jobToolManager = jobToolManager;
         this.experienceManager = experienceManager;
+        this.asyncUpdater = asyncUpdater;
         
         this.miningExperience = new HashMap<>();
         this.loggingExperience = new HashMap<>();
@@ -72,10 +77,10 @@ public class JobExperienceManager implements Listener {
     
     private void initializeExperienceTables() {
         // 採掘経験値テーブル
-        miningExperience.put(Material.COAL_ORE, 2.0);
+        miningExperience.put(Material.COAL_ORE, 2.5);
         miningExperience.put(Material.IRON_ORE, 5.0);
         miningExperience.put(Material.GOLD_ORE, 8.0);
-        miningExperience.put(Material.DIAMOND_ORE, 25.0);
+        miningExperience.put(Material.DIAMOND_ORE, 20.0);
         miningExperience.put(Material.EMERALD_ORE, 20.0);
         miningExperience.put(Material.LAPIS_ORE, 4.0);
         miningExperience.put(Material.REDSTONE_ORE, 3.0);
@@ -86,63 +91,85 @@ public class JobExperienceManager implements Listener {
         // COBBLESTONE: 経験値なし（設置→採掘での無限経験値防止）
         
         // 伐採経験値テーブル
-        loggingExperience.put(Material.OAK_LOG, 2.0);
-        loggingExperience.put(Material.BIRCH_LOG, 2.0);
-        loggingExperience.put(Material.SPRUCE_LOG, 2.0);
-        loggingExperience.put(Material.JUNGLE_LOG, 3.0);
-        loggingExperience.put(Material.ACACIA_LOG, 3.0);
-        loggingExperience.put(Material.DARK_OAK_LOG, 3.0);
-        loggingExperience.put(Material.WARPED_STEM, 4.0);
-        loggingExperience.put(Material.CRIMSON_STEM, 4.0);
+        loggingExperience.put(Material.OAK_LOG, 3.0);
+        loggingExperience.put(Material.BIRCH_LOG, 3.0);
+        loggingExperience.put(Material.SPRUCE_LOG, 3.0);
+        loggingExperience.put(Material.JUNGLE_LOG, 4.0);
+        loggingExperience.put(Material.ACACIA_LOG, 4.0);
+        loggingExperience.put(Material.DARK_OAK_LOG, 4.0);
+        loggingExperience.put(Material.WARPED_STEM, 5.0);
+        loggingExperience.put(Material.CRIMSON_STEM, 5.0);
         
         // 農業経験値テーブル
-        farmingExperience.put(Material.WHEAT, 1.5);
-        farmingExperience.put(Material.POTATO, 1.2);
-        farmingExperience.put(Material.CARROT, 1.2);
-        farmingExperience.put(Material.BEETROOT, 2.0);
-        farmingExperience.put(Material.PUMPKIN, 3.0);
-        farmingExperience.put(Material.MELON, 2.5);
-        farmingExperience.put(Material.SUGAR_CANE, 1.0);
-        farmingExperience.put(Material.COCOA_BEANS, 2.5);
-        farmingExperience.put(Material.NETHER_WART, 3.0);
+        farmingExperience.put(Material.WHEAT, 3.0);
+        farmingExperience.put(Material.POTATO, 2.5);
+        farmingExperience.put(Material.CARROT, 2.5);
+        farmingExperience.put(Material.BEETROOT, 3.0);
+        farmingExperience.put(Material.PUMPKIN, 3.5);
+        farmingExperience.put(Material.MELON, 3.0);
+        farmingExperience.put(Material.SUGAR_CANE, 2.0);
+        farmingExperience.put(Material.COCOA_BEANS, 3.0);
+        farmingExperience.put(Material.NETHER_WART, 3.5);
         
-        // 釣り経験値テーブル
-        fishingExperience.put(PlayerFishEvent.State.CAUGHT_FISH, 5.0);
-        fishingExperience.put(PlayerFishEvent.State.CAUGHT_ENTITY, 8.0);
-        fishingExperience.put(PlayerFishEvent.State.IN_GROUND, 1.0);
+        // 釣り経験値テーブル（上方修正版）
+        fishingExperience.put(PlayerFishEvent.State.CAUGHT_FISH, 10.0);      // 5.0 → 10.0 (+100%)
+        fishingExperience.put(PlayerFishEvent.State.CAUGHT_ENTITY, 15.0);    // 8.0 → 15.0 (+88%)
+        fishingExperience.put(PlayerFishEvent.State.IN_GROUND, 2.0);         // 1.0 → 2.0 (+100%)
         
-        // 製作経験値テーブル（鍛冶屋）
-        craftingExperience.put(Material.IRON_INGOT, 3.0);
-        craftingExperience.put(Material.GOLD_INGOT, 5.0);
-        craftingExperience.put(Material.IRON_SWORD, 8.0);
-        craftingExperience.put(Material.IRON_PICKAXE, 10.0);
-        craftingExperience.put(Material.IRON_AXE, 10.0);
-        craftingExperience.put(Material.IRON_SHOVEL, 6.0);
-        craftingExperience.put(Material.DIAMOND_SWORD, 20.0);
-        craftingExperience.put(Material.DIAMOND_PICKAXE, 25.0);
-        craftingExperience.put(Material.DIAMOND_AXE, 25.0);
-        craftingExperience.put(Material.NETHERITE_INGOT, 50.0);
+        // 製作経験値テーブル（鍛冶屋）- 上方修正版
+        craftingExperience.put(Material.IRON_INGOT, 5.0);           // 3.0 → 5.0 (+67%)
+        craftingExperience.put(Material.GOLD_INGOT, 8.0);           // 5.0 → 8.0 (+60%)
+        craftingExperience.put(Material.IRON_SWORD, 12.0);          // 8.0 → 12.0 (+50%)
+        craftingExperience.put(Material.IRON_PICKAXE, 15.0);        // 10.0 → 15.0 (+50%)
+        craftingExperience.put(Material.IRON_AXE, 15.0);            // 10.0 → 15.0 (+50%)
+        craftingExperience.put(Material.IRON_SHOVEL, 9.0);          // 6.0 → 9.0 (+50%)
+        craftingExperience.put(Material.DIAMOND_SWORD, 30.0);       // 20.0 → 30.0 (+50%)
+        craftingExperience.put(Material.DIAMOND_PICKAXE, 35.0);     // 25.0 → 35.0 (+40%)
+        craftingExperience.put(Material.DIAMOND_AXE, 35.0);         // 25.0 → 35.0 (+40%)
+        craftingExperience.put(Material.NETHERITE_INGOT, 75.0);     // 50.0 → 75.0 (+50%)
+        // 新規追加：防具カテゴリ
+        craftingExperience.put(Material.IRON_HELMET, 10.0);
+        craftingExperience.put(Material.IRON_CHESTPLATE, 10.0);
+        craftingExperience.put(Material.IRON_LEGGINGS, 10.0);
+        craftingExperience.put(Material.IRON_BOOTS, 10.0);
+        craftingExperience.put(Material.DIAMOND_HELMET, 25.0);
+        craftingExperience.put(Material.DIAMOND_CHESTPLATE, 25.0);
+        craftingExperience.put(Material.DIAMOND_LEGGINGS, 25.0);
+        craftingExperience.put(Material.DIAMOND_BOOTS, 25.0);
+        // 新規追加：その他装備・素材
+        craftingExperience.put(Material.SHIELD, 8.0);
+        craftingExperience.put(Material.GOLDEN_APPLE, 15.0);
+        craftingExperience.put(Material.IRON_BLOCK, 5.0);
         
-        // 醸造経験値テーブル
-        brewingExperience.put(Material.POTION, 5.0);
-        brewingExperience.put(Material.SPLASH_POTION, 8.0);
-        brewingExperience.put(Material.LINGERING_POTION, 12.0);
+        // 醸造経験値テーブル（上方修正版）
+        brewingExperience.put(Material.POTION, 10.0);               // 5.0 → 10.0 (+100%)
+        brewingExperience.put(Material.SPLASH_POTION, 15.0);        // 8.0 → 15.0 (+88%)
+        brewingExperience.put(Material.LINGERING_POTION, 22.0);     // 12.0 → 22.0 (+83%)
         
-        // エンチャント経験値テーブル（エンチャントレベル別）
-        enchantingExperience.put(1, 10.0);
-        enchantingExperience.put(2, 15.0);
-        enchantingExperience.put(3, 25.0);
-        enchantingExperience.put(4, 35.0);
-        enchantingExperience.put(5, 50.0);
+        // エンチャント経験値テーブル（エンチャントレベル別）- 上方修正版
+        enchantingExperience.put(1, 15.0);      // 10.0 → 15.0 (+50%)
+        enchantingExperience.put(2, 25.0);      // 15.0 → 25.0 (+67%)
+        enchantingExperience.put(3, 40.0);      // 25.0 → 40.0 (+60%)
+        enchantingExperience.put(4, 55.0);      // 35.0 → 55.0 (+57%)
+        enchantingExperience.put(5, 75.0);      // 50.0 → 75.0 (+50%)
         
-        // 建築経験値テーブル
-        buildingExperience.put(Material.STONE, 0.2);
-        buildingExperience.put(Material.COBBLESTONE, 0.1);
-        buildingExperience.put(Material.STONE_BRICKS, 0.5);
-        buildingExperience.put(Material.QUARTZ_BLOCK, 1.0);
-        buildingExperience.put(Material.PRISMARINE, 1.5);
-        buildingExperience.put(Material.PURPUR_BLOCK, 2.0);
-        buildingExperience.put(Material.END_STONE_BRICKS, 2.5);
+        // 建築経験値テーブル（上方修正版）
+        buildingExperience.put(Material.STONE, 0.8);                // 0.2 → 0.8 (+300%)
+        buildingExperience.put(Material.COBBLESTONE, 0.5);          // 0.1 → 0.5 (+400%)
+        buildingExperience.put(Material.STONE_BRICKS, 1.5);         // 0.5 → 1.5 (+200%)
+        buildingExperience.put(Material.QUARTZ_BLOCK, 3.0);         // 1.0 → 3.0 (+200%)
+        buildingExperience.put(Material.PRISMARINE, 4.0);           // 1.5 → 4.0 (+167%)
+        buildingExperience.put(Material.PURPUR_BLOCK, 5.0);         // 2.0 → 5.0 (+150%)
+        buildingExperience.put(Material.END_STONE_BRICKS, 6.0);     // 2.5 → 6.0 (+140%)
+        // 新規追加：板材・レンガ・ガラス
+        buildingExperience.put(Material.OAK_PLANKS, 0.6);
+        buildingExperience.put(Material.BIRCH_PLANKS, 0.6);
+        buildingExperience.put(Material.SPRUCE_PLANKS, 0.6);
+        buildingExperience.put(Material.JUNGLE_PLANKS, 0.6);
+        buildingExperience.put(Material.ACACIA_PLANKS, 0.6);
+        buildingExperience.put(Material.DARK_OAK_PLANKS, 0.6);
+        buildingExperience.put(Material.BRICKS, 2.0);
+        buildingExperience.put(Material.GLASS, 1.0);
     }
     
     @EventHandler
@@ -179,9 +206,52 @@ public class JobExperienceManager implements Listener {
             
             Player player = event.getPlayer();
             if (jobManager.hasJob(player, "fisherman")) {
-                double baseExp = fishingExperience.getOrDefault(event.getState(), 5.0);
+                double baseExp = fishingExperience.getOrDefault(event.getState(), 10.0);
+                
+                // 基本収入（魚自体はNPCで売却可能。直接収入は釣りの待機時間に対する最低保証）
+                double baseIncome = 1.0;  // 通常魚の直接収入
+                boolean isTreasure = false;
+
+                // 宝物釣りボーナス（エンチャント本、鞍、名札など）
+                if (event.getCaught() != null && event.getCaught() instanceof org.bukkit.entity.Item) {
+                    org.bukkit.entity.Item item = (org.bukkit.entity.Item) event.getCaught();
+                    Material itemType = item.getItemStack().getType();
+                    if (itemType == Material.ENCHANTED_BOOK || itemType == Material.SADDLE ||
+                        itemType == Material.NAME_TAG || itemType == Material.NAUTILUS_SHELL ||
+                        itemType == Material.BOW || itemType.name().contains("FISHING_ROD")) {
+                        baseExp += 15.0;  // 宝物釣りボーナス +15exp
+                        baseIncome = 5.0;  // 宝物収入（宝物自体の売却が主収入）
+                        isTreasure = true;
+                        player.sendMessage("§e§l[釣り] §6宝物ボーナス! §e+15経験値 §6+5金塊");
+                    }
+                }
+
+                // エンティティ釣りボーナス
+                if (event.getState() == PlayerFishEvent.State.CAUGHT_ENTITY && !isTreasure) {
+                    baseIncome = 1.5;  // エンティティを釣った場合
+                }
+
+                // 雨天ボーナス（経験値のみ +20%。収入には適用しない）
+                if (player.getWorld().hasStorm()) {
+                    baseExp *= 1.20;
+                }
+
+                // 深夜ボーナス（経験値のみ +15%。収入には適用しない）- 13000-23000 tick
+                long time = player.getWorld().getTime();
+                if (time >= 13000 && time <= 23000) {
+                    baseExp *= 1.15;
+                }
+                
                 double multipliedExp = applyJobMultiplier(player, "fisherman", baseExp);
                 giveJobExperience(player, "fisherman", multipliedExp);
+                
+                // 収入を銀行預金に加算
+                if (asyncUpdater != null && baseIncome > 0) {
+                    asyncUpdater.updatePlayerBalance(player.getUniqueId().toString(), baseIncome, "釣り人報酬");
+                    if (!isTreasure) {
+                        player.sendMessage("§e§l[釣り] §a+" + String.format("%.1f", multipliedExp) + "経験値 §6+" + String.format("%.1f", baseIncome) + "金塊");
+                    }
+                }
             }
         }
     }
@@ -259,8 +329,14 @@ public class JobExperienceManager implements Listener {
         
         // 経験値獲得メッセージ（5経験値以上の場合のみ表示）
         if (experience >= 5.0) {
-            player.sendMessage(ChatColor.GREEN + String.format("+ %.1f %s経験値", 
+            player.sendMessage(ChatColor.GREEN + String.format("+ %.1f %s経験値",
                 experience, configManager.getJobDisplayName(jobName)));
+        }
+
+        // チュートリアル進捗: ステップ2（初収入）完了チェック
+        TutorialEventListener tutorialListener = TofuNomics.getInstance().getTutorialEventListener();
+        if (tutorialListener != null) {
+            tutorialListener.onFirstIncome(player);
         }
     }
     
@@ -296,8 +372,10 @@ public class JobExperienceManager implements Listener {
         PlayerJob playerJob = jobManager.getPlayerJob(player, jobName);
         if (playerJob == null) return baseExperience;
         
-        // レベルが高いほど経験値獲得効率が下がる（現実的な成長曲線）
-        double levelPenalty = Math.max(0.1, 1.0 - (playerJob.getLevel() * 0.01));
+        // レベルが高いほど経験値獲得効率が下がる（config.yml の leveling.experience.level_penalty）
+        double penaltyFactor = configManager.getLevelPenaltyFactor();
+        double penaltyMinimum = configManager.getLevelPenaltyMinimum();
+        double levelPenalty = Math.max(penaltyMinimum, 1.0 - (playerJob.getLevel() * penaltyFactor));
         
         // 設定ファイルの経験値倍率を適用
         Job job = jobDAO.getJobByNameSafe(jobName);

--- a/src/main/java/org/tofu/tofunomics/jobs/ExperienceManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/ExperienceManager.java
@@ -19,7 +19,10 @@ public class ExperienceManager {
         if (level <= 1) {
             return 0.0;
         }
-        return Math.pow(level - 1, 2.2) * 100;
+        // 経験値曲線は config.yml の leveling.experience から取得（運用で再調整可能）
+        double exponent = configManager.getExperienceExponent();
+        int baseMultiplier = configManager.getExperienceBaseMultiplier();
+        return Math.pow(level - 1, exponent) * baseMultiplier;
     }
     
     public double calculateRequiredExperienceForNextLevel(int currentLevel) {

--- a/src/main/java/org/tofu/tofunomics/jobs/JobCraftPermissionManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobCraftPermissionManager.java
@@ -182,7 +182,7 @@ public class JobCraftPermissionManager {
             // 作業台
             Material.CRAFTING_TABLE
         ));
-        jobCraftableItems.put("builder", builderItems);
+        jobCraftableItems.put("architect", builderItems);
     }
     
     /**

--- a/src/main/java/org/tofu/tofunomics/jobs/JobManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobManager.java
@@ -204,6 +204,59 @@ public class JobManager {
         
         return JobLeaveResult.SUCCESS;
     }
+
+    /**
+     * 管理者による強制就職（レベル50制限なし）
+     * @param player 対象プレイヤー
+     * @param jobName 職業名
+     * @return 就職結果
+     */
+    public JobJoinResult forceJoinJob(Player player, String jobName) {
+        String uuid = player.getUniqueId().toString();
+        
+        Job job = jobDAO.getJobByNameSafe(jobName);
+        if (job == null) {
+            return JobJoinResult.JOB_NOT_FOUND;
+        }
+        
+        List<PlayerJob> currentJobs = playerJobDAO.getPlayerJobsByUUID(uuid);
+        int maxJobs = configManager.getMaxJobsPerPlayer();
+        
+        // 既に同じ職業に就いているかチェック
+        for (PlayerJob existingJob : currentJobs) {
+            if (existingJob.getJobId() == job.getId()) {
+                return JobJoinResult.ALREADY_HAS_JOB;
+            }
+        }
+        
+        // 最大職業数チェック（管理者コマンドでも制限）
+        if (currentJobs.size() >= maxJobs) {
+            return JobJoinResult.MAX_JOBS_REACHED;
+        }
+        
+        ensurePlayerExists(player);
+        
+        PlayerJob playerJob = new PlayerJob();
+        playerJob.setUuid(uuid);
+        playerJob.setJobId(job.getId());
+        
+        // job_historyから過去の記録を取得してレベルを復元
+        JobHistory history = jobHistoryDAO.getLatestJobHistory(uuid, job.getId());
+        if (history != null) {
+            // 過去の記録がある場合はレベルを復元
+            playerJob.setLevel(history.getMaxLevel());
+        } else {
+            // 初回就職の場合はレベル1
+            playerJob.setLevel(1);
+        }
+        playerJob.setExperience(0.0);
+        
+        if (!playerJobDAO.insertPlayerJob(playerJob)) {
+            return JobJoinResult.DATABASE_ERROR;
+        }
+        
+        return JobJoinResult.SUCCESS;
+    }
     
     public List<PlayerJob> getPlayerJobs(Player player) {
         return playerJobDAO.getPlayerJobsByUUID(player.getUniqueId().toString());

--- a/src/main/java/org/tofu/tofunomics/npc/NPCListener.java
+++ b/src/main/java/org/tofu/tofunomics/npc/NPCListener.java
@@ -17,6 +17,7 @@ import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.inventory.ItemStack;
 import org.tofu.tofunomics.TofuNomics;
 import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.tutorial.TutorialEventListener;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -151,6 +152,12 @@ public class NPCListener implements Listener {
         if (handled) {
             // 取引セッションを記録
             activeTradingSessions.put(player.getUniqueId(), new TradingSession(npcId, "banker"));
+
+            // チュートリアル進捗: ステップ3（銀行NPC）完了チェック
+            TutorialEventListener tutorialListener = plugin.getTutorialEventListener();
+            if (tutorialListener != null) {
+                tutorialListener.onBankNPCUsed(player);
+            }
         }
     }
     
@@ -166,6 +173,18 @@ public class NPCListener implements Listener {
         if (activeSession != null && activeSession.getNpcId().equals(npcId) && 
             activeSession.getSessionType().equals("trader")) {
             
+            // 営業時間チェックを追加（継続取引の前）
+            NPCManager.NPCData npcData = npcManager.getNPCData(npcId);
+            if (npcData != null) {
+                TradingNPCManager.TradingPost tradingPost = tradingNPCManager.getTradingPostByNPCId(npcId);
+                if (tradingPost != null && !tradingNPCManager.isWithinTradingHours(player, tradingPost)) {
+                    player.sendMessage(configManager.getMessage("npc.trading.outside_hours"));
+                    // セッションをクリア
+                    activeTradingSessions.remove(player.getUniqueId());
+                    return;
+                }
+            }
+            
             // 継続取引：手持ちアイテムを売却処理
             processItemSaleFromInventory(player, npcId);
         } else {
@@ -173,6 +192,12 @@ public class NPCListener implements Listener {
             boolean handled = tradingNPCManager.handleTradingNPCInteraction(player, npcId);
             if (handled) {
                 activeTradingSessions.put(player.getUniqueId(), new TradingSession(npcId, "trader"));
+
+                // チュートリアル進捗: ステップ4（取引NPC）完了チェック
+                TutorialEventListener tutorialListener = plugin.getTutorialEventListener();
+                if (tutorialListener != null) {
+                    tutorialListener.onTradingNPCUsed(player);
+                }
             }
         }
     }
@@ -248,6 +273,16 @@ public class NPCListener implements Listener {
     }
     
     private void processItemSaleFromInventory(Player player, UUID npcId) {
+        // 営業時間チェックを追加（二重チェックとして）
+        NPCManager.NPCData npcData = npcManager.getNPCData(npcId);
+        if (npcData != null) {
+            TradingNPCManager.TradingPost tradingPost = tradingNPCManager.getTradingPostByNPCId(npcId);
+            if (tradingPost != null && !tradingNPCManager.isWithinTradingHours(player, tradingPost)) {
+                player.sendMessage(configManager.getMessage("npc.trading.outside_hours"));
+                return;
+            }
+        }
+
         List<ItemStack> sellableItems = new ArrayList<>();
         
         // プレイヤーのインベントリから売却可能アイテムを収集

--- a/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
@@ -840,7 +840,7 @@ public class TradingNPCManager {
         public Map<Material, Integer> getSoldItems() { return soldItems; }
     }
     
-    private TradingPost getTradingPostByNPCId(UUID npcId) {
+    public TradingPost getTradingPostByNPCId(UUID npcId) {
         return tradingPosts.values().stream()
             .filter(post -> post.getNpcId().equals(npcId))
             .findFirst()
@@ -1306,7 +1306,7 @@ public class TradingNPCManager {
      * 取引営業時間内かどうかをチェック
      * 緊急モードのNPCは24時間営業
      */
-    private boolean isWithinTradingHours(Player player, TradingPost tradingPost) {
+    public boolean isWithinTradingHours(Player player, TradingPost tradingPost) {
         // 緊急モードの場合は常に営業時間内として扱う
         if (tradingPost != null && tradingPost.isEmergencyMode()) {
             plugin.getLogger().info("緊急モードNPCのため、営業時間チェックをスキップ");

--- a/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
@@ -153,6 +153,12 @@ public class TradingGUI implements Listener {
                 }
             }
             
+            // 営業時間チェックを追加（職業チェック後、GUI作成前）
+            if (!tradingNPCManager.isWithinTradingHours(player, tradingPost)) {
+                player.sendMessage(configManager.getMessage("npc.trading.outside_hours"));
+                return;
+            }
+            
             String title = "§6" + tradingPost.getName() + " - アイテム取引";
             plugin.getLogger().info("TradingGUI: GUIタイトル設定完了: " + title);
             
@@ -226,6 +232,12 @@ public class TradingGUI implements Listener {
                 plugin.getLogger().info("TradingGUI: 購入モードのため職業に関係なくGUI開起を続行（割増価格適用）");
             } else {
                 plugin.getLogger().info("TradingGUI: 対応職業です。購入・売却ともに可能");
+            }
+            
+            // 営業時間チェックを追加（職業チェック後、GUI作成前）
+            if (!tradingNPCManager.isWithinTradingHours(player, tradingPost)) {
+                player.sendMessage(configManager.getMessage("npc.trading.outside_hours"));
+                return;
             }
             
             String title = "§6" + tradingPost.getName() + " - アイテム取引";
@@ -833,6 +845,13 @@ public class TradingGUI implements Listener {
     
     private void handleItemSell(Player player, TradingNPCManager.TradingPost tradingPost, 
                                Material material, org.bukkit.event.inventory.ClickType clickType) {
+        // 営業時間チェックを追加（取引実行前）
+        if (!tradingNPCManager.isWithinTradingHours(player, tradingPost)) {
+            player.sendMessage(configManager.getMessage("npc.trading.outside_hours"));
+            player.closeInventory();
+            return;
+        }
+
         int sellAmount;
         
         // まとめ売りアイテムかどうかを判定
@@ -990,6 +1009,13 @@ public class TradingGUI implements Listener {
     
     private void handleItemPurchase(Player player, TradingNPCManager.TradingPost tradingPost,
                                     Material material, org.bukkit.event.inventory.ClickType clickType) {
+        // 営業時間チェックを追加（取引実行前）
+        if (!tradingNPCManager.isWithinTradingHours(player, tradingPost)) {
+            player.sendMessage(configManager.getMessage("npc.trading.outside_hours"));
+            player.closeInventory();
+            return;
+        }
+
         int purchaseAmount;
 
         switch (clickType) {
@@ -1071,6 +1097,13 @@ public class TradingGUI implements Listener {
     }
     
     private void handleSellAll(Player player, TradingNPCManager.TradingPost tradingPost) {
+        // 営業時間チェックを追加（取引実行前）
+        if (!tradingNPCManager.isWithinTradingHours(player, tradingPost)) {
+            player.sendMessage(configManager.getMessage("npc.trading.outside_hours"));
+            player.closeInventory();
+            return;
+        }
+
         List<ItemStack> allItems = new ArrayList<>();
         
         for (ItemStack item : player.getInventory().getContents()) {

--- a/src/main/java/org/tofu/tofunomics/npc/gui/TradingModeSelectionGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/TradingModeSelectionGUI.java
@@ -26,14 +26,16 @@ public class TradingModeSelectionGUI implements Listener {
     private final TofuNomics plugin;
     private final ConfigManager configManager;
     private final TradingGUI tradingGUI;
+    private final TradingNPCManager tradingNPCManager;
 
     // アクティブなモード選択セッション
     private final Map<UUID, ModeSelectionSession> activeSessions = new ConcurrentHashMap<>();
 
-    public TradingModeSelectionGUI(TofuNomics plugin, ConfigManager configManager, TradingGUI tradingGUI) {
+    public TradingModeSelectionGUI(TofuNomics plugin, ConfigManager configManager, TradingGUI tradingGUI, TradingNPCManager tradingNPCManager) {
         this.plugin = plugin;
         this.configManager = configManager;
         this.tradingGUI = tradingGUI;
+        this.tradingNPCManager = tradingNPCManager;
     }
 
     /**
@@ -63,6 +65,12 @@ public class TradingModeSelectionGUI implements Listener {
      */
     public void openModeSelectionGUI(Player player, TradingNPCManager.TradingPost tradingPost) {
         plugin.getLogger().info("モード選択GUI開起: プレイヤー=" + player.getName() + ", 取引所=" + tradingPost.getName());
+
+        // 営業時間チェックを追加
+        if (!tradingNPCManager.isWithinTradingHours(player, tradingPost)) {
+            player.sendMessage(configManager.getMessage("npc.trading.outside_hours"));
+            return;
+        }
 
         try {
             // GUIタイトル
@@ -212,6 +220,13 @@ public class TradingModeSelectionGUI implements Listener {
      */
     private void handleModeSelection(Player player, ModeSelectionSession session, int slot, Material material) {
         TradingNPCManager.TradingPost tradingPost = session.getTradingPost();
+
+        // 営業時間チェックを追加
+        if (!tradingNPCManager.isWithinTradingHours(player, tradingPost)) {
+            player.sendMessage(configManager.getMessage("npc.trading.outside_hours"));
+            player.closeInventory();
+            return;
+        }
 
         switch (slot) {
             case 11: // 売却モード

--- a/src/main/java/org/tofu/tofunomics/players/PlayerJoinHandler.java
+++ b/src/main/java/org/tofu/tofunomics/players/PlayerJoinHandler.java
@@ -19,6 +19,8 @@ import org.tofu.tofunomics.dao.PlayerDAO;
 import org.tofu.tofunomics.scoreboard.ScoreboardManager;
 import org.tofu.tofunomics.inventory.PlayerInventoryManager;
 import org.tofu.tofunomics.rules.RulesManager;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.tutorial.TutorialManager;
 
 import java.util.List;
 import java.util.Map;
@@ -249,12 +251,15 @@ public class PlayerJoinHandler implements Listener {
                 // 新規プレイヤーの場合
                 createNewPlayer(player);
                 logger.info("新規プレイヤーを登録しました: " + player.getName());
-                
+
                 // ルール確認システムは外部サイトURL方式に変更（GUI廃止）
                 // 新規プレイヤーにはウェルカムメッセージで /rules コマンドを案内
-                
+
                 // 新規プレイヤーメッセージを表示するフラグを設定
                 scheduleNewPlayerMessages(player);
+
+                // チュートリアル自動開始をスケジュール
+                scheduleTutorialStart(player);
             } else {
                 // 既存プレイヤーの場合
                 // ルール確認システムは外部サイトURL方式に変更（GUI廃止）
@@ -359,7 +364,24 @@ public class PlayerJoinHandler implements Listener {
         WelcomeBackMessageTask welcomeBackTask = new WelcomeBackMessageTask(player);
         welcomeBackTask.runTaskLater(plugin, 100L); // 5秒後に表示
     }
-    
+
+    /**
+     * チュートリアル自動開始のスケジュール
+     */
+    private void scheduleTutorialStart(Player player) {
+        TutorialManager tutorialManager = TofuNomics.getInstance().getTutorialManager();
+        if (tutorialManager == null || !tutorialManager.isAutoStartEnabled()) {
+            return;
+        }
+
+        int delaySeconds = tutorialManager.getStartDelaySeconds();
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (player.isOnline()) {
+                tutorialManager.startTutorial(player);
+            }
+        }, delaySeconds * 20L);
+    }
+
     /**
      * ウェルカムメッセージの表示
      */
@@ -454,9 +476,11 @@ public class PlayerJoinHandler implements Listener {
             int x = configManager.getSpawnX();
             int y = configManager.getSpawnY();
             int z = configManager.getSpawnZ();
+            float yaw = configManager.getSpawnYaw();
+            float pitch = configManager.getSpawnPitch();
             int delay = configManager.getSpawnTeleportDelay();
             
-            logger.info("スポーン座標設定 - ワールド: " + worldName + ", 座標: (" + x + ", " + y + ", " + z + "), 遅延: " + delay + " tick");
+            logger.info("スポーン座標設定 - ワールド: " + worldName + ", 座標: (" + x + ", " + y + ", " + z + "), 向き: (yaw=" + yaw + ", pitch=" + pitch + "), 遅延: " + delay + " tick");
             
             // ワールドを取得
             World world = Bukkit.getWorld(worldName);
@@ -465,11 +489,11 @@ public class PlayerJoinHandler implements Listener {
                 return;
             }
             
-            // スポーン座標を作成
-            Location spawnLocation = new Location(world, x + 0.5, y, z + 0.5);
+            // スポーン座標を作成（向きも設定）
+            Location spawnLocation = new Location(world, x + 0.5, y, z + 0.5, yaw, pitch);
             
             // 遅延付きでテレポート実行
-            SpawnTeleportTask teleportTask = new SpawnTeleportTask(player, spawnLocation, x, y, z, worldName);
+            SpawnTeleportTask teleportTask = new SpawnTeleportTask(player, spawnLocation, x, y, z, yaw, pitch, worldName);
             teleportTask.runTaskLater(plugin, delay);
             
         } catch (Exception e) {
@@ -662,14 +686,17 @@ public class PlayerJoinHandler implements Listener {
         private final Player player;
         private final Location spawnLocation;
         private final int x, y, z;
+        private final float yaw, pitch;
         private final String worldName;
         
-        public SpawnTeleportTask(Player player, Location spawnLocation, int x, int y, int z, String worldName) {
+        public SpawnTeleportTask(Player player, Location spawnLocation, int x, int y, int z, float yaw, float pitch, String worldName) {
             this.player = player;
             this.spawnLocation = spawnLocation;
             this.x = x;
             this.y = y;
             this.z = z;
+            this.yaw = yaw;
+            this.pitch = pitch;
             this.worldName = worldName;
         }
         
@@ -678,7 +705,7 @@ public class PlayerJoinHandler implements Listener {
             if (player.isOnline()) {
                 player.teleport(spawnLocation);
                 logger.info("プレイヤー " + player.getName() + " をスポーン座標にテレポートしました: " + 
-                          x + ", " + y + ", " + z + " (" + worldName + ")");
+                          x + ", " + y + ", " + z + " (yaw=" + yaw + ", pitch=" + pitch + ") (" + worldName + ")");
             }
         }
     }

--- a/src/main/java/org/tofu/tofunomics/rewards/JobGuideBookManager.java
+++ b/src/main/java/org/tofu/tofunomics/rewards/JobGuideBookManager.java
@@ -1,0 +1,335 @@
+package org.tofu.tofunomics.rewards;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.TofuNomics;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 職業ガイドブック管理システム
+ * 各職業に就職した際にガイドブック（Written Book）を配布する
+ */
+public class JobGuideBookManager {
+    
+    private final ConfigManager configManager;
+    
+    // ガイドブック識別用CustomModelData
+    private static final int GUIDE_BOOK_MODEL_DATA = 2001;
+    
+    // TofuNomicsガイドブック識別用Lore接頭辞
+    private static final String GUIDE_BOOK_IDENTIFIER = "§8[TofuNomics JobGuide]";
+    
+    // 配布済みプレイヤーのキャッシュ（サーバー再起動でリセット）
+    // 永続化が必要な場合はDBに保存を検討
+    private final Map<UUID, List<String>> distributedBooks;
+    
+    public JobGuideBookManager(ConfigManager configManager) {
+        this.configManager = configManager;
+        this.distributedBooks = new HashMap<>();
+    }
+    
+    /**
+     * FileConfigurationを取得するヘルパーメソッド
+     */
+    private FileConfiguration getConfig() {
+        return TofuNomics.getInstance().getConfig();
+    }
+    
+    /**
+     * ガイドブック機能が有効かどうか
+     */
+    public boolean isEnabled() {
+        return getConfig().getBoolean("guide_book_settings.enabled", true);
+    }
+    
+    /**
+     * 指定職業のガイドブック機能が有効かどうか
+     */
+    public boolean isJobGuideEnabled(String jobName) {
+        return getConfig().getBoolean("jobs.job_settings." + jobName + ".guide_book.enabled", true);
+    }
+    
+    /**
+     * 職業ガイドブックを作成する
+     * @param jobName 職業名（英語キー）
+     * @return 作成されたガイドブック、設定がない場合はnull
+     */
+    public ItemStack createJobGuideBook(String jobName) {
+        if (!isEnabled() || !isJobGuideEnabled(jobName)) {
+            return null;
+        }
+        
+        String basePath = "jobs.job_settings." + jobName + ".guide_book";
+        
+        // タイトルと著者を取得
+        String title = getConfig().getString(basePath + ".title", "&6&l職業ガイドブック");
+        String author = getConfig().getString(basePath + ".author", "TofuNomics職業組合");
+        
+        // ページ内容を取得
+        List<String> pages = getConfig().getStringList(basePath + ".pages");
+        if (pages.isEmpty()) {
+            // デフォルトページを生成
+            pages = generateDefaultPages(jobName);
+        }
+        
+        // Written Bookを作成
+        ItemStack book = new ItemStack(Material.WRITTEN_BOOK);
+        BookMeta bookMeta = (BookMeta) book.getItemMeta();
+        
+        if (bookMeta == null) {
+            return null;
+        }
+        
+        // タイトルと著者を設定（カラーコード変換）
+        bookMeta.setTitle(ChatColor.translateAlternateColorCodes('&', title));
+        bookMeta.setAuthor(ChatColor.translateAlternateColorCodes('&', author));
+        
+        // ページを追加（カラーコード変換）
+        for (String page : pages) {
+            String coloredPage = ChatColor.translateAlternateColorCodes('&', page);
+            bookMeta.addPage(coloredPage);
+        }
+        
+        // ガイドブック識別用のLoreを設定
+        List<String> lore = new ArrayList<>();
+        lore.add(GUIDE_BOOK_IDENTIFIER);
+        lore.add("§7職業: " + jobName);
+        bookMeta.setLore(lore);
+        
+        // CustomModelDataを設定（識別用）
+        bookMeta.setCustomModelData(GUIDE_BOOK_MODEL_DATA);
+        
+        book.setItemMeta(bookMeta);
+        
+        return book;
+    }
+    
+    /**
+     * デフォルトのガイドブックページを生成
+     */
+    private List<String> generateDefaultPages(String jobName) {
+        List<String> pages = new ArrayList<>();
+        
+        String displayName = getConfig().getString(
+            "jobs.job_settings." + jobName + ".display_name", 
+            jobName
+        );
+        String description = getConfig().getString(
+            "jobs.job_settings." + jobName + ".description", 
+            "職業の説明がありません"
+        );
+        
+        // ページ1: 表紙・概要
+        StringBuilder page1 = new StringBuilder();
+        page1.append("§0§l【").append(displayName).append("】\n\n");
+        page1.append("§0ようこそ！\n");
+        page1.append("この本は").append(displayName).append("として\n");
+        page1.append("活動するための\n");
+        page1.append("ガイドブックです。\n\n");
+        page1.append("§8").append(description);
+        pages.add(page1.toString());
+        
+        // ページ2: 基本情報
+        StringBuilder page2 = new StringBuilder();
+        page2.append("§0§l【基本情報】\n\n");
+        page2.append("§0この職業では\n");
+        page2.append("以下の活動で\n");
+        page2.append("報酬と経験値を\n");
+        page2.append("獲得できます。\n\n");
+        page2.append("詳細はゲーム内で\n");
+        page2.append("/jobs info\n");
+        page2.append("を確認してください。");
+        pages.add(page2.toString());
+        
+        // ページ3: コマンド一覧
+        StringBuilder page3 = new StringBuilder();
+        page3.append("§0§l【便利なコマンド】\n\n");
+        page3.append("§0/jobs stats\n");
+        page3.append("§8→ 職業の統計情報\n\n");
+        page3.append("§0/jobs info\n");
+        page3.append("§8→ 職業の詳細\n\n");
+        page3.append("§0/jobs guide\n");
+        page3.append("§8→ ガイドブック再取得");
+        pages.add(page3.toString());
+        
+        return pages;
+    }
+    
+    /**
+     * プレイヤーにガイドブックを配布する
+     * @param player 配布対象プレイヤー
+     * @param jobName 職業名
+     * @return 配布成功ならtrue
+     */
+    public boolean giveGuideBook(Player player, String jobName) {
+        if (!isEnabled()) {
+            return false;
+        }
+        
+        // 重複配布チェック
+        boolean preventDuplicate = getConfig().getBoolean(
+            "guide_book_settings.prevent_duplicate", true
+        );
+        
+        if (preventDuplicate && hasGuideBookInInventory(player, jobName)) {
+            // 既にガイドブックを持っている場合はスキップ
+            return false;
+        }
+        
+        ItemStack guideBook = createJobGuideBook(jobName);
+        if (guideBook == null) {
+            return false;
+        }
+        
+        // インベントリに空きがあるか確認
+        Map<Integer, ItemStack> leftOver = player.getInventory().addItem(guideBook);
+        
+        if (!leftOver.isEmpty()) {
+            // インベントリが満杯
+            boolean dropWhenFull = getConfig().getBoolean(
+                "guide_book_settings.drop_when_full", true
+            );
+            
+            if (dropWhenFull) {
+                // 足元にドロップ
+                player.getWorld().dropItemNaturally(player.getLocation(), guideBook);
+                player.sendMessage(ChatColor.YELLOW + "インベントリが満杯のため、ガイドブックを足元にドロップしました。");
+            } else {
+                return false;
+            }
+        }
+        
+        // 配布メッセージを送信
+        String displayName = getConfig().getString(
+            "jobs.job_settings." + jobName + ".display_name", 
+            jobName
+        );
+        String message = getConfig().getString(
+            "guide_book_settings.give_message",
+            "&a【職業ガイド】&f%job%のガイドブックを受け取りました！"
+        );
+        message = message.replace("%job%", displayName);
+        player.sendMessage(ChatColor.translateAlternateColorCodes('&', message));
+        
+        // 配布記録を更新
+        recordDistribution(player.getUniqueId(), jobName);
+        
+        return true;
+    }
+    
+    /**
+     * プレイヤーがインベントリ内に指定職業のガイドブックを持っているか確認
+     */
+    public boolean hasGuideBookInInventory(Player player, String jobName) {
+        for (ItemStack item : player.getInventory().getContents()) {
+            if (isGuideBookForJob(item, jobName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    /**
+     * アイテムがTofuNomicsのガイドブックかどうか判定
+     */
+    public boolean isGuideBook(ItemStack item) {
+        if (item == null || item.getType() != Material.WRITTEN_BOOK) {
+            return false;
+        }
+        
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !meta.hasLore()) {
+            return false;
+        }
+        
+        List<String> lore = meta.getLore();
+        if (lore == null || lore.isEmpty()) {
+            return false;
+        }
+        
+        return lore.get(0).equals(GUIDE_BOOK_IDENTIFIER);
+    }
+    
+    /**
+     * アイテムが指定職業のガイドブックかどうか判定
+     */
+    public boolean isGuideBookForJob(ItemStack item, String jobName) {
+        if (!isGuideBook(item)) {
+            return false;
+        }
+        
+        List<String> lore = item.getItemMeta().getLore();
+        if (lore == null || lore.size() < 2) {
+            return false;
+        }
+        
+        String jobLine = lore.get(1);
+        return jobLine.equals("§7職業: " + jobName);
+    }
+    
+    /**
+     * 配布記録を登録
+     */
+    private void recordDistribution(UUID playerId, String jobName) {
+        distributedBooks.computeIfAbsent(playerId, k -> new ArrayList<>());
+        if (!distributedBooks.get(playerId).contains(jobName)) {
+            distributedBooks.get(playerId).add(jobName);
+        }
+    }
+    
+    /**
+     * このセッションでガイドブックを配布済みかどうか確認
+     * （サーバー再起動でリセットされる）
+     */
+    public boolean hasDistributedThisSession(UUID playerId, String jobName) {
+        List<String> jobs = distributedBooks.get(playerId);
+        return jobs != null && jobs.contains(jobName);
+    }
+    
+    /**
+     * ガイドブックの再取得（/jobs guide用）
+     * 重複チェックをスキップして強制的に配布
+     */
+    public boolean giveGuideBookForced(Player player, String jobName) {
+        if (!isEnabled()) {
+            player.sendMessage(ChatColor.RED + "ガイドブック機能は現在無効です。");
+            return false;
+        }
+        
+        ItemStack guideBook = createJobGuideBook(jobName);
+        if (guideBook == null) {
+            player.sendMessage(ChatColor.RED + "この職業のガイドブックは設定されていません。");
+            return false;
+        }
+        
+        // インベントリに空きがあるか確認
+        Map<Integer, ItemStack> leftOver = player.getInventory().addItem(guideBook);
+        
+        if (!leftOver.isEmpty()) {
+            // インベントリが満杯 - 足元にドロップ
+            player.getWorld().dropItemNaturally(player.getLocation(), guideBook);
+            player.sendMessage(ChatColor.YELLOW + "インベントリが満杯のため、ガイドブックを足元にドロップしました。");
+        }
+        
+        // 配布メッセージを送信
+        String displayName = getConfig().getString(
+            "jobs.job_settings." + jobName + ".display_name", 
+            jobName
+        );
+        player.sendMessage(ChatColor.GREEN + "【職業ガイド】" + ChatColor.WHITE + 
+            displayName + "のガイドブックを受け取りました！");
+        
+        return true;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/scoreboard/ScoreboardManager.java
+++ b/src/main/java/org/tofu/tofunomics/scoreboard/ScoreboardManager.java
@@ -78,6 +78,12 @@ public class ScoreboardManager implements Listener {
      * スコアボード非表示時に、再表示方法を示す簡易スコアボードを提供
      */
     private void showHintScoreboard(Player player) {
+        // 対象ワールド外ではヒントスコアボードも表示しない
+        if (!isScoreboardEnabledInCurrentWorld(player)) {
+            player.setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
+            return;
+        }
+
         try {
             // 新しいスコアボードを作成
             Scoreboard scoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
@@ -146,8 +152,9 @@ public class ScoreboardManager implements Listener {
         
         // ワールド制限チェックを追加
         if (!isScoreboardEnabledInCurrentWorld(player)) {
-            // 対象ワールド外の場合はスコアボードを無効にする
-            disableScoreboard(player);
+            // 対象ワールド外の場合はスコアボードを完全に非表示にする
+            // （ヒントスコアボードも表示しない - disableScoreboardを呼ばない）
+            player.setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
             return;
         }
         
@@ -348,7 +355,7 @@ public class ScoreboardManager implements Listener {
             @Override
             public void run() {
                 for (Player player : Bukkit.getOnlinePlayers()) {
-                    if (isScoreboardEnabled(player)) {
+                    if (isScoreboardEnabled(player) && isScoreboardEnabledInCurrentWorld(player)) {
                         updatePlayerScoreboard(player);
                     }
                 }
@@ -372,6 +379,13 @@ public class ScoreboardManager implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {
         Player player = event.getPlayer();
+        String worldName = player.getWorld().getName();
+        
+        // デバッグログ
+        plugin.getLogger().info("[スコアボード] " + player.getName() + " がワールド変更: " +
+            event.getFrom().getName() + " → " + worldName);
+        plugin.getLogger().info("[スコアボード] ワールド " + worldName + " は対象ワールド: " +
+            isScoreboardEnabledInCurrentWorld(player));
         
         if (isScoreboardEnabledInCurrentWorld(player)) {
             // 対象ワールドに入った場合、スコアボードが有効なら表示する
@@ -379,10 +393,9 @@ public class ScoreboardManager implements Listener {
                 enableScoreboard(player);
             }
         } else {
-            // 対象ワールド外に出た場合、スコアボードを無効にする
-            if (isScoreboardEnabled(player)) {
-                disableScoreboard(player);
-            }
+            // 対象ワールド外に出た場合、スコアボードを完全に非表示にする
+            // （ヒントスコアボードも表示しない）
+            player.setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
         }
     }
     
@@ -398,7 +411,7 @@ public class ScoreboardManager implements Listener {
      */
     public void updateAllScoreboards() {
         for (Player player : Bukkit.getOnlinePlayers()) {
-            if (isScoreboardEnabled(player)) {
+            if (isScoreboardEnabled(player) && isScoreboardEnabledInCurrentWorld(player)) {
                 updatePlayerScoreboard(player);
             }
         }

--- a/src/main/java/org/tofu/tofunomics/trade/TradePriceManager.java
+++ b/src/main/java/org/tofu/tofunomics/trade/TradePriceManager.java
@@ -12,6 +12,12 @@ import java.util.Map;
 
 /**
  * 取引価格計算システム
+ *
+ * 注意: {@code initializePriceTables()} 系のハードコード価格テーブル（{@code jobBasePrices}）と
+ * {@code calculateTradePrice()} / {@code getBasePrice()} は旧TradeChest機能専用。
+ * NPC取引の買取価格は config.yml の {@code npc_system.item_prices} を参照する
+ * （{@code TradingNPCManager.buildItemPrices()} 経由で {@code calculateFinalPrice()} のみ使用）。
+ * 両者は別系統のため、NPC取引価格を変更する場合は config.yml 側を編集すること。
  */
 public class TradePriceManager {
     
@@ -384,25 +390,16 @@ public class TradePriceManager {
      * NPCシステム用の最終価格計算メソッド
      */
     public double calculateFinalPrice(String itemName, String jobType, double basePrice) {
-        System.out.println("[TradePriceManager] calculateFinalPrice - itemName: " + itemName + ", jobType: " + jobType + ", basePrice: " + basePrice);
-        
         // 職業倍率を取得（無職の場合は1.0）
         double jobMultiplier = (jobType == null || jobType.isEmpty()) ? 1.0 : configManager.getJobPriceMultiplier(jobType);
-        System.out.println("[TradePriceManager] jobMultiplier: " + jobMultiplier);
-        
+
         double finalPrice = basePrice * jobMultiplier;
-        System.out.println("[TradePriceManager] After job multiplier: " + finalPrice);
-        
+
         // グローバル倍率を適用
         double globalMultiplier = configManager.getTradePriceMultiplier();
-        System.out.println("[TradePriceManager] globalMultiplier: " + globalMultiplier);
-        
         finalPrice *= globalMultiplier;
-        System.out.println("[TradePriceManager] After global multiplier: " + finalPrice);
-        
+
         // 個数を掛ける前の価格を返す（切り捨ては呼び出し側で行う）
-        System.out.println("[TradePriceManager] Returning finalPrice (before floor): " + finalPrice);
-        
         return finalPrice;
     }
 }

--- a/src/main/java/org/tofu/tofunomics/tutorial/TutorialCommand.java
+++ b/src/main/java/org/tofu/tofunomics/tutorial/TutorialCommand.java
@@ -1,0 +1,161 @@
+package org.tofu.tofunomics.tutorial;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * チュートリアルコマンドハンドラー
+ * /tutorial - 現在の進捗表示
+ * /tutorial skip [confirm] - チュートリアルをスキップ
+ * /tutorial restart - チュートリアルをやり直し
+ * /tutorial reset <player> - 他プレイヤーのチュートリアルをリセット（管理者用）
+ */
+public class TutorialCommand implements CommandExecutor, TabCompleter {
+
+    private final TofuNomics plugin;
+    private final TutorialManager tutorialManager;
+    private final ConfigManager configManager;
+
+    public TutorialCommand(TofuNomics plugin, TutorialManager tutorialManager, ConfigManager configManager) {
+        this.plugin = plugin;
+        this.tutorialManager = tutorialManager;
+        this.configManager = configManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "このコマンドはプレイヤーのみ使用できます。");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (!tutorialManager.isEnabled()) {
+            player.sendMessage(ChatColor.YELLOW + "チュートリアルシステムは現在無効です。");
+            return true;
+        }
+
+        if (args.length == 0) {
+            // /tutorial - 進捗表示
+            tutorialManager.sendProgressDisplay(player);
+            return true;
+        }
+
+        String subCommand = args[0].toLowerCase();
+
+        switch (subCommand) {
+            case "skip":
+                return handleSkip(player, args);
+
+            case "restart":
+                return handleRestart(player);
+
+            case "reset":
+                return handleReset(player, args);
+
+            default:
+                sendUsage(player);
+                return true;
+        }
+    }
+
+    private boolean handleSkip(Player player, String[] args) {
+        boolean confirmed = args.length >= 2 && args[1].equalsIgnoreCase("confirm");
+        tutorialManager.skipTutorial(player, confirmed);
+        return true;
+    }
+
+    private boolean handleRestart(Player player) {
+        tutorialManager.restartTutorial(player);
+        return true;
+    }
+
+    private boolean handleReset(Player player, String[] args) {
+        // 管理者権限チェック
+        if (!player.hasPermission("tofunomics.tutorial.admin")) {
+            player.sendMessage(ChatColor.RED + "このコマンドを実行する権限がありません。");
+            return true;
+        }
+
+        if (args.length < 2) {
+            player.sendMessage(ChatColor.RED + "使用法: /tutorial reset <プレイヤー名>");
+            return true;
+        }
+
+        String targetName = args[1];
+        Player targetPlayer = Bukkit.getPlayerExact(targetName);
+
+        if (targetPlayer != null) {
+            // オンラインプレイヤー
+            tutorialManager.adminResetTutorial(player, targetPlayer.getUniqueId(), targetName);
+        } else {
+            // オフラインプレイヤー（UUIDを取得してリセット）
+            @SuppressWarnings("deprecation")
+            org.bukkit.OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(targetName);
+            if (offlinePlayer.hasPlayedBefore()) {
+                tutorialManager.adminResetTutorial(player, offlinePlayer.getUniqueId(), targetName);
+            } else {
+                player.sendMessage(ChatColor.RED + "プレイヤー「" + targetName + "」が見つかりません。");
+            }
+        }
+
+        return true;
+    }
+
+    private void sendUsage(Player player) {
+        player.sendMessage(ChatColor.GOLD + "=== チュートリアルコマンド ===");
+        player.sendMessage(ChatColor.YELLOW + "/tutorial " + ChatColor.WHITE + "- 進捗を表示");
+        player.sendMessage(ChatColor.YELLOW + "/tutorial skip " + ChatColor.WHITE + "- スキップ");
+        player.sendMessage(ChatColor.YELLOW + "/tutorial restart " + ChatColor.WHITE + "- やり直し");
+        if (player.hasPermission("tofunomics.tutorial.admin")) {
+            player.sendMessage(ChatColor.YELLOW + "/tutorial reset <player> " + ChatColor.WHITE + "- リセット（管理者）");
+        }
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> completions = new ArrayList<>();
+
+        if (args.length == 1) {
+            List<String> subCommands = new ArrayList<>(Arrays.asList("skip", "restart"));
+            if (sender.hasPermission("tofunomics.tutorial.admin")) {
+                subCommands.add("reset");
+            }
+            String input = args[0].toLowerCase();
+            for (String sub : subCommands) {
+                if (sub.startsWith(input)) {
+                    completions.add(sub);
+                }
+            }
+        } else if (args.length == 2) {
+            if (args[0].equalsIgnoreCase("skip")) {
+                if ("confirm".startsWith(args[1].toLowerCase())) {
+                    completions.add("confirm");
+                }
+            } else if (args[0].equalsIgnoreCase("reset") && sender.hasPermission("tofunomics.tutorial.admin")) {
+                // オンラインプレイヤー名を補完
+                String input = args[1].toLowerCase();
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    if (player.getName().toLowerCase().startsWith(input)) {
+                        completions.add(player.getName());
+                    }
+                }
+            }
+        }
+
+        return completions;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/tutorial/TutorialEventListener.java
+++ b/src/main/java/org/tofu/tofunomics/tutorial/TutorialEventListener.java
@@ -1,0 +1,101 @@
+package org.tofu.tofunomics.tutorial;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.tofu.tofunomics.TofuNomics;
+
+import java.util.UUID;
+
+/**
+ * チュートリアル進捗を検知するためのイベントリスナー
+ * 各種イベントでチュートリアルステップの完了を検知する
+ */
+public class TutorialEventListener implements Listener {
+
+    private final TofuNomics plugin;
+    private final TutorialManager tutorialManager;
+
+    public TutorialEventListener(TofuNomics plugin, TutorialManager tutorialManager) {
+        this.plugin = plugin;
+        this.tutorialManager = tutorialManager;
+    }
+
+    /**
+     * プレイヤー退出時にキャッシュをクリア
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        tutorialManager.clearPlayerCache(event.getPlayer().getUniqueId());
+    }
+
+    /**
+     * ステップ1完了: 職業就職時に呼び出される
+     * JobsCommandから呼び出される
+     */
+    public void onJobJoined(Player player) {
+        if (!tutorialManager.isEnabled()) {
+            return;
+        }
+
+        UUID uuid = player.getUniqueId();
+        TutorialStep currentStep = tutorialManager.getCurrentStep(uuid);
+
+        if (currentStep == TutorialStep.JOB_SELECT) {
+            tutorialManager.advanceStep(player);
+        }
+    }
+
+    /**
+     * ステップ2完了: 初収入時に呼び出される
+     * UnifiedEventHandlerから呼び出される
+     */
+    public void onFirstIncome(Player player) {
+        if (!tutorialManager.isEnabled()) {
+            return;
+        }
+
+        UUID uuid = player.getUniqueId();
+        TutorialStep currentStep = tutorialManager.getCurrentStep(uuid);
+
+        if (currentStep == TutorialStep.FIRST_INCOME) {
+            tutorialManager.advanceStep(player);
+        }
+    }
+
+    /**
+     * ステップ3完了: 銀行NPC使用時に呼び出される
+     * NPCListenerから呼び出される
+     */
+    public void onBankNPCUsed(Player player) {
+        if (!tutorialManager.isEnabled()) {
+            return;
+        }
+
+        UUID uuid = player.getUniqueId();
+        TutorialStep currentStep = tutorialManager.getCurrentStep(uuid);
+
+        if (currentStep == TutorialStep.BANK_NPC) {
+            tutorialManager.advanceStep(player);
+        }
+    }
+
+    /**
+     * ステップ4完了: 取引NPC使用時に呼び出される
+     * NPCListenerから呼び出される
+     */
+    public void onTradingNPCUsed(Player player) {
+        if (!tutorialManager.isEnabled()) {
+            return;
+        }
+
+        UUID uuid = player.getUniqueId();
+        TutorialStep currentStep = tutorialManager.getCurrentStep(uuid);
+
+        if (currentStep == TutorialStep.TRADING_NPC) {
+            tutorialManager.advanceStep(player);
+        }
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/tutorial/TutorialManager.java
+++ b/src/main/java/org/tofu/tofunomics/tutorial/TutorialManager.java
@@ -1,0 +1,442 @@
+package org.tofu.tofunomics.tutorial;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+/**
+ * チュートリアルシステムの中心管理クラス
+ * プレイヤーのチュートリアル進捗を管理し、メッセージ表示を行う
+ */
+public class TutorialManager {
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final TutorialProgressDAO tutorialProgressDAO;
+    private final Logger logger;
+
+    // インメモリキャッシュ（パフォーマンス最適化）
+    private final Map<UUID, TutorialStep> playerProgressCache;
+
+    public TutorialManager(TofuNomics plugin, ConfigManager configManager, TutorialProgressDAO tutorialProgressDAO) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.tutorialProgressDAO = tutorialProgressDAO;
+        this.logger = plugin.getLogger();
+        this.playerProgressCache = new HashMap<>();
+    }
+
+    /**
+     * チュートリアルが有効かどうか
+     */
+    public boolean isEnabled() {
+        return plugin.getConfig().getBoolean("tutorial.enabled", true);
+    }
+
+    /**
+     * 自動開始が有効かどうか
+     */
+    public boolean isAutoStartEnabled() {
+        return plugin.getConfig().getBoolean("tutorial.auto_start", true);
+    }
+
+    /**
+     * 開始遅延時間（秒）
+     */
+    public int getStartDelaySeconds() {
+        return plugin.getConfig().getInt("tutorial.start_delay_seconds", 10);
+    }
+
+    /**
+     * チュートリアルを開始
+     * @param player プレイヤー
+     */
+    public void startTutorial(Player player) {
+        if (!isEnabled()) {
+            return;
+        }
+
+        UUID uuid = player.getUniqueId();
+
+        try {
+            // 既に開始済みの場合は何もしない
+            if (tutorialProgressDAO.hasProgress(uuid)) {
+                TutorialStep currentStep = tutorialProgressDAO.getProgress(uuid);
+                if (currentStep.isCompleted()) {
+                    return;
+                }
+                // 進行中の場合は現在のステップを表示
+                playerProgressCache.put(uuid, currentStep);
+                sendStepMessage(player, currentStep);
+                return;
+            }
+
+            // 新規開始
+            TutorialStep firstStep = TutorialStep.JOB_SELECT;
+            tutorialProgressDAO.createProgress(uuid, firstStep);
+            playerProgressCache.put(uuid, firstStep);
+
+            // 開始メッセージを送信
+            sendStartMessage(player);
+
+            // 少し遅延してから最初のステップメッセージを送信
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                if (player.isOnline()) {
+                    sendStepMessage(player, firstStep);
+                }
+            }, 60L); // 3秒後
+
+        } catch (SQLException e) {
+            logger.warning("チュートリアル開始時にエラーが発生しました: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 次のステップに進む
+     * @param player プレイヤー
+     */
+    public void advanceStep(Player player) {
+        UUID uuid = player.getUniqueId();
+        TutorialStep currentStep = getCurrentStep(uuid);
+
+        if (currentStep == null || currentStep.isCompleted()) {
+            return;
+        }
+
+        TutorialStep nextStep = currentStep.getNextStep();
+
+        try {
+            // 現在のステップの完了メッセージを送信
+            sendStepCompleteMessage(player, currentStep);
+
+            if (nextStep.isCompleted()) {
+                // チュートリアル完了
+                tutorialProgressDAO.markCompleted(uuid);
+                playerProgressCache.put(uuid, TutorialStep.COMPLETED);
+                sendCompletedMessage(player);
+                giveCompletionReward(player);
+            } else {
+                // 次のステップへ
+                tutorialProgressDAO.updateProgress(uuid, nextStep);
+                playerProgressCache.put(uuid, nextStep);
+
+                // 少し遅延してから次のステップメッセージを送信
+                Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                    if (player.isOnline()) {
+                        sendStepMessage(player, nextStep);
+                    }
+                }, 40L); // 2秒後
+            }
+        } catch (SQLException e) {
+            logger.warning("チュートリアル進行時にエラーが発生しました: " + e.getMessage());
+        }
+    }
+
+    /**
+     * チュートリアルをスキップ
+     * @param player プレイヤー
+     * @param confirmed 確認済みかどうか
+     * @return スキップが成功した場合true
+     */
+    public boolean skipTutorial(Player player, boolean confirmed) {
+        UUID uuid = player.getUniqueId();
+
+        if (!confirmed) {
+            String message = plugin.getConfig().getString("tutorial.messages.skip_confirm",
+                    "&eチュートリアルをスキップしますか？ &f/tutorial skip confirm &eで確定");
+            player.sendMessage(colorize(message));
+            return false;
+        }
+
+        try {
+            if (!tutorialProgressDAO.hasProgress(uuid)) {
+                tutorialProgressDAO.createProgress(uuid, TutorialStep.COMPLETED);
+            }
+            tutorialProgressDAO.markSkipped(uuid);
+            playerProgressCache.put(uuid, TutorialStep.COMPLETED);
+
+            String successMessage = plugin.getConfig().getString("tutorial.messages.skip_success",
+                    "&aチュートリアルをスキップしました。");
+            String noteMessage = plugin.getConfig().getString("tutorial.messages.skip_note",
+                    "&7いつでも &f/tutorial restart &7でやり直せます。");
+            player.sendMessage(colorize(successMessage));
+            player.sendMessage(colorize(noteMessage));
+            return true;
+        } catch (SQLException e) {
+            logger.warning("チュートリアルスキップ時にエラーが発生しました: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * チュートリアルをリスタート
+     * @param player プレイヤー
+     */
+    public void restartTutorial(Player player) {
+        UUID uuid = player.getUniqueId();
+
+        try {
+            // プレイヤーの現在の状態に応じて開始ステップを決定
+            TutorialStep startStep = determineStartingStep(player);
+
+            if (tutorialProgressDAO.hasProgress(uuid)) {
+                tutorialProgressDAO.resetProgress(uuid);
+                tutorialProgressDAO.updateProgress(uuid, startStep);
+            } else {
+                tutorialProgressDAO.createProgress(uuid, startStep);
+            }
+            playerProgressCache.put(uuid, startStep);
+
+            String message = plugin.getConfig().getString("tutorial.messages.restart_success",
+                    "&aチュートリアルを最初からやり直します。");
+            player.sendMessage(colorize(message));
+
+            // 開始メッセージを送信
+            sendStartMessage(player);
+
+            // 少し遅延してから開始ステップメッセージを送信
+            final TutorialStep finalStartStep = startStep;
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                if (player.isOnline()) {
+                    sendStepMessage(player, finalStartStep);
+                }
+            }, 60L);
+        } catch (SQLException e) {
+            logger.warning("チュートリアルリスタート時にエラーが発生しました: " + e.getMessage());
+        }
+    }
+
+    /**
+     * プレイヤーの現在の状態に応じて開始すべきステップを決定
+     * 既に条件を満たしているステップはスキップ
+     */
+    private TutorialStep determineStartingStep(Player player) {
+        // ステップ1: 職業に就いているかチェック
+        var jobManager = plugin.getJobManager();
+        if (jobManager != null) {
+            var playerJobs = jobManager.getPlayerJobs(player);
+            if (playerJobs != null && !playerJobs.isEmpty()) {
+                // 既に職業に就いている → ステップ2から開始
+                return TutorialStep.FIRST_INCOME;
+            }
+        }
+
+        // デフォルト: ステップ1から開始
+        return TutorialStep.JOB_SELECT;
+    }
+
+    /**
+     * 管理者による他プレイヤーのチュートリアルリセット
+     * @param admin 管理者
+     * @param targetUuid 対象プレイヤーUUID
+     * @param targetName 対象プレイヤー名
+     */
+    public void adminResetTutorial(Player admin, UUID targetUuid, String targetName) {
+        try {
+            if (tutorialProgressDAO.hasProgress(targetUuid)) {
+                tutorialProgressDAO.resetProgress(targetUuid);
+            } else {
+                tutorialProgressDAO.createProgress(targetUuid, TutorialStep.JOB_SELECT);
+            }
+            playerProgressCache.put(targetUuid, TutorialStep.JOB_SELECT);
+
+            String message = plugin.getConfig().getString("tutorial.messages.admin_reset_success",
+                    "&a%player%さんのチュートリアルをリセットしました。");
+            admin.sendMessage(colorize(message.replace("%player%", targetName)));
+        } catch (SQLException e) {
+            logger.warning("チュートリアルリセット時にエラーが発生しました: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 現在のステップを取得
+     * @param uuid プレイヤーUUID
+     * @return 現在のステップ
+     */
+    public TutorialStep getCurrentStep(UUID uuid) {
+        // キャッシュから取得
+        if (playerProgressCache.containsKey(uuid)) {
+            return playerProgressCache.get(uuid);
+        }
+
+        // DBから取得
+        try {
+            TutorialStep step = tutorialProgressDAO.getProgress(uuid);
+            playerProgressCache.put(uuid, step);
+            return step;
+        } catch (SQLException e) {
+            logger.warning("チュートリアル進捗取得時にエラーが発生しました: " + e.getMessage());
+            return TutorialStep.NOT_STARTED;
+        }
+    }
+
+    /**
+     * チュートリアルが完了しているか確認
+     * @param uuid プレイヤーUUID
+     * @return 完了している場合true
+     */
+    public boolean isTutorialCompleted(UUID uuid) {
+        TutorialStep step = getCurrentStep(uuid);
+        return step != null && step.isCompleted();
+    }
+
+    /**
+     * 進捗表示を送信
+     * @param player プレイヤー
+     */
+    public void sendProgressDisplay(Player player) {
+        UUID uuid = player.getUniqueId();
+        TutorialStep currentStep = getCurrentStep(uuid);
+
+        if (currentStep == TutorialStep.NOT_STARTED) {
+            String message = plugin.getConfig().getString("tutorial.messages.not_started",
+                    "&cチュートリアルがまだ開始されていません。");
+            player.sendMessage(colorize(message));
+            return;
+        }
+
+        if (currentStep.isCompleted()) {
+            String message = plugin.getConfig().getString("tutorial.messages.already_completed",
+                    "&eチュートリアルは既に完了しています。");
+            player.sendMessage(colorize(message));
+            return;
+        }
+
+        // ヘッダー
+        String header = plugin.getConfig().getString("tutorial.messages.progress.header",
+                "&6▬▬▬▬▬▬▬▬ チュートリアル進捗 ▬▬▬▬▬▬▬▬");
+        player.sendMessage(colorize(header));
+
+        // 現在のステップ
+        String currentStepMsg = plugin.getConfig().getString("tutorial.messages.progress.current_step",
+                "&e現在のステップ: &f%step%");
+        player.sendMessage(colorize(currentStepMsg.replace("%step%", currentStep.getDisplayName())));
+
+        // 各ステップの状態
+        String completeFormat = plugin.getConfig().getString("tutorial.messages.progress.step_complete",
+                "&a✓ %step_name% - 完了");
+        String currentFormat = plugin.getConfig().getString("tutorial.messages.progress.step_current",
+                "&e→ %step_name% - 進行中");
+        String pendingFormat = plugin.getConfig().getString("tutorial.messages.progress.step_pending",
+                "&7○ %step_name% - 未完了");
+
+        TutorialStep[] steps = {TutorialStep.JOB_SELECT, TutorialStep.FIRST_INCOME,
+                TutorialStep.BANK_NPC, TutorialStep.TRADING_NPC};
+
+        for (TutorialStep step : steps) {
+            String format;
+            if (step.getOrder() < currentStep.getOrder()) {
+                format = completeFormat;
+            } else if (step == currentStep) {
+                format = currentFormat;
+            } else {
+                format = pendingFormat;
+            }
+            player.sendMessage(colorize(format.replace("%step_name%", step.getDisplayName())));
+        }
+    }
+
+    /**
+     * 開始メッセージを送信
+     */
+    private void sendStartMessage(Player player) {
+        List<String> messages = plugin.getConfig().getStringList("tutorial.messages.start");
+        for (String message : messages) {
+            player.sendMessage(colorize(message.replace("%player%", player.getName())));
+        }
+    }
+
+    /**
+     * ステップメッセージを送信
+     */
+    private void sendStepMessage(Player player, TutorialStep step) {
+        String configKey = "tutorial.messages." + step.getConfigKey().replace("tutorial.", "");
+
+        String title = plugin.getConfig().getString(configKey + ".title", "");
+        if (!title.isEmpty()) {
+            player.sendMessage(colorize(title));
+        }
+
+        List<String> description = plugin.getConfig().getStringList(configKey + ".description");
+        for (String line : description) {
+            player.sendMessage(colorize(line));
+        }
+    }
+
+    /**
+     * ステップ完了メッセージを送信
+     */
+    private void sendStepCompleteMessage(Player player, TutorialStep step) {
+        String configKey = "tutorial.messages." + step.getConfigKey().replace("tutorial.", "") + ".complete";
+        String message = plugin.getConfig().getString(configKey, "");
+        if (!message.isEmpty()) {
+            player.sendMessage(colorize(message));
+        }
+    }
+
+    /**
+     * 完了メッセージを送信
+     */
+    private void sendCompletedMessage(Player player) {
+        List<String> messages = plugin.getConfig().getStringList("tutorial.messages.completed");
+        for (String message : messages) {
+            player.sendMessage(colorize(message));
+        }
+    }
+
+    /**
+     * 完了報酬を付与
+     */
+    private void giveCompletionReward(Player player) {
+        boolean rewardEnabled = plugin.getConfig().getBoolean("tutorial.completion_rewards.enabled", true);
+        if (!rewardEnabled) {
+            return;
+        }
+
+        double money = plugin.getConfig().getDouble("tutorial.completion_rewards.money", 50.0);
+        if (money > 0) {
+            try {
+                // プレイヤーに報酬を付与
+                var playerDAO = plugin.getPlayerDAO();
+                var playerData = playerDAO.getPlayer(player.getUniqueId());
+                if (playerData != null) {
+                    double newBalance = playerData.getBalance() + money;
+                    playerDAO.updateBalance(player.getUniqueId(), newBalance);
+
+                    String rewardMessage = plugin.getConfig().getString("tutorial.messages.completed_reward",
+                            "&6報酬: &f%money%%currency% &6を獲得しました！");
+                    rewardMessage = rewardMessage
+                            .replace("%money%", String.format("%.0f", money))
+                            .replace("%currency%", configManager.getCurrencyName());
+                    player.sendMessage(colorize(rewardMessage));
+                }
+            } catch (SQLException e) {
+                logger.warning("チュートリアル報酬付与時にエラーが発生しました: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * プレイヤーのキャッシュをクリア（ログアウト時に呼び出す）
+     */
+    public void clearPlayerCache(UUID uuid) {
+        playerProgressCache.remove(uuid);
+    }
+
+    /**
+     * カラーコードを適用
+     */
+    private String colorize(String message) {
+        return ChatColor.translateAlternateColorCodes('&', message);
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/tutorial/TutorialProgressDAO.java
+++ b/src/main/java/org/tofu/tofunomics/tutorial/TutorialProgressDAO.java
@@ -1,0 +1,186 @@
+package org.tofu.tofunomics.tutorial;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.UUID;
+
+/**
+ * チュートリアル進捗のデータベース操作を行うDAO
+ */
+public class TutorialProgressDAO {
+    private final Connection connection;
+
+    public TutorialProgressDAO(Connection connection) {
+        this.connection = connection;
+    }
+
+    /**
+     * プレイヤーのチュートリアル進捗を取得
+     * @param uuid プレイヤーUUID
+     * @return 現在のステップ、レコードがない場合はNOT_STARTED
+     */
+    public TutorialStep getProgress(UUID uuid) throws SQLException {
+        String query = "SELECT current_step FROM tutorial_progress WHERE uuid = ?";
+        try (PreparedStatement stmt = connection.prepareStatement(query)) {
+            stmt.setString(1, uuid.toString());
+            ResultSet rs = stmt.executeQuery();
+            if (rs.next()) {
+                return TutorialStep.fromOrder(rs.getInt("current_step"));
+            }
+        }
+        return TutorialStep.NOT_STARTED;
+    }
+
+    /**
+     * チュートリアル進捗レコードを作成
+     * @param uuid プレイヤーUUID
+     * @param step 初期ステップ
+     */
+    public void createProgress(UUID uuid, TutorialStep step) throws SQLException {
+        String query = "INSERT INTO tutorial_progress (uuid, current_step, started_at) VALUES (?, ?, ?)";
+        try (PreparedStatement stmt = connection.prepareStatement(query)) {
+            stmt.setString(1, uuid.toString());
+            stmt.setInt(2, step.getOrder());
+            stmt.setTimestamp(3, new Timestamp(System.currentTimeMillis()));
+            stmt.executeUpdate();
+        }
+    }
+
+    /**
+     * チュートリアル進捗を更新
+     * @param uuid プレイヤーUUID
+     * @param step 新しいステップ
+     */
+    public void updateProgress(UUID uuid, TutorialStep step) throws SQLException {
+        String columnName = getStepCompletedColumn(step.getOrder() - 1);
+        String query;
+
+        if (columnName != null) {
+            // 前のステップの完了時刻を記録しながら進捗を更新
+            query = "UPDATE tutorial_progress SET current_step = ?, " + columnName + " = ? WHERE uuid = ?";
+            try (PreparedStatement stmt = connection.prepareStatement(query)) {
+                stmt.setInt(1, step.getOrder());
+                stmt.setTimestamp(2, new Timestamp(System.currentTimeMillis()));
+                stmt.setString(3, uuid.toString());
+                stmt.executeUpdate();
+            }
+        } else {
+            query = "UPDATE tutorial_progress SET current_step = ? WHERE uuid = ?";
+            try (PreparedStatement stmt = connection.prepareStatement(query)) {
+                stmt.setInt(1, step.getOrder());
+                stmt.setString(2, uuid.toString());
+                stmt.executeUpdate();
+            }
+        }
+    }
+
+    /**
+     * チュートリアルを完了としてマーク
+     * @param uuid プレイヤーUUID
+     */
+    public void markCompleted(UUID uuid) throws SQLException {
+        String query = "UPDATE tutorial_progress SET current_step = ?, tutorial_completed = TRUE, completed_at = ? WHERE uuid = ?";
+        try (PreparedStatement stmt = connection.prepareStatement(query)) {
+            stmt.setInt(1, TutorialStep.COMPLETED.getOrder());
+            stmt.setTimestamp(2, new Timestamp(System.currentTimeMillis()));
+            stmt.setString(3, uuid.toString());
+            stmt.executeUpdate();
+        }
+    }
+
+    /**
+     * チュートリアルをスキップとしてマーク
+     * @param uuid プレイヤーUUID
+     */
+    public void markSkipped(UUID uuid) throws SQLException {
+        String query = "UPDATE tutorial_progress SET current_step = ?, tutorial_completed = TRUE, tutorial_skipped = TRUE, completed_at = ? WHERE uuid = ?";
+        try (PreparedStatement stmt = connection.prepareStatement(query)) {
+            stmt.setInt(1, TutorialStep.COMPLETED.getOrder());
+            stmt.setTimestamp(2, new Timestamp(System.currentTimeMillis()));
+            stmt.setString(3, uuid.toString());
+            stmt.executeUpdate();
+        }
+    }
+
+    /**
+     * チュートリアル進捗をリセット
+     * @param uuid プレイヤーUUID
+     */
+    public void resetProgress(UUID uuid) throws SQLException {
+        String query = "UPDATE tutorial_progress SET current_step = ?, " +
+                "step1_completed_at = NULL, step2_completed_at = NULL, " +
+                "step3_completed_at = NULL, step4_completed_at = NULL, " +
+                "tutorial_completed = FALSE, tutorial_skipped = FALSE, " +
+                "started_at = ?, completed_at = NULL WHERE uuid = ?";
+        try (PreparedStatement stmt = connection.prepareStatement(query)) {
+            stmt.setInt(1, TutorialStep.JOB_SELECT.getOrder());
+            stmt.setTimestamp(2, new Timestamp(System.currentTimeMillis()));
+            stmt.setString(3, uuid.toString());
+            stmt.executeUpdate();
+        }
+    }
+
+    /**
+     * プレイヤーのチュートリアル進捗レコードが存在するか確認
+     * @param uuid プレイヤーUUID
+     * @return レコードが存在する場合true
+     */
+    public boolean hasProgress(UUID uuid) throws SQLException {
+        String query = "SELECT 1 FROM tutorial_progress WHERE uuid = ?";
+        try (PreparedStatement stmt = connection.prepareStatement(query)) {
+            stmt.setString(1, uuid.toString());
+            ResultSet rs = stmt.executeQuery();
+            return rs.next();
+        }
+    }
+
+    /**
+     * チュートリアルが完了しているか確認
+     * @param uuid プレイヤーUUID
+     * @return 完了している場合true
+     */
+    public boolean isCompleted(UUID uuid) throws SQLException {
+        String query = "SELECT tutorial_completed FROM tutorial_progress WHERE uuid = ?";
+        try (PreparedStatement stmt = connection.prepareStatement(query)) {
+            stmt.setString(1, uuid.toString());
+            ResultSet rs = stmt.executeQuery();
+            if (rs.next()) {
+                return rs.getBoolean("tutorial_completed");
+            }
+        }
+        return false;
+    }
+
+    /**
+     * チュートリアルがスキップされたか確認
+     * @param uuid プレイヤーUUID
+     * @return スキップされた場合true
+     */
+    public boolean isSkipped(UUID uuid) throws SQLException {
+        String query = "SELECT tutorial_skipped FROM tutorial_progress WHERE uuid = ?";
+        try (PreparedStatement stmt = connection.prepareStatement(query)) {
+            stmt.setString(1, uuid.toString());
+            ResultSet rs = stmt.executeQuery();
+            if (rs.next()) {
+                return rs.getBoolean("tutorial_skipped");
+            }
+        }
+        return false;
+    }
+
+    /**
+     * ステップ番号に対応する完了時刻カラム名を取得
+     */
+    private String getStepCompletedColumn(int stepOrder) {
+        return switch (stepOrder) {
+            case 1 -> "step1_completed_at";
+            case 2 -> "step2_completed_at";
+            case 3 -> "step3_completed_at";
+            case 4 -> "step4_completed_at";
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/tutorial/TutorialStep.java
+++ b/src/main/java/org/tofu/tofunomics/tutorial/TutorialStep.java
@@ -1,0 +1,98 @@
+package org.tofu.tofunomics.tutorial;
+
+/**
+ * チュートリアルステップの列挙型
+ * 各ステップは順番に進行し、プレイヤーの行動に応じて完了となる
+ */
+public enum TutorialStep {
+
+    NOT_STARTED(0, "tutorial.not_started", "未開始"),
+    JOB_SELECT(1, "tutorial.step1", "職業選択"),
+    FIRST_INCOME(2, "tutorial.step2", "初収入"),
+    BANK_NPC(3, "tutorial.step3", "銀行NPC"),
+    TRADING_NPC(4, "tutorial.step4", "取引NPC"),
+    COMPLETED(5, "tutorial.completed", "完了");
+
+    private final int order;
+    private final String configKey;
+    private final String displayName;
+
+    TutorialStep(int order, String configKey, String displayName) {
+        this.order = order;
+        this.configKey = configKey;
+        this.displayName = displayName;
+    }
+
+    /**
+     * ステップの順序を取得
+     */
+    public int getOrder() {
+        return order;
+    }
+
+    /**
+     * 設定キーを取得
+     */
+    public String getConfigKey() {
+        return configKey;
+    }
+
+    /**
+     * 表示名を取得
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * 次のステップを取得
+     * @return 次のステップ、既に完了の場合はCOMPLETEDを返す
+     */
+    public TutorialStep getNextStep() {
+        if (this == COMPLETED) {
+            return COMPLETED;
+        }
+        int nextOrder = this.order + 1;
+        for (TutorialStep step : values()) {
+            if (step.order == nextOrder) {
+                return step;
+            }
+        }
+        return COMPLETED;
+    }
+
+    /**
+     * 順序からステップを取得
+     * @param order 順序番号
+     * @return 対応するステップ、見つからない場合はNOT_STARTED
+     */
+    public static TutorialStep fromOrder(int order) {
+        for (TutorialStep step : values()) {
+            if (step.order == order) {
+                return step;
+            }
+        }
+        return NOT_STARTED;
+    }
+
+    /**
+     * このステップが完了済みかどうか
+     */
+    public boolean isCompleted() {
+        return this == COMPLETED;
+    }
+
+    /**
+     * このステップが開始済みかどうか
+     */
+    public boolean isStarted() {
+        return this != NOT_STARTED;
+    }
+
+    /**
+     * 進行中のステップかどうか（開始済みかつ未完了）
+     */
+    public boolean isInProgress() {
+        return isStarted() && !isCompleted();
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -86,6 +86,10 @@ commands:
     description: 中心都市の案内地図を入手する
     usage: /citymap
     permission: tofunomics.citymap.use
+  tutorial:
+    description: チュートリアル進捗確認・管理
+    usage: /tutorial [skip|restart|reset <player>]
+    permission: tofunomics.tutorial.view
 
 permissions:
   tofunomics.*:
@@ -271,4 +275,19 @@ permissions:
   
   tofunomics.rules.reset:
     description: ルール同意状態をリセット（テスト用）
+    default: op
+
+  tofunomics.tutorial.*:
+    description: チュートリアル関連権限（全て）
+    children:
+      tofunomics.tutorial.view: true
+      tofunomics.tutorial.admin: false
+    default: true
+
+  tofunomics.tutorial.view:
+    description: チュートリアル進捗確認・スキップ
+    default: true
+
+  tofunomics.tutorial.admin:
+    description: 他プレイヤーのチュートリアルリセット権限
     default: op


### PR DESCRIPTION
> ⚠️ **このPRは作業中（WIP）のドラフトです。** マージ前にコンフリクト解決・機能整理・動作検証が必要です。現状の作業の可視化・保全を目的に作成しています。

## 概要

チュートリアル機能、tohu-app API連携、職業ガイドブック配布などのWIP実装です。

## 含まれる主な新規機能

- `tutorial/` パッケージ一式（TutorialManager / TutorialCommand / TutorialEventListener / TutorialProgressDAO / TutorialStep）
- `api/client/TohuAppApiClient` / `api/model/PlayerStatsData`（tohu-app API連携）
- `rewards/JobGuideBookManager`（職業ガイドブック配布）
- `events/BankBalanceUpdateNotifier`

## ⚠️ マージ前に対応が必要な事項

### 1. main とのコンフリクト（src 12ファイル）
このブランチは古いベースから派生しており、その後 main にマージされた作業（jobs GUI化 #63、取引カテゴリ刷新 #62 等）と以下が競合します:

`TofuNomics.java` / `JobsCommand.java` / `TradingGUI.java` / `TradingModeSelectionGUI.java` / `PlayerJoinHandler.java` / `JobExperienceManager.java` / `NPCListener.java` / `ScoreboardManager.java` / `UnifiedEventHandler.java` / `TofuNomicsCommand.java` / `TimeAnnouncementSystem.java` / `plugin.yml`

### 2. 職業ガイドブック機能の重複
本ブランチの `rewards/JobGuideBookManager` は、main にマージ済みの **jobs GUI（PR #63）のガイドブック入手機能と重複** します。どちらを採用するか／共存させるかの設計判断が必要です。

### 3. WIP（未完成）
tutorial 機能は実装途中で、ビルド・動作は未検証です。

## 次のステップ（提案）
- main を取り込んでコンフリクトを解決（jobs/trading側の確定実装を基本に、tutorial機能を上乗せ）
- ガイドブック機能の重複を解消
- ビルド・動作検証後に Ready for review へ

🤖 Generated with [Claude Code](https://claude.com/claude-code)