### PR TITLE
feat: クエスト受注NPC機能を追加

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -96,6 +96,7 @@ public final class TofuNomics extends JavaPlugin {
     private org.tofu.tofunomics.npc.TradingNPCManager tradingNPCManager;
     private org.tofu.tofunomics.npc.FoodNPCManager foodNPCManager;
     private org.tofu.tofunomics.npc.ProcessingNPCManager processingNPCManager;
+    private org.tofu.tofunomics.npc.QuestNPCManager questNPCManager;
     private org.tofu.tofunomics.npc.NPCListener npcListener;
     // 食事による職業経験値ブーストバフ
     private org.tofu.tofunomics.food.FoodBuffManager foodBuffManager;
@@ -105,6 +106,7 @@ public final class TofuNomics extends JavaPlugin {
     private org.tofu.tofunomics.npc.gui.TradingModeSelectionGUI tradingModeSelectionGUI = null;
     private org.tofu.tofunomics.npc.gui.FoodGUI foodGUI;
     private org.tofu.tofunomics.npc.gui.ProcessingGUI processingGUI;
+    private org.tofu.tofunomics.npc.gui.QuestGUI questGUI;
     private org.tofu.tofunomics.npc.gui.QuantitySelectorGUI quantitySelectorGUI;
 
     // エリアシステム
@@ -124,6 +126,7 @@ public final class TofuNomics extends JavaPlugin {
     private org.tofu.tofunomics.dao.MarketListingDAO marketListingDAO;
     private org.tofu.tofunomics.dao.MarketBuyOrderDAO marketBuyOrderDAO;
     private org.tofu.tofunomics.dao.MarketServiceRequestDAO marketServiceRequestDAO;
+    private org.tofu.tofunomics.dao.QuestProgressDAO questProgressDAO;
     private org.tofu.tofunomics.market.MarketManager marketManager;
     private org.tofu.tofunomics.market.gui.MarketBrowseGUI marketBrowseGUI;
     private org.tofu.tofunomics.market.gui.MyListingsGUI myListingsGUI;
@@ -337,6 +340,7 @@ public final class TofuNomics extends JavaPlugin {
             marketListingDAO = new org.tofu.tofunomics.dao.MarketListingDAO(databaseManager.getConnection());
             marketBuyOrderDAO = new org.tofu.tofunomics.dao.MarketBuyOrderDAO(databaseManager.getConnection());
             marketServiceRequestDAO = new org.tofu.tofunomics.dao.MarketServiceRequestDAO(databaseManager.getConnection());
+            questProgressDAO = new org.tofu.tofunomics.dao.QuestProgressDAO(databaseManager.getConnection());
 
             getLogger().info("データアクセス層（DAO）を初期化しました");
         }
@@ -865,9 +869,15 @@ public final class TofuNomics extends JavaPlugin {
             // メインコマンド（NPC管理機能含む）
             if (npcManager != null) {
                 org.tofu.tofunomics.commands.TofuNomicsCommand mainCommand = 
-                    new org.tofu.tofunomics.commands.TofuNomicsCommand(this, configManager, npcManager, bankNPCManager, tradingNPCManager, foodNPCManager, processingNPCManager);
+                    new org.tofu.tofunomics.commands.TofuNomicsCommand(this, configManager, npcManager, bankNPCManager, tradingNPCManager, foodNPCManager, processingNPCManager, questNPCManager);
                 getCommand("tofunomics").setExecutor(mainCommand);
                 getCommand("tofunomics").setTabCompleter(mainCommand);
+
+                // /npc コマンド（plugin.ymlで宣言済み）にもNPC管理機能を直接登録
+                if (getCommand("npc") != null) {
+                    getCommand("npc").setExecutor(mainCommand.getNpcCommand());
+                    getCommand("npc").setTabCompleter(mainCommand.getNpcCommand());
+                }
             }
             
             // ルール確認コマンド（外部サイトURL表示方式）
@@ -1013,6 +1023,15 @@ public final class TofuNomics extends JavaPlugin {
                 jobManager
             );
 
+            // クエストNPCマネージャーの初期化
+            questNPCManager = new org.tofu.tofunomics.npc.QuestNPCManager(
+                this,
+                configManager,
+                npcManager,
+                currencyConverter,
+                questProgressDAO
+            );
+
             // NPCリスナーの初期化
             npcListener = new org.tofu.tofunomics.npc.NPCListener(
                 this,
@@ -1021,7 +1040,8 @@ public final class TofuNomics extends JavaPlugin {
                 bankNPCManager,
                 tradingNPCManager,
                 foodNPCManager,
-                processingNPCManager
+                processingNPCManager,
+                questNPCManager
             );
 
             // TradingGUIの初期化
@@ -1087,6 +1107,18 @@ public final class TofuNomics extends JavaPlugin {
                 processingGUI = null;
             }
 
+            // QuestGUIの初期化
+            try {
+                questGUI = new org.tofu.tofunomics.npc.gui.QuestGUI(
+                    this,
+                    configManager,
+                    questNPCManager
+                );
+            } catch (Exception e) {
+                getLogger().severe("QuestGUIの初期化中にエラーが発生しました: " + e.getMessage());
+                questGUI = null;
+            }
+
             // 既存のシステムNPCを削除（重複防止）
             npcManager.removeExistingSystemNPCs();
 
@@ -1097,6 +1129,7 @@ public final class TofuNomics extends JavaPlugin {
                 tradingNPCManager.initializeTradingNPCs();
                 foodNPCManager.initializeFoodNPCs();
                 processingNPCManager.initializeProcessingNPCs();
+                questNPCManager.initializeQuestNPCs();
 
                 getLogger().info("NPCの生成が完了しました");
             }, 40L);  // 40 ticks = 2秒待機
@@ -1130,7 +1163,11 @@ public final class TofuNomics extends JavaPlugin {
             if (processingGUI != null) {
                 processingGUI.closeAllGUIs();
             }
-            
+
+            if (questGUI != null) {
+                questGUI.closeAllGUIs();
+            }
+
             if (quantitySelectorGUI != null) {
                 quantitySelectorGUI.closeAllGUIs();
             }
@@ -1176,7 +1213,12 @@ public final class TofuNomics extends JavaPlugin {
             getServer().getPluginManager().registerEvents(processingGUI, this);
             getLogger().info("加工GUIリスナーを登録しました");
         }
-        
+
+        if (questGUI != null) {
+            getServer().getPluginManager().registerEvents(questGUI, this);
+            getLogger().info("クエストGUIリスナーを登録しました");
+        }
+
         if (quantitySelectorGUI != null) {
             getServer().getPluginManager().registerEvents(quantitySelectorGUI, this);
             getLogger().info("数量選択GUIリスナーを登録しました");
@@ -1203,6 +1245,10 @@ public final class TofuNomics extends JavaPlugin {
     public org.tofu.tofunomics.npc.ProcessingNPCManager getProcessingNPCManager() {
         return processingNPCManager;
     }
+
+    public org.tofu.tofunomics.npc.QuestNPCManager getQuestNPCManager() {
+        return questNPCManager;
+    }
     
     public org.tofu.tofunomics.npc.gui.BankGUI getBankGUI() {
         return bankGUI;
@@ -1225,6 +1271,10 @@ public final class TofuNomics extends JavaPlugin {
     
     public org.tofu.tofunomics.npc.gui.ProcessingGUI getProcessingGUI() {
         return processingGUI;
+    }
+
+    public org.tofu.tofunomics.npc.gui.QuestGUI getQuestGUI() {
+        return questGUI;
     }
     
     // Phase 6 クラフト制限システムGetter

--- a/src/main/java/org/tofu/tofunomics/commands/NPCCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/NPCCommand.java
@@ -14,6 +14,7 @@ import org.tofu.tofunomics.npc.NPCManager;
 import org.tofu.tofunomics.npc.TradingNPCManager;
 import org.tofu.tofunomics.npc.FoodNPCManager;
 import org.tofu.tofunomics.npc.ProcessingNPCManager;
+import org.tofu.tofunomics.npc.QuestNPCManager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +31,8 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
     private final TradingNPCManager tradingNPCManager;
     private final FoodNPCManager foodNPCManager;
     private final ProcessingNPCManager processingNPCManager;
-    
+    private final QuestNPCManager questNPCManager;
+
     private static final String[] VALID_JOBS = {
         "miner", "woodcutter", "farmer", "fisherman",
         "blacksmith", "alchemist", "enchanter", "architect"
@@ -38,7 +40,8 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
     
     public NPCCommand(TofuNomics plugin, ConfigManager configManager, NPCManager npcManager,
                     BankNPCManager bankNPCManager, TradingNPCManager tradingNPCManager,
-                    FoodNPCManager foodNPCManager, ProcessingNPCManager processingNPCManager) {
+                    FoodNPCManager foodNPCManager, ProcessingNPCManager processingNPCManager,
+                    QuestNPCManager questNPCManager) {
         this.plugin = plugin;
         this.configManager = configManager;
         this.npcManager = npcManager;
@@ -46,6 +49,7 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
         this.tradingNPCManager = tradingNPCManager;
         this.foodNPCManager = foodNPCManager;
         this.processingNPCManager = processingNPCManager;
+        this.questNPCManager = questNPCManager;
     }
     
     @Override
@@ -126,9 +130,11 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
                 return handleSpawnFoodMerchant(player, args, spawnLocation);
             case "processing":
                 return handleSpawnProcessing(player, args, spawnLocation);
+            case "quest":
+                return handleSpawnQuest(player, args, spawnLocation);
             default:
                 sender.sendMessage("§c無効なNPCタイプです: " + npcType);
-                sender.sendMessage("§7有効なタイプ: trader, banker, food_merchant, processing");
+                sender.sendMessage("§7有効なタイプ: trader, banker, food_merchant, processing, quest");
                 return true;
         }
     }
@@ -410,7 +416,62 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
             return true;
         }
     }
-    
+
+    private boolean handleSpawnQuest(Player player, String[] args, Location spawnLocation) {
+        String npcName = args.length > 2 ?
+            String.join(" ", Arrays.copyOfRange(args, 2, args.length)) :
+            "&6クエスト受付";
+        // プレイヤーは§を入力できないため、&カラーコードを§に変換する
+        npcName = org.bukkit.ChatColor.translateAlternateColorCodes('&', npcName);
+
+        try {
+            // クエスト受注NPCを生成
+            Villager questNPC = npcManager.createNPC(spawnLocation, "quest", npcName);
+
+            if (questNPC != null) {
+                // クエスト受注NPCデータをconfig.ymlに自動追加
+                try {
+                    configManager.addQuestNPC(npcName, spawnLocation);
+
+                    // QuestNPCManagerに即座に反映（reloadを使わず直接登録）
+                    if (questNPCManager != null) {
+                        String stationId = "quest_station_" + System.currentTimeMillis();
+                        questNPCManager.registerQuestNPC(
+                            questNPC.getUniqueId(),
+                            stationId,
+                            npcName,
+                            spawnLocation
+                        );
+                        plugin.getLogger().info("クエスト受注NPCをQuestNPCManagerに即座に登録: " + npcName);
+                    }
+
+                    player.sendMessage("§aクエスト受注NPCを生成し、データを追加しました！");
+                    player.sendMessage("§7名前: " + npcName);
+                    player.sendMessage("§7場所: " + formatLocation(spawnLocation));
+                    player.sendMessage("§7UUID: " + questNPC.getUniqueId());
+                    player.sendMessage("§eクエスト受注NPCデータがconfig.ymlに自動追加されました。");
+                    player.sendMessage("§e§l右クリックでクエストメニューを開く");
+                } catch (Exception configError) {
+                    plugin.getLogger().severe("クエスト受注NPCデータの追加に失敗しました: " + configError.getMessage());
+                    player.sendMessage("§aクエスト受注NPCを生成しました！");
+                    player.sendMessage("§cクエスト受注NPCデータの自動追加に失敗しました。手動でconfig.ymlを編集してください。");
+                    player.sendMessage("§7名前: " + npcName);
+                    player.sendMessage("§7場所: " + formatLocation(spawnLocation));
+                    player.sendMessage("§7UUID: " + questNPC.getUniqueId());
+                }
+
+                return true;
+            } else {
+                player.sendMessage("§cクエスト受注NPCの生成に失敗しました");
+                return true;
+            }
+        } catch (Exception e) {
+            player.sendMessage("§cクエスト受注NPC生成中にエラーが発生しました: " + e.getMessage());
+            plugin.getLogger().severe("クエスト受注NPC生成エラー: " + e.getMessage());
+            return true;
+        }
+    }
+
     /**
      * NPC削除コマンド
      */
@@ -629,6 +690,13 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
                 processingNPCManager.reloadProcessingStations();
                 reloadedCount++;
                 sender.sendMessage("§a加工NPCデータをリロードしました");
+            }
+
+            // クエストNPCデータをリロード
+            if (questNPCManager != null) {
+                questNPCManager.reloadQuestData();
+                reloadedCount++;
+                sender.sendMessage("§aクエストNPCデータをリロードしました");
             }
             
             plugin.getLogger().info("NPCデータをリロードしました (" + reloadedCount + "種類)");
@@ -1132,6 +1200,8 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
         sender.sendMessage("§f/npc spawn banker [NPC名] §7- 銀行NPCをスポーン");
         sender.sendMessage("§f/npc spawn food_merchant [NPC名] [タイプ] §7- 食料NPCをスポーン");
         sender.sendMessage("§7食料NPCタイプ: general_store, bakery, butcher, fishmonger, greengrocer, specialty");
+        sender.sendMessage("§f/npc spawn processing [NPC名] §7- 木材加工NPCをスポーン");
+        sender.sendMessage("§f/npc spawn quest [NPC名] §7- クエスト受注NPCをスポーン");
         sender.sendMessage("§f/npc remove <NPC名> §7- NPCを削除");
         sender.sendMessage("§f/npc delete <NPC指定> §7- NPC完全削除（復元不可・簡単指定対応）");
         sender.sendMessage("§f/npc status <NPC名> §7- NPC状況診断（削除フラグ・重複チェック）");
@@ -1183,7 +1253,7 @@ public class NPCCommand implements CommandExecutor, TabCompleter {
         } else if (args.length == 2) {
             switch (args[0].toLowerCase()) {
                 case "spawn":
-                    String[] npcTypes = {"trader", "banker", "food_merchant", "processing"};
+                    String[] npcTypes = {"trader", "banker", "food_merchant", "processing", "quest"};
                     for (String npcType : npcTypes) {
                         if (npcType.startsWith(args[1].toLowerCase())) {
                             completions.add(npcType);

--- a/src/main/java/org/tofu/tofunomics/commands/TofuNomicsCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/TofuNomicsCommand.java
@@ -11,6 +11,7 @@ import org.tofu.tofunomics.npc.NPCManager;
 import org.tofu.tofunomics.npc.TradingNPCManager;
 import org.tofu.tofunomics.npc.FoodNPCManager;
 import org.tofu.tofunomics.npc.ProcessingNPCManager;
+import org.tofu.tofunomics.npc.QuestNPCManager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,13 +26,21 @@ public class TofuNomicsCommand implements CommandExecutor, TabCompleter {
     private final FoodNPCManager foodNPCManager;
 
     public TofuNomicsCommand(TofuNomics plugin, ConfigManager configManager, NPCManager npcManager,
-                        BankNPCManager bankNPCManager, TradingNPCManager tradingNPCManager, FoodNPCManager foodNPCManager, ProcessingNPCManager processingNPCManager) {
+                        BankNPCManager bankNPCManager, TradingNPCManager tradingNPCManager, FoodNPCManager foodNPCManager, ProcessingNPCManager processingNPCManager,
+                        QuestNPCManager questNPCManager) {
     this.plugin = plugin;
     this.configManager = configManager;
     this.tradingNPCManager = tradingNPCManager;
     this.foodNPCManager = foodNPCManager;
-    this.npcCommand = new NPCCommand(plugin, configManager, npcManager, bankNPCManager, tradingNPCManager, foodNPCManager, processingNPCManager);
+    this.npcCommand = new NPCCommand(plugin, configManager, npcManager, bankNPCManager, tradingNPCManager, foodNPCManager, processingNPCManager, questNPCManager);
 }
+
+    /**
+     * NPC管理コマンドの実体を取得（/npc コマンドへの直接登録用）
+     */
+    public NPCCommand getNpcCommand() {
+        return npcCommand;
+    }
     
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -4174,6 +4174,149 @@ public class ConfigManager {
         }
     }
     
+    // ===== クエスト受注NPC =====
+
+    /**
+     * クエストNPCシステムの有効化状態
+     */
+    public boolean isQuestNPCEnabled() {
+        return config.getBoolean("npc_system.quest_npc.enabled", true);
+    }
+
+    /**
+     * 同時に受注できるクエストの最大数（デフォルト5）
+     */
+    public int getMaxConcurrentQuests() {
+        return config.getInt("npc_system.quest_npc.max_concurrent_quests", 5);
+    }
+
+    /**
+     * クエストNPCの配置リストを取得
+     */
+    @SuppressWarnings("unchecked")
+    public List<Map<?, ?>> getQuestNPCConfigs() {
+        return (List<Map<?, ?>>) config.getList("npc_system.quest_npc.locations", new ArrayList<>());
+    }
+
+    /**
+     * クエスト定義リストを取得（npc_system.quest_npc.quests を読み込む）
+     * 無効なMaterial名のエントリはスキップする。
+     */
+    public List<org.tofu.tofunomics.quests.QuestDefinition> getQuestDefinitions() {
+        List<org.tofu.tofunomics.quests.QuestDefinition> definitions = new ArrayList<>();
+        ConfigurationSection section = config.getConfigurationSection("npc_system.quest_npc.quests");
+        if (section == null) {
+            return definitions;
+        }
+
+        for (String key : section.getKeys(false)) {
+            ConfigurationSection q = section.getConfigurationSection(key);
+            if (q == null) {
+                continue;
+            }
+
+            String displayName = org.bukkit.ChatColor.translateAlternateColorCodes('&', q.getString("display_name", key));
+            String description = org.bukkit.ChatColor.translateAlternateColorCodes('&', q.getString("description", ""));
+            String materialName = q.getString("target_material", "");
+            int requiredAmount = q.getInt("required_amount", 1);
+            int rewardNuggets = q.getInt("reward_nuggets", 1);
+
+            org.bukkit.Material material;
+            try {
+                material = org.bukkit.Material.valueOf(materialName.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                plugin.getLogger().warning("クエスト定義の無効なMaterial名をスキップしました: " + materialName + " (quest: " + key + ")");
+                continue;
+            }
+
+            definitions.add(new org.tofu.tofunomics.quests.QuestDefinition(
+                key, displayName, description, material, requiredAmount, rewardNuggets));
+        }
+
+        return definitions;
+    }
+
+    /**
+     * クエストNPCメッセージを取得（フォールバック付き）
+     */
+    public String getQuestNPCMessage(String messageKey) {
+        String message = config.getString("npc_system.quest_npc.messages." + messageKey, null);
+
+        if (message == null) {
+            switch (messageKey) {
+                case "greeting":
+                    return "§6「冒険者よ、討伐の依頼を受けてくれるか？」";
+                case "quest_accepted":
+                    return "§aクエストを受注しました: %quest%";
+                case "quest_completed":
+                    return "§a納品完了！『%quest%』の報酬として金塊 %reward% 個を受け取りました。";
+                case "not_enough_items":
+                    return "§c納品アイテムが不足しています。（%held% / %required%）";
+                default:
+                    return "§7メッセージが見つかりません: " + messageKey;
+            }
+        }
+
+        return org.bukkit.ChatColor.translateAlternateColorCodes('&', message);
+    }
+
+    /**
+     * クエストNPCをconfig.ymlに追加
+     */
+    public void addQuestNPC(String npcName, org.bukkit.Location location) {
+        try {
+            java.util.List<java.util.Map<String, Object>> questNPCs = new java.util.ArrayList<>();
+            java.util.List<java.util.Map<?, ?>> existingNPCs = config.getMapList("npc_system.quest_npc.locations");
+
+            java.util.Map<String, Object> newNPC = new java.util.HashMap<>();
+            newNPC.put("world", location.getWorld().getName());
+            newNPC.put("x", location.getBlockX());
+            newNPC.put("y", location.getBlockY());
+            newNPC.put("z", location.getBlockZ());
+            newNPC.put("id", "quest_" + System.currentTimeMillis());
+            newNPC.put("name", npcName);
+            newNPC.put("yaw", location.getYaw());
+            newNPC.put("pitch", location.getPitch());
+
+            int newX = location.getBlockX();
+            int newY = location.getBlockY();
+            int newZ = location.getBlockZ();
+            String newWorld = location.getWorld().getName();
+            boolean alreadyAdded = false;
+
+            for (java.util.Map<?, ?> npc : existingNPCs) {
+                @SuppressWarnings("unchecked")
+                java.util.Map<String, Object> existingNPC = (java.util.Map<String, Object>) npc;
+
+                if (newWorld.equals(existingNPC.get("world")) &&
+                    newX == ((Number) existingNPC.get("x")).intValue() &&
+                    newY == ((Number) existingNPC.get("y")).intValue() &&
+                    newZ == ((Number) existingNPC.get("z")).intValue()) {
+                    if (!alreadyAdded) {
+                        questNPCs.add(newNPC);
+                        alreadyAdded = true;
+                        plugin.getLogger().info("同じ座標のクエストNPCを更新しました: " + npcName);
+                    }
+                } else {
+                    questNPCs.add(existingNPC);
+                }
+            }
+
+            if (!alreadyAdded) {
+                questNPCs.add(newNPC);
+            }
+
+            config.set("npc_system.quest_npc.locations", questNPCs);
+            plugin.saveConfig();
+
+            plugin.getLogger().info("クエストNPC「" + npcName + "」をconfig.ymlに追加しました");
+            plugin.getLogger().info("  座標: " + newWorld + " (" + newX + ", " + newY + ", " + newZ + ")");
+
+        } catch (Exception e) {
+            plugin.getLogger().severe("クエストNPCデータの追加に失敗しました: " + e.getMessage());
+        }
+    }
+
     /**
      * 加工NPCデータを完全削除（物理削除・復元不可）
      */

--- a/src/main/java/org/tofu/tofunomics/dao/QuestProgressDAO.java
+++ b/src/main/java/org/tofu/tofunomics/dao/QuestProgressDAO.java
@@ -1,0 +1,162 @@
+package org.tofu.tofunomics.dao;
+
+import org.tofu.tofunomics.models.QuestProgress;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * クエスト受注NPCの受注状態のデータアクセスオブジェクト
+ *
+ * 受注状態（どのクエストを受注中か）のみを永続化する。進捗は持たず、
+ * 納品時にインベントリの実数で判定する。
+ */
+public class QuestProgressDAO {
+    private final Connection connection;
+
+    public QuestProgressDAO(Connection connection) {
+        this.connection = connection;
+    }
+
+    /**
+     * クエストを受注（accepted で新規 insert）し、生成された id を返す。
+     * accepted_at は DB 側の DEFAULT CURRENT_TIMESTAMP に委ねる。
+     * UNIQUE(player_uuid, quest_id) 制約に違反する場合は SQLException を送出する。
+     */
+    public int insertProgress(QuestProgress progress) throws SQLException {
+        String query = "INSERT INTO quest_progress (player_uuid, quest_id, status) VALUES (?, ?, ?)";
+        try (PreparedStatement statement = connection.prepareStatement(query, Statement.RETURN_GENERATED_KEYS)) {
+            statement.setString(1, progress.getPlayerUuid().toString());
+            statement.setString(2, progress.getQuestId());
+            statement.setString(3, progress.getStatus() != null ? progress.getStatus() : QuestProgress.STATUS_ACCEPTED);
+            statement.executeUpdate();
+
+            try (ResultSet generatedKeys = statement.getGeneratedKeys()) {
+                if (generatedKeys.next()) {
+                    int id = generatedKeys.getInt(1);
+                    progress.setId(id);
+                    return id;
+                }
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * 指定プレイヤーの指定クエストの受注状態を取得（存在しなければ null）
+     */
+    public QuestProgress getByPlayerAndQuest(UUID playerUuid, String questId) throws SQLException {
+        String query = "SELECT * FROM quest_progress WHERE player_uuid = ? AND quest_id = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUuid.toString());
+            statement.setString(2, questId);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    return mapResultSet(rs);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 指定プレイヤーの受注中（accepted）クエストID集合を取得（GUI 表示用）
+     */
+    public List<QuestProgress> getAcceptedByPlayer(UUID playerUuid) throws SQLException {
+        String query = "SELECT * FROM quest_progress WHERE player_uuid = ? AND status = ?";
+        List<QuestProgress> list = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUuid.toString());
+            statement.setString(2, QuestProgress.STATUS_ACCEPTED);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    list.add(mapResultSet(rs));
+                }
+            }
+        }
+        return list;
+    }
+
+    /**
+     * 指定プレイヤーが指定クエストを受注中（accepted）かどうか
+     */
+    public boolean isAccepted(UUID playerUuid, String questId) throws SQLException {
+        String query = "SELECT COUNT(*) FROM quest_progress WHERE player_uuid = ? AND quest_id = ? AND status = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUuid.toString());
+            statement.setString(2, questId);
+            statement.setString(3, QuestProgress.STATUS_ACCEPTED);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getInt(1) > 0;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 指定プレイヤーの受注中（accepted）クエスト数をカウント（同時受注上限チェック用）
+     */
+    public int countAcceptedByPlayer(UUID playerUuid) throws SQLException {
+        String query = "SELECT COUNT(*) FROM quest_progress WHERE player_uuid = ? AND status = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUuid.toString());
+            statement.setString(2, QuestProgress.STATUS_ACCEPTED);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getInt(1);
+                }
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * 受注を完了に更新（楽観ロック）。
+     * status='accepted' の行のみを対象とし、影響行数が 1 のときだけ成功とする。
+     * これにより、同一クエストへの同時納品（二重報酬）を防止する。
+     *
+     * @return 完了処理に成功した場合 true（影響行数 == 1）
+     */
+    public boolean markAsCompleted(UUID playerUuid, String questId, long completedAtMillis) throws SQLException {
+        String query = "UPDATE quest_progress SET status = ?, completed_at = ? " +
+                "WHERE player_uuid = ? AND quest_id = ? AND status = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, QuestProgress.STATUS_COMPLETED);
+            statement.setTimestamp(2, new Timestamp(completedAtMillis));
+            statement.setString(3, playerUuid.toString());
+            statement.setString(4, questId);
+            statement.setString(5, QuestProgress.STATUS_ACCEPTED);
+            return statement.executeUpdate() == 1;
+        }
+    }
+
+    /**
+     * 指定プレイヤーの指定クエストの受注行を削除（再受注を許可するために使用）
+     */
+    public boolean deleteByPlayerAndQuest(UUID playerUuid, String questId) throws SQLException {
+        String query = "DELETE FROM quest_progress WHERE player_uuid = ? AND quest_id = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUuid.toString());
+            statement.setString(2, questId);
+            return statement.executeUpdate() > 0;
+        }
+    }
+
+    /**
+     * ResultSet から QuestProgress にマッピング
+     */
+    private QuestProgress mapResultSet(ResultSet rs) throws SQLException {
+        QuestProgress progress = new QuestProgress();
+        progress.setId(rs.getInt("id"));
+        progress.setPlayerUuid(UUID.fromString(rs.getString("player_uuid")));
+        progress.setQuestId(rs.getString("quest_id"));
+        progress.setStatus(rs.getString("status"));
+        progress.setAcceptedAt(rs.getTimestamp("accepted_at"));
+        progress.setCompletedAt(rs.getTimestamp("completed_at"));
+        return progress;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/database/DatabaseManager.java
+++ b/src/main/java/org/tofu/tofunomics/database/DatabaseManager.java
@@ -282,6 +282,18 @@ public class DatabaseManager {
             "    expires_at INTEGER," +
             "    fulfilled_at TIMESTAMP," +
             "    FOREIGN KEY (requester_uuid) REFERENCES players(uuid) ON DELETE CASCADE" +
+            ");",
+
+            // クエスト受注NPC用 受注状態テーブル（進捗は納品時にインベントリ実数で判定するため保持しない）
+            "CREATE TABLE IF NOT EXISTS quest_progress (" +
+            "    id INTEGER PRIMARY KEY AUTOINCREMENT," +
+            "    player_uuid TEXT NOT NULL," +
+            "    quest_id TEXT NOT NULL," +
+            "    status TEXT NOT NULL DEFAULT 'accepted'," +
+            "    accepted_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+            "    completed_at TIMESTAMP," +
+            "    UNIQUE(player_uuid, quest_id)," +
+            "    FOREIGN KEY (player_uuid) REFERENCES players(uuid) ON DELETE CASCADE" +
             ");"
         };
 
@@ -429,6 +441,9 @@ public class DatabaseManager {
             statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_buyorder_status ON market_buy_orders(status)");
             statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_buyorder_requester ON market_buy_orders(requester_uuid, status)");
             statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_buyorder_expires ON market_buy_orders(status, expires_at)");
+
+            // クエスト受注状態検索高速化用インデックス（存在しなければ作成）
+            statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_quest_player ON quest_progress(player_uuid, status)");
         } catch (SQLException e) {
             logger.warning("マイグレーション処理に失敗しました: " + e.getMessage());
         }

--- a/src/main/java/org/tofu/tofunomics/models/QuestProgress.java
+++ b/src/main/java/org/tofu/tofunomics/models/QuestProgress.java
@@ -1,0 +1,93 @@
+package org.tofu.tofunomics.models;
+
+import java.sql.Timestamp;
+import java.util.UUID;
+
+/**
+ * クエスト受注NPCの受注状態を表すモデルクラス
+ *
+ * 「集めて納品」形式のため進捗カラムは持たず、納品時のインベントリ実数で都度判定する。
+ * 保持するのは「どのクエストを受注中か」という受注状態のみ。
+ * 完了後の再受注は completed 行を削除して accepted を再 insert する方式で許可する。
+ */
+public class QuestProgress {
+
+    // 受注ステータス定数
+    public static final String STATUS_ACCEPTED = "accepted";    // 受注中（納品待ち）
+    public static final String STATUS_COMPLETED = "completed";  // 納品完了（履歴用途）
+
+    private int id;
+    private UUID playerUuid;
+    private String questId;          // config の quests キー
+    private String status;
+    private Timestamp acceptedAt;
+    private Timestamp completedAt;   // 完了時刻（nullable）
+
+    public QuestProgress() {
+    }
+
+    /**
+     * 新規受注用コンストラクタ（id・acceptedAt は INSERT 時/DB側で確定）
+     */
+    public QuestProgress(UUID playerUuid, String questId) {
+        this.playerUuid = playerUuid;
+        this.questId = questId;
+        this.status = STATUS_ACCEPTED;
+    }
+
+    /**
+     * 受注中（納品可能）かどうか
+     */
+    public boolean isAccepted() {
+        return STATUS_ACCEPTED.equals(status);
+    }
+
+    // Getters and Setters
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public UUID getPlayerUuid() {
+        return playerUuid;
+    }
+
+    public void setPlayerUuid(UUID playerUuid) {
+        this.playerUuid = playerUuid;
+    }
+
+    public String getQuestId() {
+        return questId;
+    }
+
+    public void setQuestId(String questId) {
+        this.questId = questId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Timestamp getAcceptedAt() {
+        return acceptedAt;
+    }
+
+    public void setAcceptedAt(Timestamp acceptedAt) {
+        this.acceptedAt = acceptedAt;
+    }
+
+    public Timestamp getCompletedAt() {
+        return completedAt;
+    }
+
+    public void setCompletedAt(Timestamp completedAt) {
+        this.completedAt = completedAt;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/npc/NPCListener.java
+++ b/src/main/java/org/tofu/tofunomics/npc/NPCListener.java
@@ -29,13 +29,15 @@ public class NPCListener implements Listener {
     private final TradingNPCManager tradingNPCManager;
     private final FoodNPCManager foodNPCManager;
     private final ProcessingNPCManager processingNPCManager;
+    private final QuestNPCManager questNPCManager;
     
     // プレイヤーの取引状態を管理
     private final Map<UUID, TradingSession> activeTradingSessions = new ConcurrentHashMap<>();
     
     public NPCListener(TofuNomics plugin, ConfigManager configManager, NPCManager npcManager,
-                     BankNPCManager bankNPCManager, TradingNPCManager tradingNPCManager, 
-                     FoodNPCManager foodNPCManager, ProcessingNPCManager processingNPCManager) {
+                     BankNPCManager bankNPCManager, TradingNPCManager tradingNPCManager,
+                     FoodNPCManager foodNPCManager, ProcessingNPCManager processingNPCManager,
+                     QuestNPCManager questNPCManager) {
         this.plugin = plugin;
         this.configManager = configManager;
         this.npcManager = npcManager;
@@ -43,6 +45,7 @@ public class NPCListener implements Listener {
         this.tradingNPCManager = tradingNPCManager;
         this.foodNPCManager = foodNPCManager;
         this.processingNPCManager = processingNPCManager;
+        this.questNPCManager = questNPCManager;
     }
     
     private static class TradingSession {
@@ -116,6 +119,10 @@ public class NPCListener implements Listener {
                     handleProcessingNPCInteraction(player, npcId);
                     break;
 
+                case "quest":
+                    handleQuestNPCInteraction(player, npcId);
+                    break;
+
                 default:
                     plugin.getLogger().warning("不明なNPCタイプ: " + npcData.getNpcType());
                     player.sendMessage(configManager.getMessage("npc.unknown_type"));
@@ -165,6 +172,35 @@ public class NPCListener implements Listener {
         }
     }
     
+    /**
+     * クエスト受注NPC相互作用の処理
+     */
+    private void handleQuestNPCInteraction(Player player, UUID npcId) {
+        // クールダウンチェック
+        if (hasRecentInteraction(player.getUniqueId(), "quest")) {
+            player.sendMessage("§c少し待ってからもう一度お試しください。");
+            return;
+        }
+
+        try {
+            if (questNPCManager != null) {
+                boolean handled = questNPCManager.handleQuestNPCInteraction(player, npcId);
+                if (handled) {
+                    activeTradingSessions.put(player.getUniqueId(), new TradingSession(npcId, "quest"));
+                } else {
+                    plugin.getLogger().warning("クエスト受注NPC相互作用の処理に失敗: " + npcId);
+                    player.sendMessage("§cクエスト受注NPCとの処理中にエラーが発生しました。");
+                }
+            } else {
+                plugin.getLogger().severe("QuestNPCManagerが初期化されていません");
+                player.sendMessage("§cクエスト受注NPCシステムが利用できません。管理者にお知らせください。");
+            }
+        } catch (Exception e) {
+            plugin.getLogger().severe("クエスト受注NPC相互作用処理中に例外が発生しました: " + e.getMessage());
+            player.sendMessage("§c処理中にエラーが発生しました。管理者にお知らせください。");
+        }
+    }
+
     /**
      * 加工NPC相互作用の処理
      */

--- a/src/main/java/org/tofu/tofunomics/npc/QuestNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/QuestNPCManager.java
@@ -310,6 +310,25 @@ public class QuestNPCManager {
     }
 
     /**
+     * 同時受注できるクエストの最大数（受注枠の上限）
+     */
+    public int getMaxConcurrentQuests() {
+        return maxConcurrentQuests;
+    }
+
+    /**
+     * 指定プレイヤーが現在受注中のクエスト数（使用中の受注枠）
+     */
+    public int getAcceptedCount(Player player) {
+        try {
+            return questProgressDAO.countAcceptedByPlayer(player.getUniqueId());
+        } catch (SQLException e) {
+            plugin.getLogger().warning("受注中クエスト数の取得に失敗しました: " + e.getMessage());
+            return 0;
+        }
+    }
+
+    /**
      * 指定プレイヤーが指定クエストを受注中かどうか
      */
     public boolean isQuestAccepted(Player player, String questId) {

--- a/src/main/java/org/tofu/tofunomics/npc/QuestNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/QuestNPCManager.java
@@ -1,0 +1,428 @@
+package org.tofu.tofunomics.npc;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.QuestProgressDAO;
+import org.tofu.tofunomics.economy.CurrencyConverter;
+import org.tofu.tofunomics.models.QuestProgress;
+import org.tofu.tofunomics.quests.QuestDefinition;
+
+import java.sql.SQLException;
+import java.util.*;
+
+/**
+ * クエスト受注NPCマネージャー
+ *
+ * 敵モブのドロップを集めて納品すると金塊報酬を受け取れる常設クエストを提供する。
+ * クエスト定義は config.yml の npc_system.quest_npc.quests を駆動とし、
+ * 受注状態は {@link QuestProgressDAO} で永続化する（進捗は持たず、納品時にインベントリ実数で判定）。
+ *
+ * 既存の {@code ProcessingNPCManager} / {@code FoodNPCManager} と同型の構成。
+ */
+public class QuestNPCManager {
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final NPCManager npcManager;
+    private final CurrencyConverter currencyConverter;
+    private final QuestProgressDAO questProgressDAO;
+
+    // クエスト受付所のデータを保持（id -> ステーション）
+    private final Map<String, QuestStation> questStations = new HashMap<>();
+
+    // クエスト定義（questId -> 定義）。config.yml 駆動・挿入順を保持
+    private final Map<String, QuestDefinition> questDefinitions = new LinkedHashMap<>();
+
+    // 同時に受注できるクエストの最大数（config駆動）
+    private int maxConcurrentQuests;
+
+    public QuestNPCManager(TofuNomics plugin, ConfigManager configManager, NPCManager npcManager,
+                           CurrencyConverter currencyConverter, QuestProgressDAO questProgressDAO) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.npcManager = npcManager;
+        this.currencyConverter = currencyConverter;
+        this.questProgressDAO = questProgressDAO;
+
+        loadQuestDefinitions();
+    }
+
+    /**
+     * config.yml からクエスト定義と同時受注上限を読み込む
+     */
+    private void loadQuestDefinitions() {
+        questDefinitions.clear();
+        this.maxConcurrentQuests = configManager.getMaxConcurrentQuests();
+
+        for (QuestDefinition def : configManager.getQuestDefinitions()) {
+            questDefinitions.put(def.getQuestId(), def);
+        }
+
+        plugin.getLogger().info("クエスト定義を読み込みました: " + questDefinitions.size() + "件（同時受注上限: " + maxConcurrentQuests + "）");
+    }
+
+    /**
+     * クエスト受付所データクラス
+     */
+    public static class QuestStation {
+        private final String id;
+        private final String name;
+        private final Location location;
+        private UUID npcId;
+
+        public QuestStation(String id, String name, Location location, UUID npcId) {
+            this.id = id;
+            this.name = name;
+            this.location = location;
+            this.npcId = npcId;
+        }
+
+        public String getId() { return id; }
+        public String getName() { return name; }
+        public Location getLocation() { return location; }
+        public UUID getNpcId() { return npcId; }
+        public void setNpcId(UUID npcId) { this.npcId = npcId; }
+    }
+
+    // ===== NPCライフサイクル =====
+
+    /**
+     * クエストNPCシステムを初期化
+     */
+    public void initializeQuestNPCs() {
+        try {
+            if (!configManager.isQuestNPCEnabled()) {
+                plugin.getLogger().info("クエストNPCシステムは無効化されています");
+                return;
+            }
+
+            spawnQuestNPCs();
+            plugin.getLogger().info("クエストNPCシステムを初期化しました");
+        } catch (Exception e) {
+            plugin.getLogger().severe("クエストNPCシステムの初期化中にエラーが発生しました: " + e.getMessage());
+        }
+    }
+
+    /**
+     * config.ymlの配置情報に基づいてクエストNPCを生成（既存NPCは座標一致で再利用）
+     */
+    private void spawnQuestNPCs() {
+        questStations.clear();
+
+        // 現在スポーン中のクエストNPCを座標キーで索引（重複生成防止）
+        Map<String, UUID> existingNPCsByLocation = new HashMap<>();
+        for (NPCManager.NPCData npc : npcManager.getAllNPCs()) {
+            if ("quest".equals(npc.getNpcType())) {
+                existingNPCsByLocation.put(locationKey(npc.getLocation()), npc.getEntityId());
+            }
+        }
+
+        List<Map<?, ?>> questConfigs = configManager.getQuestNPCConfigs();
+
+        for (Map<?, ?> config : questConfigs) {
+            try {
+                String id = (String) config.get("id");
+                String name = (String) config.get("name");
+                String world = (String) config.get("world");
+                if (id == null || name == null || world == null) {
+                    plugin.getLogger().warning("クエストNPCの設定が不完全です: " + config);
+                    continue;
+                }
+
+                int x = ((Number) config.get("x")).intValue();
+                int y = ((Number) config.get("y")).intValue();
+                int z = ((Number) config.get("z")).intValue();
+
+                float yaw = config.get("yaw") != null ? ((Number) config.get("yaw")).floatValue() : 0.0f;
+                float pitch = config.get("pitch") != null ? ((Number) config.get("pitch")).floatValue() : 0.0f;
+
+                Location location = new Location(plugin.getServer().getWorld(world), x + 0.5, y, z + 0.5, yaw, pitch);
+                String key = world + "," + x + "," + y + "," + z;
+
+                UUID npcId;
+                if (existingNPCsByLocation.containsKey(key)) {
+                    // 既存NPCを再利用
+                    npcId = existingNPCsByLocation.get(key);
+                    NPCManager.NPCData existing = npcManager.getNPCData(npcId);
+                    if (existing != null && existing.getEntity() != null && !name.equals(existing.getName())) {
+                        existing.getEntity().setCustomName(name);
+                    }
+                } else {
+                    // 新規生成
+                    Villager questNPC = npcManager.createNPC(location, "quest", name);
+                    if (questNPC == null) {
+                        plugin.getLogger().severe("クエストNPCの生成に失敗しました: " + name);
+                        continue;
+                    }
+                    setupQuestNPC(questNPC);
+                    npcId = questNPC.getUniqueId();
+                }
+
+                questStations.put(id, new QuestStation(id, name, location, npcId));
+                plugin.getLogger().info("クエスト受付所を登録しました: " + name + " [" + x + ", " + y + ", " + z + "]");
+
+            } catch (Exception e) {
+                plugin.getLogger().warning("クエストNPC処理中にエラーが発生しました: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * クエストNPCの外観設定
+     */
+    private void setupQuestNPC(Villager npc) {
+        // 基本設定は NPCManager.createNPC() で完了済み（職業はNITWIT維持）
+        npc.setVillagerLevel(5);
+    }
+
+    /**
+     * コマンドで生成されたNPCを即座に登録（リロードなし）。NPCCommandからの直接呼び出し用。
+     */
+    public void registerQuestNPC(UUID npcId, String id, String name, Location location) {
+        try {
+            questStations.put(id, new QuestStation(id, name, location, npcId));
+            plugin.getLogger().info("クエストNPCを登録しました: " + name);
+        } catch (Exception e) {
+            plugin.getLogger().severe("クエストNPC即座登録中にエラーが発生: " + e.getMessage());
+        }
+    }
+
+    /**
+     * クエストNPCを削除
+     */
+    public void removeQuestNPCs() {
+        for (NPCManager.NPCData npcData : npcManager.getNPCsByType("quest")) {
+            npcManager.removeNPC(npcData.getEntityId());
+        }
+        questStations.clear();
+        plugin.getLogger().info("全てのクエストNPCを削除しました");
+    }
+
+    /**
+     * クエストNPCをリロード（定義の再読込 + NPC再生成）
+     */
+    public void reloadQuestNPCs() {
+        loadQuestDefinitions();
+        removeQuestNPCs();
+        spawnQuestNPCs();
+        plugin.getLogger().info("クエストNPCのリロードが完了しました");
+    }
+
+    /**
+     * 既存NPCを保持したままクエスト定義と受付所データのみ再読込する。
+     * /npc reload（既存NPC保持方針）から呼び出される。
+     */
+    public void reloadQuestData() {
+        loadQuestDefinitions();
+
+        // config.ymlの配置情報と現在スポーン中のNPCを座標で突き合わせ、stationsを再構築
+        questStations.clear();
+        Map<String, UUID> existingNPCsByLocation = new HashMap<>();
+        for (NPCManager.NPCData npc : npcManager.getNPCsByType("quest")) {
+            existingNPCsByLocation.put(locationKey(npc.getLocation()), npc.getEntityId());
+        }
+
+        for (Map<?, ?> config : configManager.getQuestNPCConfigs()) {
+            try {
+                String id = (String) config.get("id");
+                String name = (String) config.get("name");
+                String world = (String) config.get("world");
+                if (id == null || name == null || world == null) {
+                    continue;
+                }
+                int x = ((Number) config.get("x")).intValue();
+                int y = ((Number) config.get("y")).intValue();
+                int z = ((Number) config.get("z")).intValue();
+                String key = world + "," + x + "," + y + "," + z;
+
+                UUID npcId = existingNPCsByLocation.get(key);
+                if (npcId != null) {
+                    Location location = new Location(plugin.getServer().getWorld(world), x + 0.5, y, z + 0.5);
+                    questStations.put(id, new QuestStation(id, name, location, npcId));
+                } else {
+                    plugin.getLogger().warning("クエスト受付所 " + name + " に対応するNPCが見つかりません");
+                }
+            } catch (Exception e) {
+                plugin.getLogger().warning("クエスト受付所データ更新中にエラーが発生しました: " + e.getMessage());
+            }
+        }
+
+        plugin.getLogger().info("クエストデータの再読み込みが完了しました");
+    }
+
+    // ===== インタラクション =====
+
+    /**
+     * クエストNPCとのインタラクション処理。GUIを開く。
+     */
+    public boolean handleQuestNPCInteraction(Player player, UUID npcId) {
+        try {
+            if (!npcManager.isNPCEntity(npcId)) {
+                plugin.getLogger().warning("NPCエンティティが見つかりません: " + npcId);
+                return false;
+            }
+
+            NPCManager.NPCData npcData = npcManager.getNPCData(npcId);
+            if (npcData == null || !"quest".equals(npcData.getNpcType())) {
+                plugin.getLogger().warning("クエストNPCデータが見つかりません: " + npcId);
+                return false;
+            }
+
+            // 挨拶
+            player.sendMessage(configManager.getQuestNPCMessage("greeting"));
+
+            // GUIを少し遅延して開く（クリック誤爆防止・既存NPCと同挙動）
+            org.tofu.tofunomics.npc.gui.QuestGUI questGUI = plugin.getQuestGUI();
+            if (questGUI == null) {
+                plugin.getLogger().severe("QuestGUIが初期化されていません");
+                player.sendMessage("§cクエストメニューの表示に失敗しました。");
+                return false;
+            }
+
+            int delayTicks = configManager.getNPCGUIDelayTicks();
+            plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+                if (player.isOnline()) {
+                    questGUI.openQuestGUI(player);
+                }
+            }, delayTicks);
+
+            return true;
+
+        } catch (Exception e) {
+            plugin.getLogger().severe("クエストNPC処理中に例外発生: " + e.getMessage());
+            player.sendMessage("§c処理中にエラーが発生しました。");
+            return true;
+        }
+    }
+
+    // ===== GUI向けAPI =====
+
+    /**
+     * 全クエスト定義を取得（GUI表示用）
+     */
+    public Collection<QuestDefinition> getAllQuestDefinitions() {
+        return questDefinitions.values();
+    }
+
+    /**
+     * 指定プレイヤーが指定クエストを受注中かどうか
+     */
+    public boolean isQuestAccepted(Player player, String questId) {
+        try {
+            return questProgressDAO.isAccepted(player.getUniqueId(), questId);
+        } catch (SQLException e) {
+            plugin.getLogger().warning("クエスト受注状態の取得に失敗しました: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * プレイヤーのインベントリ内（収納欄）の指定アイテム所持数を取得
+     */
+    public int getHeldAmount(Player player, Material material) {
+        int count = 0;
+        for (ItemStack item : player.getInventory().getStorageContents()) {
+            if (item != null && item.getType() == material) {
+                count += item.getAmount();
+            }
+        }
+        return count;
+    }
+
+    /**
+     * クエストを受注する。同時受注上限・重複受注をチェックする。
+     */
+    public void acceptQuest(Player player, String questId) {
+        QuestDefinition def = questDefinitions.get(questId);
+        if (def == null) {
+            player.sendMessage("§cそのクエストは存在しません。");
+            return;
+        }
+
+        try {
+            if (questProgressDAO.isAccepted(player.getUniqueId(), questId)) {
+                player.sendMessage("§e既にこのクエストを受注しています。");
+                return;
+            }
+
+            int active = questProgressDAO.countAcceptedByPlayer(player.getUniqueId());
+            if (active >= maxConcurrentQuests) {
+                player.sendMessage("§c同時に受注できるクエストは最大 " + maxConcurrentQuests + " 件までです。");
+                return;
+            }
+
+            // 過去の完了行などが残っていれば削除してから新規受注（リピート受注を許可）
+            questProgressDAO.deleteByPlayerAndQuest(player.getUniqueId(), questId);
+            questProgressDAO.insertProgress(new QuestProgress(player.getUniqueId(), questId));
+
+            player.sendMessage(configManager.getQuestNPCMessage("quest_accepted").replace("%quest%", def.getDisplayName()));
+        } catch (SQLException e) {
+            plugin.getLogger().severe("クエスト受注処理に失敗しました: " + e.getMessage());
+            player.sendMessage("§cクエストの受注に失敗しました。");
+        }
+    }
+
+    /**
+     * クエストを納品する。
+     * 1) 受注中か確認 → 2) 所持数確認 → 3) 完了化を原子的に確定（二重納品防止）
+     * → 4) アイテム消費 → 5) 報酬付与 → 6) 受注行削除（リピート受注を許可）
+     */
+    public void deliverQuest(Player player, String questId) {
+        QuestDefinition def = questDefinitions.get(questId);
+        if (def == null) {
+            player.sendMessage("§cそのクエストは存在しません。");
+            return;
+        }
+
+        try {
+            if (!questProgressDAO.isAccepted(player.getUniqueId(), questId)) {
+                player.sendMessage("§cこのクエストを受注していません。");
+                return;
+            }
+
+            int held = getHeldAmount(player, def.getTargetMaterial());
+            if (held < def.getRequiredAmount()) {
+                player.sendMessage(configManager.getQuestNPCMessage("not_enough_items")
+                    .replace("%held%", String.valueOf(held))
+                    .replace("%required%", String.valueOf(def.getRequiredAmount())));
+                return;
+            }
+
+            // 原子的に完了化（accepted行のみ対象・影響1件のみ成功）。同時納品による二重報酬を防止
+            if (!questProgressDAO.markAsCompleted(player.getUniqueId(), questId, System.currentTimeMillis())) {
+                player.sendMessage("§c納品処理に失敗しました（既に処理済みの可能性があります）。");
+                return;
+            }
+
+            // 納品アイテムを消費
+            player.getInventory().removeItem(new ItemStack(def.getTargetMaterial(), def.getRequiredAmount()));
+
+            // 報酬付与（金塊1:1）。インベントリ満杯時は足元にドロップ
+            boolean given = currencyConverter.receiveCash(player, def.getRewardNuggets());
+            if (!given) {
+                player.getWorld().dropItem(player.getLocation(), new ItemStack(Material.GOLD_NUGGET, def.getRewardNuggets()));
+                player.sendMessage("§eインベントリに空きがなかったため、報酬を足元にドロップしました。");
+            }
+
+            // リピート受注を許可するため受注行を削除
+            questProgressDAO.deleteByPlayerAndQuest(player.getUniqueId(), questId);
+
+            player.sendMessage(configManager.getQuestNPCMessage("quest_completed")
+                .replace("%quest%", def.getDisplayName())
+                .replace("%reward%", String.valueOf(def.getRewardNuggets())));
+
+        } catch (SQLException e) {
+            plugin.getLogger().severe("クエスト納品処理に失敗しました: " + e.getMessage());
+            player.sendMessage("§cクエストの納品に失敗しました。");
+        }
+    }
+
+    private String locationKey(Location loc) {
+        return loc.getWorld().getName() + "," + (int) loc.getX() + "," + (int) loc.getY() + "," + (int) loc.getZ();
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/npc/gui/QuestGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/QuestGUI.java
@@ -1,0 +1,236 @@
+package org.tofu.tofunomics.npc.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.npc.QuestNPCManager;
+import org.tofu.tofunomics.quests.QuestDefinition;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * クエスト受注NPCのGUI
+ *
+ * クエスト一覧を1スロット1クエストで表示し、未受注クエストのクリックで受注、
+ * 受注中クエストのクリックで納品を行う。BankGUI と同型に自身が Listener を実装する。
+ */
+public class QuestGUI implements Listener {
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final QuestNPCManager questNPCManager;
+
+    private final Map<UUID, QuestGUISession> activeSessions = new ConcurrentHashMap<>();
+
+    // クエストアイコンを並べる先頭スロット（27スロットインベントリの中央付近）
+    private static final int[] QUEST_SLOTS = {10, 11, 12, 13, 14, 15, 16};
+    private static final int CLOSE_SLOT = 26;
+
+    public QuestGUI(TofuNomics plugin, ConfigManager configManager, QuestNPCManager questNPCManager) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.questNPCManager = questNPCManager;
+    }
+
+    private static class QuestGUISession {
+        private final UUID playerId;
+        private final Inventory inventory;
+        // スロット番号 -> questId のマッピング
+        private final Map<Integer, String> slotToQuestId = new HashMap<>();
+
+        public QuestGUISession(UUID playerId, Inventory inventory) {
+            this.playerId = playerId;
+            this.inventory = inventory;
+        }
+
+        public UUID getPlayerId() { return playerId; }
+        public Inventory getInventory() { return inventory; }
+        public Map<Integer, String> getSlotToQuestId() { return slotToQuestId; }
+    }
+
+    /**
+     * クエストGUIを開く
+     */
+    public void openQuestGUI(Player player) {
+        try {
+            String title = "§6討伐クエスト受付";
+            Inventory gui = Bukkit.createInventory(null, 27, title);
+
+            QuestGUISession session = new QuestGUISession(player.getUniqueId(), gui);
+            activeSessions.put(player.getUniqueId(), session);
+
+            setupQuestGUIItems(session, player);
+            player.openInventory(gui);
+
+        } catch (Exception e) {
+            plugin.getLogger().severe("クエストGUI作成中にエラーが発生しました: " + e.getMessage());
+            player.sendMessage("§cクエストメニューの表示に失敗しました。");
+        }
+    }
+
+    /**
+     * GUIアイテムを配置（受注状態・所持数を反映して再描画にも使う）
+     */
+    private void setupQuestGUIItems(QuestGUISession session, Player player) {
+        Inventory gui = session.getInventory();
+        gui.clear();
+        session.getSlotToQuestId().clear();
+
+        // ヘッダー
+        gui.setItem(4, createGUIItem(Material.WRITABLE_BOOK, "§6討伐クエスト",
+            Arrays.asList(
+                "§7敵モブのドロップを集めて納品しよう",
+                "§7クリックで受注 / 受注中はクリックで納品"
+            )));
+
+        Collection<QuestDefinition> quests = questNPCManager.getAllQuestDefinitions();
+        int slotIndex = 0;
+        for (QuestDefinition def : quests) {
+            if (slotIndex >= QUEST_SLOTS.length) {
+                // スロット数を超えるクエストは表示しきれない（運用上は QUEST_SLOTS を拡張）
+                plugin.getLogger().warning("表示可能なクエスト数（" + QUEST_SLOTS.length + "）を超えています。一部のクエストは表示されません。");
+                break;
+            }
+            int slot = QUEST_SLOTS[slotIndex];
+            boolean accepted = questNPCManager.isQuestAccepted(player, def.getQuestId());
+            int held = questNPCManager.getHeldAmount(player, def.getTargetMaterial());
+
+            gui.setItem(slot, createQuestItem(def, accepted, held));
+            session.getSlotToQuestId().put(slot, def.getQuestId());
+            slotIndex++;
+        }
+
+        // 閉じるボタン
+        gui.setItem(CLOSE_SLOT, createGUIItem(Material.BARRIER, "§c閉じる",
+            Collections.singletonList("§7GUIを閉じます")));
+
+        // 装飾
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glassPane = createGUIItem(Material.YELLOW_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int slot = 0; slot < gui.getSize(); slot++) {
+                if (gui.getItem(slot) == null) {
+                    gui.setItem(slot, glassPane);
+                }
+            }
+        }
+    }
+
+    /**
+     * 1クエスト分の表示アイテムを生成
+     */
+    private ItemStack createQuestItem(QuestDefinition def, boolean accepted, int held) {
+        List<String> lore = new ArrayList<>();
+        lore.add("§7" + def.getDescription());
+        lore.add("");
+        lore.add("§f対象: §e" + def.getTargetMaterial().name());
+        lore.add("§f必要数: §e" + def.getRequiredAmount() + " 個");
+        lore.add("§f報酬: §6" + def.getRewardNuggets() + " 金塊");
+        lore.add("§f所持数: " + (held >= def.getRequiredAmount() ? "§a" : "§c") + held + " / " + def.getRequiredAmount());
+        lore.add("");
+        if (accepted) {
+            if (held >= def.getRequiredAmount()) {
+                lore.add("§a▶ 受注中 - クリックで納品！");
+            } else {
+                lore.add("§e▶ 受注中 - アイテムを集めよう");
+            }
+        } else {
+            lore.add("§b▶ クリックで受注");
+        }
+
+        String prefix = accepted ? "§a[受注中] " : "§f";
+        return createGUIItem(def.getTargetMaterial(), prefix + def.getDisplayName(), lore);
+    }
+
+    private ItemStack createGUIItem(Material material, String name, List<String> lore) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) {
+            return;
+        }
+
+        Player player = (Player) event.getWhoClicked();
+        UUID playerId = player.getUniqueId();
+
+        QuestGUISession session = activeSessions.get(playerId);
+        if (session == null || !session.getInventory().equals(event.getInventory())) {
+            return;
+        }
+
+        event.setCancelled(true);
+
+        ItemStack clickedItem = event.getCurrentItem();
+        if (clickedItem == null || clickedItem.getType() == Material.AIR) {
+            return;
+        }
+
+        int slot = event.getSlot();
+
+        if (slot == CLOSE_SLOT) {
+            player.closeInventory();
+            return;
+        }
+
+        String questId = session.getSlotToQuestId().get(slot);
+        if (questId == null) {
+            return;
+        }
+
+        try {
+            if (questNPCManager.isQuestAccepted(player, questId)) {
+                // 受注中 → 納品を試行
+                questNPCManager.deliverQuest(player, questId);
+            } else {
+                // 未受注 → 受注
+                questNPCManager.acceptQuest(player, questId);
+            }
+            // 状態が変わったので再描画
+            setupQuestGUIItems(session, player);
+        } catch (Exception e) {
+            plugin.getLogger().severe("クエストGUIクリック処理中にエラーが発生しました: " + e.getMessage());
+            player.sendMessage("§c処理中にエラーが発生しました。");
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player)) {
+            return;
+        }
+        Player player = (Player) event.getPlayer();
+        activeSessions.remove(player.getUniqueId());
+    }
+
+    public void closeAllGUIs() {
+        for (QuestGUISession session : activeSessions.values()) {
+            Player player = Bukkit.getPlayer(session.getPlayerId());
+            if (player != null && player.isOnline()) {
+                player.closeInventory();
+            }
+        }
+        activeSessions.clear();
+    }
+
+    public int getActiveSessionsCount() {
+        return activeSessions.size();
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/npc/gui/QuestGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/QuestGUI.java
@@ -86,11 +86,18 @@ public class QuestGUI implements Listener {
         gui.clear();
         session.getSlotToQuestId().clear();
 
+        // 受注枠（同時受注上限）の使用状況
+        int maxQuests = questNPCManager.getMaxConcurrentQuests();
+        int acceptedCount = questNPCManager.getAcceptedCount(player);
+        int remaining = Math.max(0, maxQuests - acceptedCount);
+
         // ヘッダー
         gui.setItem(4, createGUIItem(Material.WRITABLE_BOOK, "§6討伐クエスト",
             Arrays.asList(
                 "§7敵モブのドロップを集めて納品しよう",
-                "§7クリックで受注 / 受注中はクリックで納品"
+                "§7クリックで受注 / 受注中はクリックで納品",
+                "",
+                "§f受注枠: §e" + acceptedCount + " / " + maxQuests + " §7（残り " + remaining + "）"
             )));
 
         Collection<QuestDefinition> quests = questNPCManager.getAllQuestDefinitions();
@@ -105,7 +112,7 @@ public class QuestGUI implements Listener {
             boolean accepted = questNPCManager.isQuestAccepted(player, def.getQuestId());
             int held = questNPCManager.getHeldAmount(player, def.getTargetMaterial());
 
-            gui.setItem(slot, createQuestItem(def, accepted, held));
+            gui.setItem(slot, createQuestItem(def, accepted, held, acceptedCount, maxQuests));
             session.getSlotToQuestId().put(slot, def.getQuestId());
             slotIndex++;
         }
@@ -128,7 +135,7 @@ public class QuestGUI implements Listener {
     /**
      * 1クエスト分の表示アイテムを生成
      */
-    private ItemStack createQuestItem(QuestDefinition def, boolean accepted, int held) {
+    private ItemStack createQuestItem(QuestDefinition def, boolean accepted, int held, int acceptedCount, int maxQuests) {
         List<String> lore = new ArrayList<>();
         lore.add("§7" + def.getDescription());
         lore.add("");
@@ -136,6 +143,7 @@ public class QuestGUI implements Listener {
         lore.add("§f必要数: §e" + def.getRequiredAmount() + " 個");
         lore.add("§f報酬: §6" + def.getRewardNuggets() + " 金塊");
         lore.add("§f所持数: " + (held >= def.getRequiredAmount() ? "§a" : "§c") + held + " / " + def.getRequiredAmount());
+        lore.add("§f受注枠: §e" + acceptedCount + " / " + maxQuests);
         lore.add("");
         if (accepted) {
             if (held >= def.getRequiredAmount()) {
@@ -143,6 +151,8 @@ public class QuestGUI implements Listener {
             } else {
                 lore.add("§e▶ 受注中 - アイテムを集めよう");
             }
+        } else if (acceptedCount >= maxQuests) {
+            lore.add("§c✖ 受注枠が上限です（他のクエストを納品/整理してください）");
         } else {
             lore.add("§b▶ クリックで受注");
         }

--- a/src/main/java/org/tofu/tofunomics/quests/QuestDefinition.java
+++ b/src/main/java/org/tofu/tofunomics/quests/QuestDefinition.java
@@ -1,0 +1,56 @@
+package org.tofu.tofunomics.quests;
+
+import org.bukkit.Material;
+
+/**
+ * クエスト受注NPCで提供する1件のクエスト定義（不変オブジェクト）
+ *
+ * config.yml の npc_system.quest_npc.quests 配下の各エントリに対応する。
+ * 敵モブの基本ドロップ（腐肉・骨・糸など）を required_amount だけ納品すると
+ * reward_nuggets の金塊を受け取れる、という常設クエストを表す。
+ *
+ * 既存の {@link JobQuest}（職業クエスト・メモリ管理）とは別系統のため、別名のクラスとして定義する。
+ */
+public final class QuestDefinition {
+
+    private final String questId;          // config の quests キー（例: rotten_flesh_1）
+    private final String displayName;      // GUI 表示名
+    private final String description;      // 説明文
+    private final Material targetMaterial; // 納品対象アイテム
+    private final int requiredAmount;      // 必要納品数
+    private final int rewardNuggets;       // 報酬金塊数（1以上の整数）
+
+    public QuestDefinition(String questId, String displayName, String description,
+                           Material targetMaterial, int requiredAmount, int rewardNuggets) {
+        this.questId = questId;
+        this.displayName = displayName;
+        this.description = description;
+        this.targetMaterial = targetMaterial;
+        this.requiredAmount = requiredAmount;
+        this.rewardNuggets = rewardNuggets;
+    }
+
+    public String getQuestId() {
+        return questId;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Material getTargetMaterial() {
+        return targetMaterial;
+    }
+
+    public int getRequiredAmount() {
+        return requiredAmount;
+    }
+
+    public int getRewardNuggets() {
+        return rewardNuggets;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1587,6 +1587,74 @@ npc_system:
       fee_charged: "§e加工料金: %fee%"
       outside_hours: "§c申し訳ありませんが、営業時間外です。"
 
+  # クエスト受注NPCの設定
+  quest_npc:
+    # クエストNPCシステムの有効化
+    enabled: true
+
+    # 同時に受注できるクエストの最大数
+    max_concurrent_quests: 5
+
+    # クエスト定義（敵モブのドロップを集めて納品 → 金塊報酬）
+    # ここに追記するだけでクエストを増やせる（コード変更不要）
+    # target_material は Bukkit の Material 名（大文字）で指定する
+    quests:
+      rotten_flesh_1:
+        display_name: "&2腐肉の処理"
+        description: "ゾンビの腐肉を集めて納品しよう"
+        target_material: "ROTTEN_FLESH"
+        required_amount: 32
+        reward_nuggets: 40
+      bone_1:
+        display_name: "&fスケルトン討伐"
+        description: "スケルトンの骨を集めて納品しよう"
+        target_material: "BONE"
+        required_amount: 32
+        reward_nuggets: 48
+      string_1:
+        display_name: "&7クモの巣払い"
+        description: "クモの糸を集めて納品しよう"
+        target_material: "STRING"
+        required_amount: 32
+        reward_nuggets: 44
+      gunpowder_1:
+        display_name: "&8クリーパー掃討"
+        description: "クリーパーの火薬を集めて納品しよう"
+        target_material: "GUNPOWDER"
+        required_amount: 16
+        reward_nuggets: 64
+      spider_eye_1:
+        display_name: "&cクモの目集め"
+        description: "クモの目を集めて納品しよう"
+        target_material: "SPIDER_EYE"
+        required_amount: 16
+        reward_nuggets: 56
+      ender_pearl_1:
+        display_name: "&5エンダーマン討伐"
+        description: "エンダーパールを集めて納品しよう"
+        target_material: "ENDER_PEARL"
+        required_amount: 8
+        reward_nuggets: 120
+
+    # クエストNPCの配置（サーバー上で /npc spawn quest により追加される）
+    locations: []
+    # 設定例:
+    # - world: "tofunomics"
+    #   x: -150
+    #   y: 70
+    #   z: -150
+    #   id: "quest_001"
+    #   name: "§6クエスト受付"
+    #   yaw: 0.0
+    #   pitch: 0.0
+
+    # メッセージ設定
+    messages:
+      greeting: "&6「冒険者よ、討伐の依頼を受けてくれるか？」"
+      quest_accepted: "&aクエストを受注しました: %quest%"
+      quest_completed: "&a納品完了！『%quest%』の報酬として金塊 %reward% 個を受け取りました。"
+      not_enough_items: "&c納品アイテムが不足しています。（%held% / %required%）"
+
   # 取引所の設定
   trading_posts: []
   # 取引所の設定例（職業別NPC）:

--- a/src/test/java/org/tofu/tofunomics/dao/QuestProgressDAOTest.java
+++ b/src/test/java/org/tofu/tofunomics/dao/QuestProgressDAOTest.java
@@ -1,0 +1,158 @@
+package org.tofu.tofunomics.dao;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.tofu.tofunomics.models.QuestProgress;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * QuestProgressDAO 単体テスト
+ *
+ * 本番 DatabaseManager と同一の DDL を SQLite インメモリ DB に作成して検証する
+ * （AUTOINCREMENT・DEFAULT CURRENT_TIMESTAMP・UNIQUE 制約・楽観ロックによる二重納品防止を本番同等に再現）。
+ */
+public class QuestProgressDAOTest {
+
+    private Connection connection;
+    private QuestProgressDAO dao;
+
+    @Before
+    public void setUp() throws SQLException {
+        connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+
+        String createTable = "CREATE TABLE IF NOT EXISTS quest_progress (" +
+                "    id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                "    player_uuid TEXT NOT NULL," +
+                "    quest_id TEXT NOT NULL," +
+                "    status TEXT NOT NULL DEFAULT 'accepted'," +
+                "    accepted_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+                "    completed_at TIMESTAMP," +
+                "    UNIQUE(player_uuid, quest_id)" +
+                ");";
+
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(createTable);
+        }
+
+        dao = new QuestProgressDAO(connection);
+    }
+
+    @After
+    public void tearDown() throws SQLException {
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void testInsertAndIsAccepted() throws SQLException {
+        UUID player = UUID.randomUUID();
+        int id = dao.insertProgress(new QuestProgress(player, "rotten_flesh_1"));
+
+        assertTrue("生成された id は正の値であるべき", id > 0);
+        assertTrue("受注直後は accepted であるべき", dao.isAccepted(player, "rotten_flesh_1"));
+
+        QuestProgress fetched = dao.getByPlayerAndQuest(player, "rotten_flesh_1");
+        assertNotNull("挿入した受注が取得できるべき", fetched);
+        assertEquals(player, fetched.getPlayerUuid());
+        assertEquals("rotten_flesh_1", fetched.getQuestId());
+        assertEquals(QuestProgress.STATUS_ACCEPTED, fetched.getStatus());
+        assertNotNull("accepted_at は DEFAULT で自動設定されるべき", fetched.getAcceptedAt());
+        assertNull("未完了の completed_at は null であるべき", fetched.getCompletedAt());
+    }
+
+    @Test(expected = SQLException.class)
+    public void testDuplicateInsertViolatesUnique() throws SQLException {
+        UUID player = UUID.randomUUID();
+        dao.insertProgress(new QuestProgress(player, "bone_1"));
+        // 同一プレイヤー・同一クエストの二重受注は UNIQUE 制約違反
+        dao.insertProgress(new QuestProgress(player, "bone_1"));
+    }
+
+    @Test
+    public void testGetByPlayerAndQuestNotFound() throws SQLException {
+        assertNull("存在しない受注は null を返すべき",
+                dao.getByPlayerAndQuest(UUID.randomUUID(), "unknown_quest"));
+    }
+
+    @Test
+    public void testCountAndGetAcceptedByPlayer() throws SQLException {
+        UUID player = UUID.randomUUID();
+        dao.insertProgress(new QuestProgress(player, "rotten_flesh_1"));
+        dao.insertProgress(new QuestProgress(player, "bone_1"));
+        dao.insertProgress(new QuestProgress(player, "string_1"));
+        // 別プレイヤーの受注はカウントに含めない
+        dao.insertProgress(new QuestProgress(UUID.randomUUID(), "rotten_flesh_1"));
+
+        assertEquals("対象プレイヤーの受注中は3件", 3, dao.countAcceptedByPlayer(player));
+
+        List<QuestProgress> accepted = dao.getAcceptedByPlayer(player);
+        assertEquals("受注中リストは3件", 3, accepted.size());
+    }
+
+    @Test
+    public void testMarkAsCompletedOnceAndPreventsDouble() throws SQLException {
+        UUID player = UUID.randomUUID();
+        dao.insertProgress(new QuestProgress(player, "gunpowder_1"));
+
+        long now = 1_700_000_000_000L;
+        boolean first = dao.markAsCompleted(player, "gunpowder_1", now);
+        assertTrue("初回の納品完了は成功するべき", first);
+
+        // 二重納品防止: 既に completed なので2回目は失敗（楽観ロック）
+        boolean second = dao.markAsCompleted(player, "gunpowder_1", now);
+        assertFalse("2回目の納品完了は失敗するべき", second);
+
+        assertFalse("完了後は accepted ではない", dao.isAccepted(player, "gunpowder_1"));
+
+        QuestProgress fetched = dao.getByPlayerAndQuest(player, "gunpowder_1");
+        assertEquals(QuestProgress.STATUS_COMPLETED, fetched.getStatus());
+        assertNotNull("completed_at が設定されるべき", fetched.getCompletedAt());
+    }
+
+    @Test
+    public void testMarkAsCompletedWithoutAcceptReturnsFalse() throws SQLException {
+        // 受注していないクエストの完了化は何も更新しない
+        boolean ok = dao.markAsCompleted(UUID.randomUUID(), "spider_eye_1", 1_700_000_000_000L);
+        assertFalse("未受注クエストの完了化は失敗するべき", ok);
+    }
+
+    @Test
+    public void testDeleteAllowsReaccept() throws SQLException {
+        UUID player = UUID.randomUUID();
+        dao.insertProgress(new QuestProgress(player, "ender_pearl_1"));
+        dao.markAsCompleted(player, "ender_pearl_1", 1_700_000_000_000L);
+
+        // 完了行を削除すれば同一クエストを再受注できる（リピート受注）
+        boolean deleted = dao.deleteByPlayerAndQuest(player, "ender_pearl_1");
+        assertTrue("受注行の削除に成功するべき", deleted);
+        assertNull("削除後は行が存在しない", dao.getByPlayerAndQuest(player, "ender_pearl_1"));
+
+        int newId = dao.insertProgress(new QuestProgress(player, "ender_pearl_1"));
+        assertTrue("削除後は同一クエストを再受注できるべき", newId > 0);
+        assertTrue("再受注後は accepted であるべき", dao.isAccepted(player, "ender_pearl_1"));
+    }
+
+    @Test
+    public void testDeleteNonExistentReturnsFalse() throws SQLException {
+        assertFalse("存在しない受注の削除は false を返すべき",
+                dao.deleteByPlayerAndQuest(UUID.randomUUID(), "nope"));
+    }
+
+    @Test
+    public void testIsAcceptedFalseForOtherQuest() throws SQLException {
+        UUID player = UUID.randomUUID();
+        dao.insertProgress(new QuestProgress(player, "rotten_flesh_1"));
+        assertFalse("受注していない別クエストは accepted ではない",
+                dao.isAccepted(player, "bone_1"));
+    }
+}

--- a/src/test/java/org/tofu/tofunomics/models/QuestProgressTest.java
+++ b/src/test/java/org/tofu/tofunomics/models/QuestProgressTest.java
@@ -1,0 +1,41 @@
+package org.tofu.tofunomics.models;
+
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * QuestProgress モデル単体テスト
+ */
+public class QuestProgressTest {
+
+    @Test
+    public void testNewProgressConstructorDefaultsToAccepted() {
+        UUID player = UUID.randomUUID();
+        QuestProgress progress = new QuestProgress(player, "rotten_flesh_1");
+
+        assertEquals(player, progress.getPlayerUuid());
+        assertEquals("rotten_flesh_1", progress.getQuestId());
+        assertEquals(QuestProgress.STATUS_ACCEPTED, progress.getStatus());
+        assertTrue("新規受注は accepted 判定であるべき", progress.isAccepted());
+    }
+
+    @Test
+    public void testIsAcceptedReflectsStatus() {
+        QuestProgress progress = new QuestProgress(UUID.randomUUID(), "bone_1");
+
+        progress.setStatus(QuestProgress.STATUS_COMPLETED);
+        assertFalse("completed は accepted ではない", progress.isAccepted());
+
+        progress.setStatus(QuestProgress.STATUS_ACCEPTED);
+        assertTrue("accepted に戻せば accepted 判定", progress.isAccepted());
+    }
+
+    @Test
+    public void testIsAcceptedNullStatus() {
+        QuestProgress progress = new QuestProgress();
+        assertFalse("status 未設定なら accepted ではない", progress.isAccepted());
+    }
+}

--- a/src/test/java/org/tofu/tofunomics/quests/QuestDefinitionTest.java
+++ b/src/test/java/org/tofu/tofunomics/quests/QuestDefinitionTest.java
@@ -1,0 +1,26 @@
+package org.tofu.tofunomics.quests;
+
+import org.bukkit.Material;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * QuestDefinition 単体テスト（不変オブジェクトのアクセサ検証）
+ */
+public class QuestDefinitionTest {
+
+    @Test
+    public void testGetters() {
+        QuestDefinition def = new QuestDefinition(
+                "rotten_flesh_1", "§2腐肉の処理", "ゾンビの腐肉を集めて納品しよう",
+                Material.ROTTEN_FLESH, 32, 40);
+
+        assertEquals("rotten_flesh_1", def.getQuestId());
+        assertEquals("§2腐肉の処理", def.getDisplayName());
+        assertEquals("ゾンビの腐肉を集めて納品しよう", def.getDescription());
+        assertEquals(Material.ROTTEN_FLESH, def.getTargetMaterial());
+        assertEquals(32, def.getRequiredAmount());
+        assertEquals(40, def.getRewardNuggets());
+    }
+}


### PR DESCRIPTION
## 概要
敵モブのドロップを集めて納品すると金塊報酬を受け取れる、常設のクエスト受注NPCを追加します。実機（1.21 Lobby）でNPC設置・受注・納品まで動作確認済みです。

## 主な変更
- **`QuestNPCManager`**: config駆動のクエスト定義読込・NPC生成/登録/リロード・受注/納品処理
- **`QuestGUI`**: クエスト一覧表示・受注・納品のGUI（1スロット1クエスト、所持数・受注状態を反映）
- **`QuestProgressDAO` / `QuestProgress`**: 受注状態の永続化。`markAsCompleted` の楽観ロックで**二重納品（二重報酬）を防止**
- **`QuestDefinition`**: config駆動のクエスト定義（不変オブジェクト）
- **`quest_progress` テーブル**を `DatabaseManager` に追加
- **`config.yml`** に `npc_system.quest_npc` セクションとデフォルトクエスト6種（腐肉/骨/糸/火薬/クモの目/エンダーパール）を追加

## 仕様
- **リピート受注可・同時受注上限あり**（`max_concurrent_quests`、デフォルト5）
- 報酬は金塊1:1付与。インベントリ満杯時は足元にドロップ
- 納品は `markAsCompleted`（accepted行のみ対象・影響1件のみ成功）で原子的に確定 → アイテム消費 → 報酬付与 → 受注行削除で再受注可

## 不具合修正（付随）
- **`/npc` コマンドにexecutorを登録**: plugin.ymlで宣言済みだったが `setExecutor` が無く、`/npc spawn ...` が無反応だった問題を修正
- **NPC名の `&` カラーコード対応**: プレイヤーは `§` を直接入力できないため、`&6` 形式を `§` に変換

## テスト
- `QuestProgressDAOTest`（9件）: UNIQUE制約・受注/カウント/完了化の楽観ロック・削除による再受注
- `QuestProgressTest`（3件）・`QuestDefinitionTest`（1件）
- 全13件パス

## 動作確認
- 1.21 Lobbyサーバーへデプロイ済み
- `/npc spawn quest &6クエスト受付` でNPC設置 → 右クリックでGUI → クエスト受注を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)