### PR TITLE
feat: 農家の収穫経験値を作物が完全成長した時のみ付与

### DIFF
--- a/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
+++ b/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
@@ -1,6 +1,9 @@
 package org.tofu.tofunomics.experience;
 
 import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.Ageable;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -24,15 +27,27 @@ import org.tofu.tofunomics.models.Job;
 import org.tofu.tofunomics.tools.JobToolManager;
 import org.tofu.tofunomics.util.NotificationManager;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * 職業別経験値獲得システム
  */
 public class JobExperienceManager implements Listener {
-    
+
+    // 収穫経験値の付与に「完全成長」を必要とする作物（成長段階を持つ作物）
+    private static final Set<Material> MATURITY_REQUIRED_CROPS = EnumSet.of(
+        Material.WHEAT,
+        Material.CARROTS,
+        Material.POTATOES,
+        Material.BEETROOTS,
+        Material.NETHER_WART,
+        Material.COCOA
+    );
+
     private final ConfigManager configManager;
     private final PlayerJobDAO playerJobDAO;
     private final JobDAO jobDAO;
@@ -122,15 +137,15 @@ public class JobExperienceManager implements Listener {
         loggingExperience.put(Material.MANGROVE_LOG, 3.0);  // 1.19追加。jungle/acacia相当
         loggingExperience.put(Material.CHERRY_LOG, 3.0);    // 1.20追加。jungle/acacia相当
         
-        // 農業経験値テーブル
+        // 農業経験値テーブル（キーは破壊されるブロックのMaterial）
         farmingExperience.put(Material.WHEAT, 1.5);
-        farmingExperience.put(Material.POTATO, 1.2);
-        farmingExperience.put(Material.CARROT, 1.2);
-        farmingExperience.put(Material.BEETROOT, 2.0);
+        farmingExperience.put(Material.POTATOES, 1.2);
+        farmingExperience.put(Material.CARROTS, 1.2);
+        farmingExperience.put(Material.BEETROOTS, 2.0);
         farmingExperience.put(Material.PUMPKIN, 3.0);
         farmingExperience.put(Material.MELON, 2.5);
         farmingExperience.put(Material.SUGAR_CANE, 1.0);
-        farmingExperience.put(Material.COCOA_BEANS, 2.5);
+        farmingExperience.put(Material.COCOA, 2.5);
         farmingExperience.put(Material.NETHER_WART, 3.0);
         farmingExperience.put(Material.BAMBOO, 0.5);
         farmingExperience.put(Material.CACTUS, 1.0);
@@ -289,12 +304,34 @@ public class JobExperienceManager implements Listener {
             giveJobExperience(player, "woodcutter", multipliedExp);
         }
         
-        // 農家の収穫経験値
-        if (jobManager.hasJob(player, "farmer") && farmingExperience.containsKey(blockType)) {
+        // 農家の収穫経験値（完全に成長した作物のみ付与）
+        if (jobManager.hasJob(player, "farmer") && farmingExperience.containsKey(blockType)
+                && isCropFullyGrown(event.getBlock())) {
             double baseExp = farmingExperience.get(blockType);
             double multipliedExp = applyJobMultiplier(player, "farmer", baseExp);
             giveJobExperience(player, "farmer", multipliedExp);
         }
+    }
+
+    /**
+     * 作物が「完全に成長した状態」かを判定する。
+     * 成長段階を持つ作物（小麦・ニンジン・ジャガイモ・ビートルート・ネザーウォート・ココア）は
+     * 最大成熟度に達している場合のみtrue。
+     * 成熟概念のない作物（カボチャ・スイカ・サトウキビ・サボテン・竹・キノコ）は常にtrue。
+     *
+     * @param block 破壊された作物ブロック
+     * @return 収穫経験値の付与対象ならtrue
+     */
+    static boolean isCropFullyGrown(Block block) {
+        if (block == null || !MATURITY_REQUIRED_CROPS.contains(block.getType())) {
+            return true;
+        }
+        BlockData data = block.getBlockData();
+        if (data instanceof Ageable) {
+            Ageable ageable = (Ageable) data;
+            return ageable.getAge() >= ageable.getMaximumAge();
+        }
+        return true;
     }
     
     @EventHandler

--- a/src/test/java/org/tofu/tofunomics/experience/JobExperienceManagerCropMaturityTest.java
+++ b/src/test/java/org/tofu/tofunomics/experience/JobExperienceManagerCropMaturityTest.java
@@ -1,0 +1,64 @@
+package org.tofu.tofunomics.experience;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.Ageable;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * JobExperienceManager.isCropFullyGrown の成熟判定テスト
+ */
+public class JobExperienceManagerCropMaturityTest {
+
+    private Block mockCrop(Material type, int age, int maxAge) {
+        Block block = mock(Block.class);
+        when(block.getType()).thenReturn(type);
+        Ageable data = mock(Ageable.class);
+        when(data.getAge()).thenReturn(age);
+        when(data.getMaximumAge()).thenReturn(maxAge);
+        when(block.getBlockData()).thenReturn(data);
+        return block;
+    }
+
+    @Test
+    public void testMatureCropReturnsTrue() {
+        // 完全成長した小麦（age 7/7）は経験値対象
+        assertTrue(JobExperienceManager.isCropFullyGrown(mockCrop(Material.WHEAT, 7, 7)));
+        assertTrue(JobExperienceManager.isCropFullyGrown(mockCrop(Material.CARROTS, 7, 7)));
+        assertTrue(JobExperienceManager.isCropFullyGrown(mockCrop(Material.BEETROOTS, 3, 3)));
+        assertTrue(JobExperienceManager.isCropFullyGrown(mockCrop(Material.NETHER_WART, 3, 3)));
+    }
+
+    @Test
+    public void testImmatureCropReturnsFalse() {
+        // 未成熟の作物は経験値対象外
+        assertFalse(JobExperienceManager.isCropFullyGrown(mockCrop(Material.WHEAT, 0, 7)));
+        assertFalse(JobExperienceManager.isCropFullyGrown(mockCrop(Material.WHEAT, 6, 7)));
+        assertFalse(JobExperienceManager.isCropFullyGrown(mockCrop(Material.POTATOES, 3, 7)));
+        assertFalse(JobExperienceManager.isCropFullyGrown(mockCrop(Material.COCOA, 1, 2)));
+    }
+
+    @Test
+    public void testNonMaturityCropAlwaysTrue() {
+        // 成熟概念のない作物は常に経験値対象（BlockDataを参照しない）
+        Block pumpkin = mock(Block.class);
+        when(pumpkin.getType()).thenReturn(Material.PUMPKIN);
+        assertTrue(JobExperienceManager.isCropFullyGrown(pumpkin));
+
+        Block sugarCane = mock(Block.class);
+        when(sugarCane.getType()).thenReturn(Material.SUGAR_CANE);
+        assertTrue(JobExperienceManager.isCropFullyGrown(sugarCane));
+
+        Block melon = mock(Block.class);
+        when(melon.getType()).thenReturn(Material.MELON);
+        assertTrue(JobExperienceManager.isCropFullyGrown(melon));
+    }
+
+    @Test
+    public void testNullBlockReturnsTrue() {
+        assertTrue(JobExperienceManager.isCropFullyGrown(null));
+    }
+}


### PR DESCRIPTION
## 概要
農家の収穫経験値について、**未成熟の作物でも経験値が入っていた**問題を修正し、**完全に成長した作物のみ**職業経験値を付与するようにしました（要望①）。

## 変更内容
- `isCropFullyGrown(Block)` を追加
  - 成長段階を持つ作物（小麦・ニンジン・ジャガイモ・ビートルート・ネザーウォート・ココア）は `Ageable` の最大成熟度に達したときのみ経験値対象
  - 成熟概念のない作物（カボチャ・スイカ・サトウキビ・サボテン・竹・キノコ）は従来通り常に対象
- **既存バグの修正**: 農業経験値マップのキーがアイテム型になっていた（`POTATO`/`CARROT`/`BEETROOT`/`COCOA_BEANS`）ためブロック破壊時に一致せず、**ニンジン・ジャガイモ・ビートルート・ココアは収穫しても経験値が入っていなかった**。ブロック型（`POTATOES`/`CARROTS`/`BEETROOTS`/`COCOA`）へ修正し、これらにも正しく経験値が入るようにした

## 補足（仕様）
- 未成熟の作物の**収穫自体は可能**（ブロックは壊せる）。経験値が入らないだけ
- 種まき作物は `BlockPlaceEvent` を発火しない＝設置追跡対象外のため、成熟ゲートだけで「自分で植えて育てた作物を完全成長後に収穫→経験値」が成立する
- 骨粉での即時成長は許容（要望通り）

## テスト
- `JobExperienceManagerCropMaturityTest`（4件・全パス）
- `mvn clean test` 成功

## ⚠️ 注意（バランス変更）
キー修正により、これまで経験値が入っていなかった**ニンジン・ジャガイモ・ビートルート・ココアに収穫経験値が入るようになります**。意図通りですが、もし据え置きたい場合はお知らせください。

## 動作確認（デプロイ後）
- [ ] 農家が完全成長した小麦/ニンジン/ジャガイモ/ビートルート/ネザーウォート/ココアを収穫 → 経験値が入る
- [ ] 農家が未成熟の作物を収穫 → 経験値が入らない
- [ ] カボチャ/スイカ/サトウキビは従来通り経験値が入る

🤖 Generated with [Claude Code](https://claude.com/claude-code)