### PR TITLE
deps: 依存ライブラリとCI Actionを最新化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up JDK 21
       uses: actions/setup-java@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up JDK 21
       uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M7</version>
+        <version>3.5.4</version>
         <configuration>
           <includes>
             <include>**/*Test.java</include>
@@ -58,7 +58,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.12</version>
+        <version>0.8.14</version>
         <executions>
           <execution>
             <goals>
@@ -108,7 +108,7 @@
       <dependency>
           <groupId>org.xerial</groupId>
           <artifactId>sqlite-jdbc</artifactId>
-          <version>3.36.0.3</version>
+          <version>3.51.1.0</version>
       </dependency>
       <dependency>
           <groupId>com.sk89q.worldguard</groupId>
@@ -119,7 +119,7 @@
       <dependency>
           <groupId>com.zaxxer</groupId>
           <artifactId>HikariCP</artifactId>
-          <version>6.3.0</version>
+          <version>7.0.2</version>
       </dependency>
       
       <!-- テスト用依存関係 -->


### PR DESCRIPTION
## 概要

dependabot が提案していた依存更新のうち、有効なものをまとめて適用しました。残っていた個別dependabot PR（#28/#29/#30/#15/#21）の内容を統合しています。

## 更新内容

| 対象 | 旧 | 新 | 対応PR |
|---|---|---|---|
| HikariCP | 6.3.0 | 7.0.2 | #28 |
| sqlite-jdbc | 3.36.0.3 | 3.51.1.0 | #29 |
| jacoco-maven-plugin | 0.8.12 | 0.8.14 | #30 |
| maven-surefire-plugin | 3.0.0-M7 | 3.5.4 | #15 |
| actions/checkout | v4 | v6 | #21 |

## 見送った更新

- **#27 worldguard-bukkit 7.0.15**: 本体が既に `7.0.17`（より新しい）のため更新不要・退行になるため見送り
- **#24 actions/upload-artifact v6**: CIが失敗（v4→v6 のbreaking change）。CIワークフローのみの影響でデプロイ物に無関係のため別途対応

## 検証

- ローカルで `mvn clean package` 実行、**全292テスト pass**（HikariCP 7・sqlite 3.51 のメジャー更新でもDB関連テスト含め問題なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)