### PR TITLE
fix: 種まきの植え付け制限がBlockPlaceEvent不発火で機能しない問題を修正

### DIFF
--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -10,6 +10,7 @@ import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockGrowEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
@@ -19,6 +20,9 @@ import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.inventory.BrewEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.player.PlayerFishEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.tofu.tofunomics.config.ConfigManager;
 import org.tofu.tofunomics.dao.PlayerDAO;
@@ -194,6 +198,41 @@ public class UnifiedEventHandler implements Listener {
         eventCache.markAsProcessed(player, "block_place");
     }
     
+    /**
+     * 種アイテムによる植え付け制限（農家以外の種まきを拒否）
+     * 畑・ソウルサンドへの種まきは BlockPlaceEvent を発火しないため、
+     * PlayerInteractEvent（右クリック）で捕捉する。
+     * ブロックアイテム（サトウキビ・サボテン・竹・ココア等）は onBlockPlace 側で処理する。
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onPlayerInteractPlanting(PlayerInteractEvent event) {
+        // 右クリック（ブロックに対して）のみ対象
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+        // 両手分の二重発火を防ぐためメインハンドのみ処理
+        if (event.getHand() != EquipmentSlot.HAND) return;
+
+        ItemStack item = event.getItem();
+        if (item == null) return;
+
+        // 手に持っているアイテムが種アイテムかチェック
+        Material cropBlock = blockPermissionManager.getCropBlockForSeed(item.getType());
+        if (cropBlock == null) return;
+
+        // クリックしたブロックが植え付け可能な面かチェック（食用作物の誤キャンセル防止）
+        if (event.getClickedBlock() == null) return;
+        Material clicked = event.getClickedBlock().getType();
+        boolean validSurface = (cropBlock == Material.NETHER_WART)
+            ? (clicked == Material.SOUL_SAND)
+            : (clicked == Material.FARMLAND);
+        if (!validSurface) return;
+
+        Player player = event.getPlayer();
+        if (!blockPermissionManager.canPlayerPlantBlock(player, cropBlock)) {
+            event.setCancelled(true);
+            player.sendMessage(blockPermissionManager.getPlantingDeniedMessage(player, cropBlock));
+        }
+    }
+
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockGrow(BlockGrowEvent event) {
         if (!shouldProcessEvent(event)) return;

--- a/src/main/java/org/tofu/tofunomics/jobs/JobBlockPermissionManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobBlockPermissionManager.java
@@ -25,16 +25,23 @@ public class JobBlockPermissionManager {
     // 職業専用 植え付けブロック（種まきで設置されるブロック）
     private final Map<String, Set<Material>> jobPlantingBlocks;
 
+    // 種アイテム → 種まきで設置される作物ブロックの対応
+    // （種アイテムの右クリック植え付けは BlockPlaceEvent を発火しないため、
+    //   PlayerInteractEvent で捕捉する際に使用する）
+    private final Map<Material, Material> seedItemToCropBlock;
+
     public JobBlockPermissionManager(ConfigManager configManager, JobManager jobManager) {
         this.configManager = configManager;
         this.jobManager = jobManager;
         this.basicBlocks = new HashSet<>();
         this.jobRestrictedBlocks = new HashMap<>();
         this.jobPlantingBlocks = new HashMap<>();
+        this.seedItemToCropBlock = new HashMap<>();
 
         initializeBasicBlocks();
         initializeJobRestrictedBlocks();
         initializeJobPlantingBlocks();
+        initializeSeedItemMapping();
     }
     
     /**
@@ -152,6 +159,33 @@ public class JobBlockPermissionManager {
             Material.BAMBOO_SAPLING
         ));
         jobPlantingBlocks.put("farmer", farmerPlantingBlocks);
+    }
+
+    /**
+     * 種アイテム → 設置される作物ブロックの対応を初期化
+     * 畑（FARMLAND）・ソウルサンド上に種をまくと BlockPlaceEvent が発火しないため、
+     * PlayerInteractEvent でこのマップを使って植え付けを判定する。
+     * 注意: サトウキビ・サボテン・竹・ココアはブロックアイテムとして
+     *       BlockPlaceEvent が発火するため、ここには含めない。
+     */
+    private void initializeSeedItemMapping() {
+        seedItemToCropBlock.put(Material.WHEAT_SEEDS, Material.WHEAT);
+        seedItemToCropBlock.put(Material.BEETROOT_SEEDS, Material.BEETROOTS);
+        seedItemToCropBlock.put(Material.CARROT, Material.CARROTS);
+        seedItemToCropBlock.put(Material.POTATO, Material.POTATOES);
+        seedItemToCropBlock.put(Material.PUMPKIN_SEEDS, Material.PUMPKIN_STEM);
+        seedItemToCropBlock.put(Material.MELON_SEEDS, Material.MELON_STEM);
+        seedItemToCropBlock.put(Material.NETHER_WART, Material.NETHER_WART);
+    }
+
+    /**
+     * 種アイテムから、植え付けで設置される作物ブロックを取得
+     *
+     * @param seedItem 手に持っている種アイテム
+     * @return 設置される作物ブロック。種アイテムでない場合はnull
+     */
+    public Material getCropBlockForSeed(Material seedItem) {
+        return seedItemToCropBlock.get(seedItem);
     }
 
     /**

--- a/src/test/java/org/tofu/tofunomics/jobs/JobBlockPermissionManagerTest.java
+++ b/src/test/java/org/tofu/tofunomics/jobs/JobBlockPermissionManagerTest.java
@@ -92,6 +92,21 @@ public class JobBlockPermissionManagerTest {
     }
 
     @Test
+    public void testSeedItemMapping() {
+        // 種アイテムが対応する作物ブロックへ正しくマッピングされる
+        assertEquals(Material.WHEAT, permissionManager.getCropBlockForSeed(Material.WHEAT_SEEDS));
+        assertEquals(Material.CARROTS, permissionManager.getCropBlockForSeed(Material.CARROT));
+        assertEquals(Material.POTATOES, permissionManager.getCropBlockForSeed(Material.POTATO));
+        assertEquals(Material.BEETROOTS, permissionManager.getCropBlockForSeed(Material.BEETROOT_SEEDS));
+        assertEquals(Material.PUMPKIN_STEM, permissionManager.getCropBlockForSeed(Material.PUMPKIN_SEEDS));
+        assertEquals(Material.MELON_STEM, permissionManager.getCropBlockForSeed(Material.MELON_SEEDS));
+        assertEquals(Material.NETHER_WART, permissionManager.getCropBlockForSeed(Material.NETHER_WART));
+        // 種アイテムでないものはnull
+        assertNull(permissionManager.getCropBlockForSeed(Material.STONE));
+        assertNull(permissionManager.getCropBlockForSeed(Material.DIAMOND));
+    }
+
+    @Test
     public void testPlantingDeniedMessage() {
         // 拒否メッセージに必要職業名とブロック名が含まれる
         String message = permissionManager.getPlantingDeniedMessage(player, Material.WHEAT);


### PR DESCRIPTION
## 問題
PR #68 で植え付け制限を `BlockPlaceEvent` で実装したが、**畑（FARMLAND）・ソウルサンドへの種まき（WHEAT_SEEDS 等の種アイテム）は `BlockPlaceEvent` を発火しない**ため、農家以外でも種を植えられてしまっていた。

## 原因
Minecraft/Bukkit では、種アイテムを畑に右クリックして植える操作は `BlockPlaceEvent` ではなく `PlayerInteractEvent`（右クリック）として処理される。一方、サトウキビ・サボテン・竹などの「ブロックアイテム」は `BlockPlaceEvent` を発火する。PR #68 は後者しかカバーできていなかった。

## 修正
`PlayerInteractEvent` で種アイテムの植え付けを捕捉する処理を追加。
- 種アイテム（WHEAT_SEEDS / BEETROOT_SEEDS / CARROT / POTATO / PUMPKIN_SEEDS / MELON_SEEDS / NETHER_WART）→ 作物ブロックの対応マップを追加
- 右クリック対象が植え付け可能な面（FARMLAND / ソウルサンド）のときのみ判定 → 食用作物（ニンジン・ジャガイモ）の喫食を誤キャンセルしない
- メインハンドのみ処理し、オフハンドとの二重発火を防止
- ブロックアイテム（サトウキビ・サボテン・竹・ココア）は従来通り `BlockPlaceEvent` 側で処理

## テスト
- `JobBlockPermissionManagerTest` に種アイテムマッピングのテストを追加（計7件、全パス）
- `mvn clean test` 成功

## デプロイ後の注意
**plugman リロードではなく、サーバーの完全再起動を推奨**（複雑なプラグインではリスナー再登録が不安定なことがあるため）。

## 動作確認
- [ ] 非農家で小麦の種を畑に植える → 拒否＋メッセージ
- [ ] 農家で植え付け → 正常
- [ ] 非農家でニンジン/ジャガイモを食べる → 通常通り可能（誤キャンセルなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)