### PR TITLE
feat: 建築家・エンチャンター・ポーション屋を上級職業化

### DIFF
--- a/src/main/java/org/tofu/tofunomics/commands/JobsCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/JobsCommand.java
@@ -182,7 +182,12 @@ public class JobsCommand implements CommandExecutor {
                 int maxJobs = configManager.getMaxJobsPerPlayer();
                 player.sendMessage(ChatColor.RED + "同時に就ける職業数の上限(" + maxJobs + ")に達しています。");
                 break;
-                
+
+            case ADVANCED_JOB_LOCKED:
+                player.sendMessage(ChatColor.RED + "「" + jobManager.getJobDisplayName(jobName)
+                    + "」は上級職業です。いずれかの職業でレベル50に到達すると就職できます。");
+                break;
+
             case DATABASE_ERROR:
                 player.sendMessage(ChatColor.RED + "データベースエラーが発生しました。しばらくしてから再度お試しください。");
                 break;

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -474,6 +474,26 @@ public class ConfigManager {
     public int getJobChangeCooldown() {
         return config.getInt("jobs.general.job_change_cooldown", 86400);
     }
+
+    /**
+     * 上級職業の一覧を取得する。
+     * 上級職業は初回就職では選べず、いずれかの職業でレベル50に到達した後に解禁される。
+     * 設定キーが未追加のサーバーでも機能するようデフォルト値を返す。
+     */
+    public List<String> getAdvancedJobs() {
+        List<String> list = config.getStringList("jobs.general.advanced_jobs");
+        if (list == null || list.isEmpty()) {
+            return Arrays.asList("alchemist", "enchanter", "architect");
+        }
+        return list;
+    }
+
+    /**
+     * 指定した職業が上級職業かどうかを判定する。
+     */
+    public boolean isAdvancedJob(String jobName) {
+        return jobName != null && getAdvancedJobs().contains(jobName.toLowerCase());
+    }
     
     // ========== 職業ブロック制限システム設定 ==========
     

--- a/src/main/java/org/tofu/tofunomics/jobs/JobManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobManager.java
@@ -42,7 +42,30 @@ public class JobManager {
         JOB_NOT_FOUND,
         LEVEL_TOO_LOW,
         MAX_JOBS_REACHED,
+        ADVANCED_JOB_LOCKED,
         DATABASE_ERROR
+    }
+
+    /**
+     * プレイヤーがいずれかの職業でレベル50に到達した経験があるかどうかを判定する。
+     * 現在の職業または過去の職業履歴のいずれかでレベル50到達があれば true。
+     * 転職条件・上級職業の解禁条件の判定に共通利用する。
+     */
+    private boolean hasReachedLevel50(String uuid, List<PlayerJob> currentJobs) {
+        for (PlayerJob existingJob : currentJobs) {
+            if (existingJob.getLevel() >= 50) {
+                return true;
+            }
+        }
+        return jobHistoryDAO.hasReachedLevel50(uuid);
+    }
+
+    /**
+     * プレイヤーがいずれかの職業でレベル50に到達した経験があるかどうかを判定する（GUI 用公開版）。
+     */
+    public boolean hasReachedLevel50(Player player) {
+        String uuid = player.getUniqueId().toString();
+        return hasReachedLevel50(uuid, playerJobDAO.getPlayerJobsByUUID(uuid));
     }
     
     public JobJoinResult joinJob(Player player, String jobName) {
@@ -55,32 +78,19 @@ public class JobManager {
         
         List<PlayerJob> currentJobs = playerJobDAO.getPlayerJobsByUUID(uuid);
         int maxJobs = configManager.getMaxJobsPerPlayer();
-        
-        // レベル50チェック（転職時のみ）
-        // 現在職業を持っている場合のみチェック
-        if (!currentJobs.isEmpty()) {
-            boolean hasLevel50Job = false;
-            
-            // 現在の職業でレベル50以上があるかチェック
-            for (PlayerJob existingJob : currentJobs) {
-                if (existingJob.getLevel() >= 50) {
-                    hasLevel50Job = true;
-                    break;
-                }
-            }
-            
-            // レベル50以上の職業がない場合、過去の履歴もチェック
-            if (!hasLevel50Job) {
-                hasLevel50Job = jobHistoryDAO.hasReachedLevel50(uuid);
-            }
-            
-            // レベル50以上の記録がない場合はエラー
-            if (!hasLevel50Job) {
-                return JobJoinResult.LEVEL_TOO_LOW;
-            }
+        boolean reachedLevel50 = hasReachedLevel50(uuid, currentJobs);
+
+        // 上級職業は初回就職では選べず、いずれかの職業でレベル50到達後に解禁される
+        if (configManager.isAdvancedJob(jobName) && !reachedLevel50) {
+            return JobJoinResult.ADVANCED_JOB_LOCKED;
         }
-        // 現在職業がない場合（初回就職・再就職）は制限なし
-        
+
+        // レベル50チェック（転職時のみ）
+        // 現在職業を持っている場合のみチェック。初回就職・再就職（現在職業なし）は制限なし
+        if (!currentJobs.isEmpty() && !reachedLevel50) {
+            return JobJoinResult.LEVEL_TOO_LOW;
+        }
+
         if (currentJobs.size() >= maxJobs) {
             return JobJoinResult.MAX_JOBS_REACHED;
         }

--- a/src/main/java/org/tofu/tofunomics/jobs/gui/JobConfirmGUI.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/gui/JobConfirmGUI.java
@@ -156,6 +156,10 @@ public class JobConfirmGUI {
                 int maxJobs = configManager.getMaxJobsPerPlayer();
                 player.sendMessage(ChatColor.RED + "同時に就ける職業数の上限(" + maxJobs + ")に達しています。");
                 break;
+            case ADVANCED_JOB_LOCKED:
+                player.sendMessage(ChatColor.RED + "「" + jobManager.getJobDisplayName(jobName)
+                        + "」は上級職業です。いずれかの職業でレベル50に到達すると就職できます。");
+                break;
             case DATABASE_ERROR:
             default:
                 player.sendMessage(ChatColor.RED + "データベースエラーが発生しました。しばらくしてから再度お試しください。");

--- a/src/main/java/org/tofu/tofunomics/jobs/gui/JobDetailGUI.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/gui/JobDetailGUI.java
@@ -81,9 +81,15 @@ public class JobDetailGUI {
         double incomeMultiplier = configManager.getJobIncomeMultiplier(jobName);
         double expMultiplier = configManager.getJobExpMultiplier(jobName);
         boolean employed = jobManager.hasJob(player, jobName);
+        boolean advanced = configManager.isAdvancedJob(jobName);
+        // 上級職業が未解禁か（未就職かつLv50到達経験なし）
+        boolean advancedLocked = advanced && !employed && !jobManager.hasReachedLevel50(player);
 
         // 詳細アイコン
         List<String> infoLore = new ArrayList<>();
+        if (advanced) {
+            infoLore.add("§6§l【上級職業】");
+        }
         if (description != null && !description.isEmpty()) {
             infoLore.add("§7" + description);
         }
@@ -120,6 +126,12 @@ public class JobDetailGUI {
                                 "§7仕事内容・稼ぎ方・経験値の上げ方を確認できます",
                                 "§eクリックで入手")));
             }
+        } else if (advancedLocked) {
+            gui.setItem(SLOT_JOIN, GuiUtil.createButton(Material.BARRIER, "§c§l未解禁",
+                    java.util.Arrays.asList(
+                            "§7この職業は上級職業です",
+                            "§7いずれかの職業でレベル50に到達すると",
+                            "§7就職できるようになります")));
         } else {
             gui.setItem(SLOT_JOIN, GuiUtil.createButton(Material.LIME_DYE, "§a§l就職する",
                     java.util.Arrays.asList(
@@ -154,6 +166,12 @@ public class JobDetailGUI {
             case SLOT_JOIN:
                 // 未就職時のみ就職ボタンを表示しているが、状態をここでも再確認する
                 if (jobName != null && confirmGUI != null && !jobManager.hasJob(player, jobName)) {
+                    // 上級職業の未解禁時は確認画面を開かない（joinJob 側でも弾かれるが二重ガード）
+                    if (configManager.isAdvancedJob(jobName) && !jobManager.hasReachedLevel50(player)) {
+                        player.sendMessage(ChatColor.RED + "「" + jobManager.getJobDisplayName(jobName)
+                                + "」は上級職業です。いずれかの職業でレベル50に到達すると就職できます。");
+                        break;
+                    }
                     confirmGUI.open(player, jobName, JobsGUISession.Type.CONFIRM_JOIN);
                 }
                 break;

--- a/src/main/java/org/tofu/tofunomics/jobs/gui/JobsHubGUI.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/gui/JobsHubGUI.java
@@ -110,8 +110,14 @@ public class JobsHubGUI {
         int maxLevel = configManager.getJobMaxLevel(jobName);
         double incomeMultiplier = configManager.getJobIncomeMultiplier(jobName);
         boolean employed = jobManager.hasJob(player, jobName);
+        boolean advanced = configManager.isAdvancedJob(jobName);
+        // 上級職業が未解禁か（未就職かつLv50到達経験なし）
+        boolean advancedLocked = advanced && !employed && !jobManager.hasReachedLevel50(player);
 
         List<String> lore = new ArrayList<>();
+        if (advanced) {
+            lore.add("§6§l【上級職業】");
+        }
         if (description != null && !description.isEmpty()) {
             lore.add("§7" + description);
         }
@@ -123,13 +129,17 @@ public class JobsHubGUI {
             int currentLevel = playerJob != null ? playerJob.getLevel() : 0;
             lore.add("§a現在就職中 Lv." + currentLevel);
             lore.add("§eクリックで詳細・辞職");
+        } else if (advancedLocked) {
+            lore.add("§c§l未解禁");
+            lore.add("§7いずれかの職業でLv50に到達すると就職できます");
         } else {
             lore.add("§eクリックで詳細・就職");
             lore.add("§7※転職にはレベル50が必要です");
         }
 
-        String name = (employed ? "§a§l" : "§f§l") + displayName + " §7(" + jobName + ")";
-        return GuiUtil.createButton(JobsGUIIconMapper.getIcon(jobName), name, lore);
+        Material icon = advancedLocked ? Material.BARRIER : JobsGUIIconMapper.getIcon(jobName);
+        String name = (employed ? "§a§l" : (advancedLocked ? "§c§l" : "§f§l")) + displayName + " §7(" + jobName + ")";
+        return GuiUtil.createButton(icon, name, lore);
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -102,6 +102,11 @@ jobs:
     keep_level_on_change: true
     # 職業変更のクールダウン時間（秒）。0で制限なし、86400で1日1回
     job_change_cooldown: 0
+    # 上級職業: 初回就職では選べず、いずれかの職業でレベル50に到達した後に解禁される
+    advanced_jobs:
+      - "alchemist"
+      - "enchanter"
+      - "architect"
 
   
   # 職業ブロック制限システム設定

--- a/src/test/java/org/tofu/tofunomics/jobs/JobManagerTest.java
+++ b/src/test/java/org/tofu/tofunomics/jobs/JobManagerTest.java
@@ -169,6 +169,66 @@ public class JobManagerTest {
     }
 
     @Test
+    public void testJoinAdvancedJobLockedOnFirstEmployment() {
+        // 上級職業を初回就職しようとするとロックされる
+        String jobName = "architect";
+        Job job = new Job(jobName, "建築家", 100, 15.0);
+        job.setId(8);
+
+        when(jobDAO.getJobByNameSafe(jobName)).thenReturn(job);
+        when(configManager.getMaxJobsPerPlayer()).thenReturn(1);
+        when(configManager.isAdvancedJob(jobName)).thenReturn(true);
+        when(playerJobDAO.getPlayerJobsByUUID(playerUuidString)).thenReturn(new ArrayList<>());
+        when(jobHistoryDAO.hasReachedLevel50(playerUuidString)).thenReturn(false);
+
+        JobJoinResult result = jobManager.joinJob(player, jobName);
+
+        assertEquals("初回就職で上級職業はロックされるべき", JobJoinResult.ADVANCED_JOB_LOCKED, result);
+        verify(playerJobDAO, never()).insertPlayerJob(any(PlayerJob.class));
+    }
+
+    @Test
+    public void testJoinAdvancedJobSuccessWithLevel50History() {
+        // Lv50到達履歴があれば上級職業に就職できる
+        String jobName = "architect";
+        Job job = new Job(jobName, "建築家", 100, 15.0);
+        job.setId(8);
+
+        when(jobDAO.getJobByNameSafe(jobName)).thenReturn(job);
+        when(configManager.isDailyJobChangeLimitEnabled()).thenReturn(false);
+        when(configManager.getMaxJobsPerPlayer()).thenReturn(1);
+        when(configManager.isAdvancedJob(jobName)).thenReturn(true);
+        when(playerJobDAO.getPlayerJobsByUUID(playerUuidString)).thenReturn(new ArrayList<>());
+        when(jobHistoryDAO.hasReachedLevel50(playerUuidString)).thenReturn(true);
+        when(playerJobDAO.insertPlayerJob(any(PlayerJob.class))).thenReturn(true);
+
+        JobJoinResult result = jobManager.joinJob(player, jobName);
+
+        assertEquals("Lv50到達履歴ありで上級職業に就職できるべき", JobJoinResult.SUCCESS, result);
+        verify(playerJobDAO).insertPlayerJob(any(PlayerJob.class));
+    }
+
+    @Test
+    public void testJoinNonAdvancedJobOnFirstEmployment() {
+        // 通常職業は初回就職できる（既存挙動が壊れていないことの確認）
+        String jobName = "miner";
+        Job job = new Job(jobName, "鉱夫", 100, 15.0);
+        job.setId(1);
+
+        when(jobDAO.getJobByNameSafe(jobName)).thenReturn(job);
+        when(configManager.isDailyJobChangeLimitEnabled()).thenReturn(false);
+        when(configManager.getMaxJobsPerPlayer()).thenReturn(1);
+        when(configManager.isAdvancedJob(jobName)).thenReturn(false);
+        when(playerJobDAO.getPlayerJobsByUUID(playerUuidString)).thenReturn(new ArrayList<>());
+        when(playerJobDAO.insertPlayerJob(any(PlayerJob.class))).thenReturn(true);
+
+        JobJoinResult result = jobManager.joinJob(player, jobName);
+
+        assertEquals("通常職業は初回就職できるべき", JobJoinResult.SUCCESS, result);
+        verify(playerJobDAO).insertPlayerJob(any(PlayerJob.class));
+    }
+
+    @Test
     public void testJoinJobDatabaseError() {
         String jobName = "farmer";
         Job job = new Job(jobName, "農家", 100, 15.0);


### PR DESCRIPTION
## 概要

建築家(architect)・エンチャンター(enchanter)・ポーション屋(alchemist) の3職業は、サーバーが序盤・未発展の段階では「やることがなさすぎる」職業になっていた。これらを **上級職業** として扱い、初回就職では選べず、**いずれかの職業でレベル50に到達した後（＝2度目の就職以降）に解禁** されるようにした。

残り5職業（miner, woodcutter, farmer, fisherman, blacksmith）は従来どおり初回から就ける。解禁条件は既存の「転職にはレベル50が必要」ルールと完全に一致させている。

## 変更内容

- **ConfigManager**: `getAdvancedJobs()` / `isAdvancedJob()` を追加。設定キー未追加のサーバーでも機能するようデフォルト値（3職業）を返す
- **JobManager**: `JobJoinResult.ADVANCED_JOB_LOCKED` を追加。Lv50判定を共通ヘルパーに抽出し、`joinJob()` に上級職業ゲートを追加
- **JobsCommand / JobConfirmGUI**: 上級職業ロック時のメッセージ分岐を追加
- **JobsHubGUI / JobDetailGUI**: 上級職業に「【上級職業】」ラベルを表示。未解禁時はアイコンをロック表示（BARRIER）にし、就職ボタンを未解禁表示に差し替え、クリックガードを追加
- **config.yml**: `jobs.general.advanced_jobs` を追記
- **JobManagerTest**: 上級職業の就職可否テストを3件追加

## テスト

- `mvn clean test` で全305テストパス（新規3件含む）
- config.yml YAML構文チェック OK

## デプロイ時の注意

- サーバー側 config.yml への `advanced_jobs` 反映はユーザー手動（jarのconfigは既存サーバーconfigを上書きしない）。ただしデフォルト値があるため未追記でも機能する
- 反映後 `/tofunomics reload` で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)