### PR TITLE
feat: 作物の植え付けを農家職業のみに制限

### DIFF
--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -503,7 +503,14 @@ public class ConfigManager {
     public boolean isJobBlockRestrictionEnabled() {
         return (Boolean) getCachedValue("jobs.block_restrictions.enabled", true);
     }
-    
+
+    /**
+     * 職業別 植え付け（種まき）制限システムが有効かどうか
+     */
+    public boolean isJobPlantingRestrictionEnabled() {
+        return (Boolean) getCachedValue("jobs.block_restrictions.planting_restrictions.enabled", true);
+    }
+
     /**
      * 基本ブロック（全職業で採掘可能）のリストを取得
      */

--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -165,7 +165,14 @@ public class UnifiedEventHandler implements Listener {
             player.sendMessage(ChatColor.RED + "鉱石ブロックは設置できません。");
             return;
         }
-        
+
+        // 職業別 植え付け制限チェック（農家以外の作物植え付けを拒否）
+        if (!blockPermissionManager.canPlayerPlantBlock(player, blockType)) {
+            event.setCancelled(true);
+            player.sendMessage(blockPermissionManager.getPlantingDeniedMessage(player, blockType));
+            return;
+        }
+
         if (!shouldProcessEvent(event)) return;
         
         // プレイヤーが設置したブロックを記録（メモリ内追跡）

--- a/src/main/java/org/tofu/tofunomics/jobs/JobBlockPermissionManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobBlockPermissionManager.java
@@ -21,15 +21,20 @@ public class JobBlockPermissionManager {
     
     // 職業専用ブロック
     private final Map<String, Set<Material>> jobRestrictedBlocks;
-    
+
+    // 職業専用 植え付けブロック（種まきで設置されるブロック）
+    private final Map<String, Set<Material>> jobPlantingBlocks;
+
     public JobBlockPermissionManager(ConfigManager configManager, JobManager jobManager) {
         this.configManager = configManager;
         this.jobManager = jobManager;
         this.basicBlocks = new HashSet<>();
         this.jobRestrictedBlocks = new HashMap<>();
-        
+        this.jobPlantingBlocks = new HashMap<>();
+
         initializeBasicBlocks();
         initializeJobRestrictedBlocks();
+        initializeJobPlantingBlocks();
     }
     
     /**
@@ -121,7 +126,34 @@ public class JobBlockPermissionManager {
         jobRestrictedBlocks.put("enchanter", new HashSet<>());
         jobRestrictedBlocks.put("architect", new HashSet<>());
     }
-    
+
+    /**
+     * 職業別 植え付け制限ブロックを初期化
+     * 種まき時に設置されるブロック（成長ブロック・苗）を対象とする。
+     * 注意: 装飾用フルブロック（PUMPKIN/MELON/HAY_BLOCK等）は含めない（誰でも設置可）
+     */
+    private void initializeJobPlantingBlocks() {
+        // 農家専用の植え付けブロック
+        Set<Material> farmerPlantingBlocks = new HashSet<>(Arrays.asList(
+            // 種まきで設置される作物ブロック
+            Material.WHEAT,
+            Material.CARROTS,
+            Material.POTATOES,
+            Material.BEETROOTS,
+            Material.NETHER_WART,
+            Material.COCOA,
+            // カボチャ・スイカの種は苗（STEM）として設置される
+            Material.PUMPKIN_STEM,
+            Material.MELON_STEM,
+            // その他の作物
+            Material.SUGAR_CANE,
+            Material.CACTUS,
+            Material.BAMBOO,
+            Material.BAMBOO_SAPLING
+        ));
+        jobPlantingBlocks.put("farmer", farmerPlantingBlocks);
+    }
+
     /**
      * プレイヤーが指定ブロックを採掘する権限があるかチェック
      * 
@@ -190,7 +222,68 @@ public class JobBlockPermissionManager {
         String jobDisplayName = jobManager.getJobDisplayName(requiredJob);
         return "§c" + blockType.name() + " を採掘するには " + jobDisplayName + " の職業が必要です。";
     }
-    
+
+    /**
+     * プレイヤーが指定ブロックを植え付け（設置）する権限があるかチェック
+     *
+     * @param player プレイヤー
+     * @param blockType 設置されるブロックタイプ
+     * @return 植え付け可能な場合true
+     */
+    public boolean canPlayerPlantBlock(Player player, Material blockType) {
+        // 植え付け制限システムが無効の場合は常に許可
+        if (!configManager.isJobPlantingRestrictionEnabled()) {
+            return true;
+        }
+
+        // 管理者権限を持つ場合は常に許可
+        if (player.hasPermission("tofunomics.admin.place")) {
+            return true;
+        }
+
+        // 植え付け制限対象かチェック
+        String requiredJob = getRequiredJobForPlanting(blockType);
+        if (requiredJob == null) {
+            // 制限されていないブロックは誰でも植え付け可能
+            return true;
+        }
+
+        // プレイヤーが必要な職業を持っているかチェック
+        return jobManager.hasJob(player, requiredJob);
+    }
+
+    /**
+     * ブロック植え付けに必要な職業を取得
+     *
+     * @param blockType ブロックタイプ
+     * @return 必要な職業名、制限がない場合はnull
+     */
+    private String getRequiredJobForPlanting(Material blockType) {
+        for (Map.Entry<String, Set<Material>> entry : jobPlantingBlocks.entrySet()) {
+            if (entry.getValue().contains(blockType)) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 職業制限によって植え付けが拒否された場合のメッセージを取得
+     *
+     * @param player プレイヤー
+     * @param blockType ブロックタイプ
+     * @return 表示メッセージ
+     */
+    public String getPlantingDeniedMessage(Player player, Material blockType) {
+        String requiredJob = getRequiredJobForPlanting(blockType);
+        if (requiredJob == null) {
+            return "§cこのブロックは植えられません。";
+        }
+
+        String jobDisplayName = jobManager.getJobDisplayName(requiredJob);
+        return "§c" + blockType.name() + " を植えるには " + jobDisplayName + " の職業が必要です。";
+    }
+
     /**
      * 基本ブロックセットを取得
      */

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -240,6 +240,25 @@ jobs:
         - "CAMPFIRE"
         - "SOUL_CAMPFIRE"
 
+    # 植え付け（種まき）制限（農家のみ作物を植え付け可能）
+    # 注意: 装飾用フルブロック（PUMPKIN/MELON/HAY_BLOCK等）は制限対象外（誰でも設置可）
+    planting_restrictions:
+      # 植え付け制限システムの有効化
+      enabled: true
+      # 農家専用の植え付けブロック（参考。実際の判定はJava側の定義に準拠）
+      farmer:
+        - "WHEAT"
+        - "CARROTS"
+        - "POTATOES"
+        - "BEETROOTS"
+        - "NETHER_WART"
+        - "COCOA"
+        - "PUMPKIN_STEM"
+        - "MELON_STEM"
+        - "SUGAR_CANE"
+        - "CACTUS"
+        - "BAMBOO"
+
   # 各職業の設定
   job_settings:
     miner:

--- a/src/test/java/org/tofu/tofunomics/jobs/JobBlockPermissionManagerTest.java
+++ b/src/test/java/org/tofu/tofunomics/jobs/JobBlockPermissionManagerTest.java
@@ -1,0 +1,103 @@
+package org.tofu.tofunomics.jobs;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.tofu.tofunomics.config.ConfigManager;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * JobBlockPermissionManager の植え付け制限機能テスト
+ */
+public class JobBlockPermissionManagerTest {
+
+    @Mock
+    private ConfigManager configManager;
+
+    @Mock
+    private JobManager jobManager;
+
+    @Mock
+    private Player player;
+
+    private JobBlockPermissionManager permissionManager;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        // デフォルトで植え付け制限を有効化、管理者権限なし
+        when(configManager.isJobPlantingRestrictionEnabled()).thenReturn(true);
+        when(player.hasPermission("tofunomics.admin.place")).thenReturn(false);
+        when(jobManager.getJobDisplayName("farmer")).thenReturn("農家");
+
+        permissionManager = new JobBlockPermissionManager(configManager, jobManager);
+    }
+
+    @Test
+    public void testFarmerCanPlantCrop() {
+        // 農家は作物を植え付け可能
+        when(jobManager.hasJob(player, "farmer")).thenReturn(true);
+
+        assertTrue(permissionManager.canPlayerPlantBlock(player, Material.WHEAT));
+        assertTrue(permissionManager.canPlayerPlantBlock(player, Material.CARROTS));
+        assertTrue(permissionManager.canPlayerPlantBlock(player, Material.SUGAR_CANE));
+        assertTrue(permissionManager.canPlayerPlantBlock(player, Material.BAMBOO));
+    }
+
+    @Test
+    public void testNonFarmerCannotPlantCrop() {
+        // 農家でないプレイヤーは作物を植え付け不可
+        when(jobManager.hasJob(player, "farmer")).thenReturn(false);
+
+        assertFalse(permissionManager.canPlayerPlantBlock(player, Material.WHEAT));
+        assertFalse(permissionManager.canPlayerPlantBlock(player, Material.POTATOES));
+        assertFalse(permissionManager.canPlayerPlantBlock(player, Material.PUMPKIN_STEM));
+        assertFalse(permissionManager.canPlayerPlantBlock(player, Material.MELON_STEM));
+    }
+
+    @Test
+    public void testDecorativeBlocksAllowedForEveryone() {
+        // 装飾用フルブロックは農家でなくても設置可能（植え付け制限対象外）
+        when(jobManager.hasJob(player, "farmer")).thenReturn(false);
+
+        assertTrue(permissionManager.canPlayerPlantBlock(player, Material.PUMPKIN));
+        assertTrue(permissionManager.canPlayerPlantBlock(player, Material.MELON));
+        assertTrue(permissionManager.canPlayerPlantBlock(player, Material.HAY_BLOCK));
+        assertTrue(permissionManager.canPlayerPlantBlock(player, Material.DRIED_KELP_BLOCK));
+        // 一般建材も当然許可
+        assertTrue(permissionManager.canPlayerPlantBlock(player, Material.STONE));
+    }
+
+    @Test
+    public void testPlantingAllowedWhenRestrictionDisabled() {
+        // 植え付け制限が無効なら誰でも植え付け可能
+        when(configManager.isJobPlantingRestrictionEnabled()).thenReturn(false);
+        when(jobManager.hasJob(player, "farmer")).thenReturn(false);
+
+        assertTrue(permissionManager.canPlayerPlantBlock(player, Material.WHEAT));
+    }
+
+    @Test
+    public void testAdminBypassesPlantingRestriction() {
+        // 管理者権限があれば農家でなくても植え付け可能
+        when(player.hasPermission("tofunomics.admin.place")).thenReturn(true);
+        when(jobManager.hasJob(player, "farmer")).thenReturn(false);
+
+        assertTrue(permissionManager.canPlayerPlantBlock(player, Material.WHEAT));
+    }
+
+    @Test
+    public void testPlantingDeniedMessage() {
+        // 拒否メッセージに必要職業名とブロック名が含まれる
+        String message = permissionManager.getPlantingDeniedMessage(player, Material.WHEAT);
+
+        assertTrue(message.contains("農家"));
+        assertTrue(message.contains("WHEAT"));
+        assertTrue(message.contains("植える"));
+    }
+}


### PR DESCRIPTION
## 概要
従来は農作物の**収穫（ブロック破壊）**のみが農家（farmer）職業に制限されており、**植え付け（種まき）**は誰でも可能でした。本PRで植え付けも農家のみに制限し、職業システムの整合性を取ります。

農家以外が種を植えようとすると、設置をキャンセルし「○○ を植えるには 農家 の職業が必要です。」と表示します。

## 仕様
- **対象**: 全農作物（小麦・ニンジン・ジャガイモ・ビートルート・ネザーウォート・ココア・カボチャ/スイカの苗(STEM)・サトウキビ・サボテン・竹）
- **挙動**: 設置キャンセル＋メッセージ表示（既存の収穫制限と同パターン）
- **装飾ブロックは制限外**: `PUMPKIN` / `MELON`（フルブロック）/ `HAY_BLOCK` / `DRIED_KELP_BLOCK` は誰でも設置可のまま（ビルド用途を巻き込まない）

## 変更内容
- `JobBlockPermissionManager`: 植え付け専用ブロックセットと `canPlayerPlantBlock` / `getRequiredJobForPlanting` / `getPlantingDeniedMessage` を追加（既存の収穫制限と対称的な実装）
- `UnifiedEventHandler.onBlockPlace`: 植え付け制限チェックを追加（優先度 HIGH、既存ハンドラへインライン追加）
- `ConfigManager`: `isJobPlantingRestrictionEnabled()` トグルを追加（収穫制限とは独立して ON/OFF 可能）
- `config.yml`: `jobs.block_restrictions.planting_restrictions` セクションを追加（デフォルト `enabled: true`）
- 管理者は `tofunomics.admin.place` 権限でバイパス可能

## テスト
- `JobBlockPermissionManagerTest` を新規追加（6件、全パス）
  - 農家=許可 / 非農家=拒否 / 装飾ブロックは全員許可 / トグル無効時は全員許可 / 管理者バイパス / 拒否メッセージ内容
- `mvn clean compile` 成功、YAML 構文チェック OK

## 動作確認（デプロイ後）
- [ ] 非農家で小麦の種を植える → 拒否＋メッセージ
- [ ] 農家で植え付け → 正常
- [ ] 非農家で `PUMPKIN`/`HAY_BLOCK` 設置 → 許可（装飾は制限外）
- [ ] 既存の収穫制限がリグレッションなく動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)