### PR TITLE
feat: 農家の畑区画(プロット)制システムを追加

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -127,6 +127,8 @@ public final class TofuNomics extends JavaPlugin {
     private org.tofu.tofunomics.dao.MarketBuyOrderDAO marketBuyOrderDAO;
     private org.tofu.tofunomics.dao.MarketServiceRequestDAO marketServiceRequestDAO;
     private org.tofu.tofunomics.dao.QuestProgressDAO questProgressDAO;
+    private org.tofu.tofunomics.dao.FarmPlotDAO farmPlotDAO;
+    private org.tofu.tofunomics.farming.FarmPlotManager farmPlotManager;
     private org.tofu.tofunomics.market.MarketManager marketManager;
     private org.tofu.tofunomics.market.gui.MarketBrowseGUI marketBrowseGUI;
     private org.tofu.tofunomics.market.gui.MyListingsGUI myListingsGUI;
@@ -341,6 +343,7 @@ public final class TofuNomics extends JavaPlugin {
             marketBuyOrderDAO = new org.tofu.tofunomics.dao.MarketBuyOrderDAO(databaseManager.getConnection());
             marketServiceRequestDAO = new org.tofu.tofunomics.dao.MarketServiceRequestDAO(databaseManager.getConnection());
             questProgressDAO = new org.tofu.tofunomics.dao.QuestProgressDAO(databaseManager.getConnection());
+            farmPlotDAO = new org.tofu.tofunomics.dao.FarmPlotDAO(databaseManager.getConnection());
 
             getLogger().info("データアクセス層（DAO）を初期化しました");
         }
@@ -520,7 +523,14 @@ public final class TofuNomics extends JavaPlugin {
                 configManager,
                 jobManager
             );
-            
+
+            // FarmPlotManagerの初期化（WorldGuard連携は使用時に遅延取得）
+            farmPlotManager = new org.tofu.tofunomics.farming.FarmPlotManager(
+                this,
+                configManager,
+                farmPlotDAO
+            );
+
             getLogger().info("Phase 3 職業特化機能を初期化しました");
         } catch (Exception e) {
             getLogger().severe("Phase 3 マネージャー初期化中にエラーが発生しました: " + e.getMessage());
@@ -818,6 +828,14 @@ public final class TofuNomics extends JavaPlugin {
             
             // 職業系コマンド
             getCommand("jobs").setExecutor(new JobsCommand(configManager, jobManager, experienceManager, jobsHubGUI));
+
+            // 畑区画コマンド
+            if (farmPlotManager != null && getCommand("farmplot") != null) {
+                org.tofu.tofunomics.commands.FarmPlotCommand farmPlotCommand =
+                    new org.tofu.tofunomics.commands.FarmPlotCommand(this, farmPlotManager);
+                getCommand("farmplot").setExecutor(farmPlotCommand);
+                getCommand("farmplot").setTabCompleter(farmPlotCommand);
+            }
             getCommand("jobstats").setExecutor(new JobStatsCommand(jobStatsManager));
             getCommand("quest").setExecutor(new JobQuestCommand(configManager, jobQuestManager));
             
@@ -959,6 +977,10 @@ public final class TofuNomics extends JavaPlugin {
     
     public ExperienceManager getExperienceManager() {
         return experienceManager;
+    }
+
+    public org.tofu.tofunomics.farming.FarmPlotManager getFarmPlotManager() {
+        return farmPlotManager;
     }
     
     public org.tofu.tofunomics.scoreboard.ScoreboardManager getScoreboardManager() {

--- a/src/main/java/org/tofu/tofunomics/commands/FarmPlotCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/FarmPlotCommand.java
@@ -1,0 +1,215 @@
+package org.tofu.tofunomics.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.farming.FarmPlotManager;
+import org.tofu.tofunomics.models.FarmPlot;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 畑区画(プロット)管理コマンド /farmplot
+ * 管理者(tofunomics.farmplot.admin)向け。
+ */
+public class FarmPlotCommand implements CommandExecutor, TabCompleter {
+
+    private static final String PERMISSION = "tofunomics.farmplot.admin";
+
+    private final TofuNomics plugin;
+    private final FarmPlotManager farmPlotManager;
+
+    public FarmPlotCommand(TofuNomics plugin, FarmPlotManager farmPlotManager) {
+        this.plugin = plugin;
+        this.farmPlotManager = farmPlotManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission(PERMISSION)) {
+            sender.sendMessage(ChatColor.RED + "権限がありません。");
+            return true;
+        }
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "このコマンドはプレイヤーのみ実行できます。");
+            return true;
+        }
+        Player player = (Player) sender;
+
+        if (args.length == 0) {
+            sendUsage(player);
+            return true;
+        }
+
+        switch (args[0].toLowerCase()) {
+            case "pos1":
+                farmPlotManager.setPos1(player, player.getLocation().getBlock().getLocation());
+                player.sendMessage(ChatColor.GREEN + "pos1 を設定しました: " + formatLoc(player));
+                return true;
+            case "pos2":
+                farmPlotManager.setPos2(player, player.getLocation().getBlock().getLocation());
+                player.sendMessage(ChatColor.GREEN + "pos2 を設定しました: " + formatLoc(player));
+                return true;
+            case "create":
+                if (args.length < 2) {
+                    player.sendMessage(ChatColor.RED + "使用法: /farmplot create <名前>");
+                    return true;
+                }
+                farmPlotManager.createPlot(player, args[1]);
+                return true;
+            case "delete":
+                if (args.length < 2) {
+                    player.sendMessage(ChatColor.RED + "使用法: /farmplot delete <名前>");
+                    return true;
+                }
+                farmPlotManager.deletePlot(player, args[1]);
+                return true;
+            case "list":
+                handleList(player);
+                return true;
+            case "info":
+                if (args.length < 2) {
+                    player.sendMessage(ChatColor.RED + "使用法: /farmplot info <名前>");
+                    return true;
+                }
+                handleInfo(player, args[1]);
+                return true;
+            case "assign":
+                if (args.length < 2) {
+                    player.sendMessage(ChatColor.RED + "使用法: /farmplot assign <プレイヤー> [区画名]");
+                    return true;
+                }
+                handleAssign(player, args);
+                return true;
+            case "release":
+                if (args.length < 2) {
+                    player.sendMessage(ChatColor.RED + "使用法: /farmplot release <プレイヤー>");
+                    return true;
+                }
+                handleRelease(player, args[1]);
+                return true;
+            default:
+                sendUsage(player);
+                return true;
+        }
+    }
+
+    private void handleList(Player player) {
+        List<FarmPlot> plots = farmPlotManager.listPlots();
+        if (plots.isEmpty()) {
+            player.sendMessage(ChatColor.YELLOW + "登録されている畑区画はありません。");
+            return;
+        }
+        player.sendMessage(ChatColor.GOLD + "===== 畑区画一覧 (" + plots.size() + ") =====");
+        for (FarmPlot p : plots) {
+            String owner = p.isAssigned() ? ownerName(p.getOwnerUuid()) : ChatColor.GRAY + "空き";
+            player.sendMessage(ChatColor.YELLOW + "・" + p.getPlotName() + ChatColor.WHITE
+                    + " [" + p.getWorldName() + "] " + ChatColor.WHITE + "所有: " + owner);
+        }
+    }
+
+    private void handleInfo(Player player, String name) {
+        FarmPlot p = farmPlotManager.getPlotByName(name);
+        if (p == null) {
+            player.sendMessage(ChatColor.RED + "区画 '" + name + "' は存在しません。");
+            return;
+        }
+        player.sendMessage(ChatColor.GOLD + "===== 区画情報: " + p.getPlotName() + " =====");
+        player.sendMessage(ChatColor.YELLOW + "ワールド: " + ChatColor.WHITE + p.getWorldName());
+        player.sendMessage(ChatColor.YELLOW + "範囲: " + ChatColor.WHITE
+                + "(" + p.getX1() + "," + p.getY1() + "," + p.getZ1() + ") - ("
+                + p.getX2() + "," + p.getY2() + "," + p.getZ2() + ")");
+        player.sendMessage(ChatColor.YELLOW + "リージョン: " + ChatColor.WHITE + p.getWorldguardRegionId());
+        player.sendMessage(ChatColor.YELLOW + "所有者: " + ChatColor.WHITE
+                + (p.isAssigned() ? ownerName(p.getOwnerUuid()) : "空き"));
+    }
+
+    private void handleAssign(Player admin, String[] args) {
+        Player target = plugin.getServer().getPlayerExact(args[1]);
+        if (target == null) {
+            admin.sendMessage(ChatColor.RED + "オンラインのプレイヤーが見つかりません: " + args[1]);
+            return;
+        }
+        String plotName = args.length >= 3 ? args[2] : null;
+        farmPlotManager.assignPlotManually(admin, target, plotName);
+    }
+
+    private void handleRelease(Player admin, String targetName) {
+        Player target = plugin.getServer().getPlayerExact(targetName);
+        if (target == null) {
+            admin.sendMessage(ChatColor.RED + "オンラインのプレイヤーが見つかりません: " + targetName);
+            return;
+        }
+        farmPlotManager.releasePlotManually(admin, target);
+    }
+
+    private String ownerName(String uuid) {
+        try {
+            String name = plugin.getServer().getOfflinePlayer(java.util.UUID.fromString(uuid)).getName();
+            return name != null ? name : uuid;
+        } catch (Exception e) {
+            return uuid;
+        }
+    }
+
+    private String formatLoc(Player player) {
+        return player.getLocation().getBlockX() + ", " + player.getLocation().getBlockY()
+                + ", " + player.getLocation().getBlockZ();
+    }
+
+    private void sendUsage(Player player) {
+        player.sendMessage(ChatColor.GOLD + "===== /farmplot 使用法 =====");
+        player.sendMessage(ChatColor.YELLOW + "/farmplot pos1|pos2" + ChatColor.GRAY + " - 立っている位置を角に設定");
+        player.sendMessage(ChatColor.YELLOW + "/farmplot create <名前>" + ChatColor.GRAY + " - 選択範囲で区画を作成");
+        player.sendMessage(ChatColor.YELLOW + "/farmplot delete <名前>" + ChatColor.GRAY + " - 区画を削除");
+        player.sendMessage(ChatColor.YELLOW + "/farmplot list" + ChatColor.GRAY + " - 区画一覧");
+        player.sendMessage(ChatColor.YELLOW + "/farmplot info <名前>" + ChatColor.GRAY + " - 区画詳細");
+        player.sendMessage(ChatColor.YELLOW + "/farmplot assign <プレイヤー> [区画名]" + ChatColor.GRAY + " - 手動割り当て");
+        player.sendMessage(ChatColor.YELLOW + "/farmplot release <プレイヤー>" + ChatColor.GRAY + " - 手動解放");
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (!sender.hasPermission(PERMISSION)) {
+            return new ArrayList<>();
+        }
+        if (args.length == 1) {
+            List<String> subs = Arrays.asList("pos1", "pos2", "create", "delete", "list", "info", "assign", "release");
+            List<String> result = new ArrayList<>();
+            for (String s : subs) {
+                if (s.startsWith(args[0].toLowerCase())) {
+                    result.add(s);
+                }
+            }
+            return result;
+        }
+        if (args.length == 2) {
+            String sub = args[0].toLowerCase();
+            if (sub.equals("delete") || sub.equals("info")) {
+                List<String> names = new ArrayList<>();
+                for (FarmPlot p : farmPlotManager.listPlots()) {
+                    if (p.getPlotName().toLowerCase().startsWith(args[1].toLowerCase())) {
+                        names.add(p.getPlotName());
+                    }
+                }
+                return names;
+            }
+            if (sub.equals("assign") || sub.equals("release")) {
+                List<String> players = new ArrayList<>();
+                for (Player p : plugin.getServer().getOnlinePlayers()) {
+                    if (p.getName().toLowerCase().startsWith(args[1].toLowerCase())) {
+                        players.add(p.getName());
+                    }
+                }
+                return players;
+            }
+        }
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/dao/FarmPlotDAO.java
+++ b/src/main/java/org/tofu/tofunomics/dao/FarmPlotDAO.java
@@ -1,0 +1,162 @@
+package org.tofu.tofunomics.dao;
+
+import org.tofu.tofunomics.models.FarmPlot;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 農家畑区画(farm_plots)のデータアクセスオブジェクト
+ */
+public class FarmPlotDAO {
+    private final Connection connection;
+
+    public FarmPlotDAO(Connection connection) {
+        this.connection = connection;
+    }
+
+    /**
+     * 区画を新規作成し、生成IDを返す（失敗時 -1）
+     */
+    public int createPlot(FarmPlot plot) throws SQLException {
+        String query = "INSERT INTO farm_plots " +
+                "(plot_name, world_name, x1, y1, z1, x2, y2, z2, worldguard_region_id, owner_uuid) " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        try (PreparedStatement st = connection.prepareStatement(query, Statement.RETURN_GENERATED_KEYS)) {
+            st.setString(1, plot.getPlotName());
+            st.setString(2, plot.getWorldName());
+            st.setInt(3, plot.getX1());
+            st.setInt(4, plot.getY1());
+            st.setInt(5, plot.getZ1());
+            st.setInt(6, plot.getX2());
+            st.setInt(7, plot.getY2());
+            st.setInt(8, plot.getZ2());
+            st.setString(9, plot.getWorldguardRegionId());
+            if (plot.getOwnerUuid() != null) {
+                st.setString(10, plot.getOwnerUuid());
+            } else {
+                st.setNull(10, Types.VARCHAR);
+            }
+            st.executeUpdate();
+            try (ResultSet keys = st.getGeneratedKeys()) {
+                if (keys.next()) {
+                    int id = keys.getInt(1);
+                    plot.setId(id);
+                    return id;
+                }
+            }
+        }
+        return -1;
+    }
+
+    public FarmPlot getById(int id) throws SQLException {
+        String query = "SELECT * FROM farm_plots WHERE id = ?";
+        try (PreparedStatement st = connection.prepareStatement(query)) {
+            st.setInt(1, id);
+            try (ResultSet rs = st.executeQuery()) {
+                if (rs.next()) {
+                    return map(rs);
+                }
+            }
+        }
+        return null;
+    }
+
+    public FarmPlot getPlotByName(String plotName) throws SQLException {
+        String query = "SELECT * FROM farm_plots WHERE plot_name = ?";
+        try (PreparedStatement st = connection.prepareStatement(query)) {
+            st.setString(1, plotName);
+            try (ResultSet rs = st.executeQuery()) {
+                if (rs.next()) {
+                    return map(rs);
+                }
+            }
+        }
+        return null;
+    }
+
+    public List<FarmPlot> getAllPlots() throws SQLException {
+        String query = "SELECT * FROM farm_plots ORDER BY id";
+        List<FarmPlot> plots = new ArrayList<>();
+        try (PreparedStatement st = connection.prepareStatement(query);
+             ResultSet rs = st.executeQuery()) {
+            while (rs.next()) {
+                plots.add(map(rs));
+            }
+        }
+        return plots;
+    }
+
+    /**
+     * 指定プレイヤーが所有する区画（1人1区画のため単一想定）
+     */
+    public FarmPlot getPlotByOwner(String ownerUuid) throws SQLException {
+        String query = "SELECT * FROM farm_plots WHERE owner_uuid = ? LIMIT 1";
+        try (PreparedStatement st = connection.prepareStatement(query)) {
+            st.setString(1, ownerUuid);
+            try (ResultSet rs = st.executeQuery()) {
+                if (rs.next()) {
+                    return map(rs);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 空き区画（owner_uuid IS NULL）を1件取得（なければnull）
+     */
+    public FarmPlot findAvailablePlot() throws SQLException {
+        String query = "SELECT * FROM farm_plots WHERE owner_uuid IS NULL ORDER BY id LIMIT 1";
+        try (PreparedStatement st = connection.prepareStatement(query);
+             ResultSet rs = st.executeQuery()) {
+            if (rs.next()) {
+                return map(rs);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 区画の所有者を更新（解放する場合は ownerUuid に null を渡す）
+     */
+    public boolean updateOwner(int id, String ownerUuid) throws SQLException {
+        String query = "UPDATE farm_plots SET owner_uuid = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?";
+        try (PreparedStatement st = connection.prepareStatement(query)) {
+            if (ownerUuid != null) {
+                st.setString(1, ownerUuid);
+            } else {
+                st.setNull(1, Types.VARCHAR);
+            }
+            st.setInt(2, id);
+            return st.executeUpdate() > 0;
+        }
+    }
+
+    public boolean deletePlot(int id) throws SQLException {
+        String query = "DELETE FROM farm_plots WHERE id = ?";
+        try (PreparedStatement st = connection.prepareStatement(query)) {
+            st.setInt(1, id);
+            return st.executeUpdate() > 0;
+        }
+    }
+
+    private FarmPlot map(ResultSet rs) throws SQLException {
+        FarmPlot plot = new FarmPlot();
+        plot.setId(rs.getInt("id"));
+        plot.setPlotName(rs.getString("plot_name"));
+        plot.setWorldName(rs.getString("world_name"));
+        plot.setX1(rs.getInt("x1"));
+        plot.setY1(rs.getInt("y1"));
+        plot.setZ1(rs.getInt("z1"));
+        plot.setX2(rs.getInt("x2"));
+        plot.setY2(rs.getInt("y2"));
+        plot.setZ2(rs.getInt("z2"));
+        plot.setWorldguardRegionId(rs.getString("worldguard_region_id"));
+        plot.setOwnerUuid(rs.getString("owner_uuid"));
+        plot.setCreatedAt(rs.getTimestamp("created_at"));
+        plot.setUpdatedAt(rs.getTimestamp("updated_at"));
+        return plot;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/database/DatabaseManager.java
+++ b/src/main/java/org/tofu/tofunomics/database/DatabaseManager.java
@@ -294,6 +294,23 @@ public class DatabaseManager {
             "    completed_at TIMESTAMP," +
             "    UNIQUE(player_uuid, quest_id)," +
             "    FOREIGN KEY (player_uuid) REFERENCES players(uuid) ON DELETE CASCADE" +
+            ");",
+
+            // 農家畑区画テーブル（owner_uuid が NULL の区画は空き）
+            "CREATE TABLE IF NOT EXISTS farm_plots (" +
+            "    id INTEGER PRIMARY KEY AUTOINCREMENT," +
+            "    plot_name TEXT NOT NULL UNIQUE," +
+            "    world_name TEXT NOT NULL," +
+            "    x1 INTEGER NOT NULL," +
+            "    y1 INTEGER NOT NULL," +
+            "    z1 INTEGER NOT NULL," +
+            "    x2 INTEGER NOT NULL," +
+            "    y2 INTEGER NOT NULL," +
+            "    z2 INTEGER NOT NULL," +
+            "    worldguard_region_id TEXT," +
+            "    owner_uuid TEXT," +
+            "    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP," +
+            "    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP" +
             ");"
         };
 

--- a/src/main/java/org/tofu/tofunomics/farming/FarmPlotManager.java
+++ b/src/main/java/org/tofu/tofunomics/farming/FarmPlotManager.java
@@ -1,0 +1,295 @@
+package org.tofu.tofunomics.farming;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.FarmPlotDAO;
+import org.tofu.tofunomics.integration.WorldGuardIntegration;
+import org.tofu.tofunomics.models.FarmPlot;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 農家畑区画(プロット)の管理マネージャ。
+ * - 管理者のコマンドによる区画作成/削除
+ * - 農家就職時の自動割り当て / 離職時の解放（1人1区画）
+ * 窃盗防止はWorldGuardのメンバー機構（所有者をmember登録）で実現する。
+ */
+public class FarmPlotManager {
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final FarmPlotDAO farmPlotDAO;
+
+    // 管理者のコマンドによる角選択（足元ブロック位置）
+    private final Map<UUID, Location> pos1 = new HashMap<>();
+    private final Map<UUID, Location> pos2 = new HashMap<>();
+
+    public FarmPlotManager(TofuNomics plugin, ConfigManager configManager, FarmPlotDAO farmPlotDAO) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.farmPlotDAO = farmPlotDAO;
+    }
+
+    // WorldGuard連携は初期化順序の都合で遅延取得する
+    private WorldGuardIntegration wg() {
+        return plugin.getWorldGuardIntegration();
+    }
+
+    // ========== 角選択（コマンド） ==========
+
+    public void setPos1(Player player, Location location) {
+        pos1.put(player.getUniqueId(), location);
+    }
+
+    public void setPos2(Player player, Location location) {
+        pos2.put(player.getUniqueId(), location);
+    }
+
+    public boolean hasSelection(Player player) {
+        return pos1.containsKey(player.getUniqueId()) && pos2.containsKey(player.getUniqueId());
+    }
+
+    // ========== 区画の作成/削除（管理者） ==========
+
+    /**
+     * 選択範囲から区画を作成（WGリージョン作成 + DB登録）
+     */
+    public boolean createPlot(Player admin, String name) {
+        WorldGuardIntegration wg = wg();
+        if (wg == null || !wg.isEnabled()) {
+            admin.sendMessage(ChatColor.RED + "WorldGuardが無効なため区画を作成できません。");
+            return false;
+        }
+        if (!hasSelection(admin)) {
+            admin.sendMessage(ChatColor.RED + "範囲が未選択です。/farmplot pos1 と /farmplot pos2 で角を指定してください。");
+            return false;
+        }
+        Location p1 = pos1.get(admin.getUniqueId());
+        Location p2 = pos2.get(admin.getUniqueId());
+        if (p1.getWorld() == null || p2.getWorld() == null
+                || !p1.getWorld().getName().equals(p2.getWorld().getName())) {
+            admin.sendMessage(ChatColor.RED + "pos1とpos2は同じワールドで指定してください。");
+            return false;
+        }
+
+        try {
+            if (farmPlotDAO.getPlotByName(name) != null) {
+                admin.sendMessage(ChatColor.RED + "区画名 '" + name + "' は既に存在します。");
+                return false;
+            }
+            String regionId = ("farmplot_" + name).toLowerCase();
+            World world = p1.getWorld();
+
+            if (!wg.createRegion(regionId, world, p1, p2)) {
+                admin.sendMessage(ChatColor.RED + "WorldGuardリージョンの作成に失敗しました（同名リージョンが存在する可能性）。");
+                return false;
+            }
+
+            FarmPlot plot = new FarmPlot(name, world.getName(),
+                    p1.getBlockX(), p1.getBlockY(), p1.getBlockZ(),
+                    p2.getBlockX(), p2.getBlockY(), p2.getBlockZ(), regionId);
+            int id = farmPlotDAO.createPlot(plot);
+            if (id <= 0) {
+                // DB登録失敗時はWGリージョンをロールバック
+                wg.removeRegion(regionId, world);
+                admin.sendMessage(ChatColor.RED + "区画のDB登録に失敗しました。");
+                return false;
+            }
+
+            // 選択をクリア
+            pos1.remove(admin.getUniqueId());
+            pos2.remove(admin.getUniqueId());
+
+            admin.sendMessage(ChatColor.GREEN + "畑区画 '" + name + "' を作成しました（リージョン: " + regionId + "）。");
+            return true;
+        } catch (SQLException e) {
+            admin.sendMessage(ChatColor.RED + "区画作成中にエラーが発生しました。");
+            plugin.getLogger().severe("farm plot 作成エラー: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public boolean deletePlot(Player admin, String name) {
+        try {
+            FarmPlot plot = farmPlotDAO.getPlotByName(name);
+            if (plot == null) {
+                admin.sendMessage(ChatColor.RED + "区画 '" + name + "' は存在しません。");
+                return false;
+            }
+            WorldGuardIntegration wg = wg();
+            World world = Bukkit.getWorld(plot.getWorldName());
+            if (wg != null && wg.isEnabled() && world != null && plot.getWorldguardRegionId() != null) {
+                wg.removeRegion(plot.getWorldguardRegionId(), world);
+            }
+            farmPlotDAO.deletePlot(plot.getId());
+            admin.sendMessage(ChatColor.GREEN + "畑区画 '" + name + "' を削除しました。");
+            return true;
+        } catch (SQLException e) {
+            admin.sendMessage(ChatColor.RED + "区画削除中にエラーが発生しました。");
+            plugin.getLogger().severe("farm plot 削除エラー: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public List<FarmPlot> listPlots() {
+        try {
+            return farmPlotDAO.getAllPlots();
+        } catch (SQLException e) {
+            plugin.getLogger().severe("farm plot 一覧取得エラー: " + e.getMessage());
+            return java.util.Collections.emptyList();
+        }
+    }
+
+    public FarmPlot getPlotByName(String name) {
+        try {
+            return farmPlotDAO.getPlotByName(name);
+        } catch (SQLException e) {
+            plugin.getLogger().severe("farm plot 取得エラー: " + e.getMessage());
+            return null;
+        }
+    }
+
+    // ========== 割り当て / 解放 ==========
+
+    /**
+     * 農家就職時の自動割り当て（1人1区画）。職業就職自体は妨げない。
+     */
+    public void assignPlot(Player player) {
+        WorldGuardIntegration wg = wg();
+        if (wg == null || !wg.isEnabled()) {
+            return;
+        }
+        String uuid = player.getUniqueId().toString();
+        try {
+            // 既に所有していれば何もしない
+            if (farmPlotDAO.getPlotByOwner(uuid) != null) {
+                return;
+            }
+            FarmPlot plot = farmPlotDAO.findAvailablePlot();
+            if (plot == null) {
+                // 区画が1つも登録されていない場合は機能未導入とみなし無言でスキップ
+                if (farmPlotDAO.getAllPlots().isEmpty()) {
+                    return;
+                }
+                player.sendMessage(ChatColor.YELLOW + "現在割り当て可能な畑区画がありません。管理者にお問い合わせください。");
+                plugin.getLogger().warning("農家区画の空きがありません: " + player.getName());
+                return;
+            }
+            World world = Bukkit.getWorld(plot.getWorldName());
+            if (world == null) {
+                plugin.getLogger().warning("農家区画のワールドが見つかりません: " + plot.getWorldName());
+                return;
+            }
+            boolean memberAdded = wg.addMember(plot.getWorldguardRegionId(), world, player.getUniqueId());
+            if (!memberAdded) {
+                plugin.getLogger().warning("農家区画のWGメンバー追加に失敗: " + plot.getPlotName());
+                return;
+            }
+            farmPlotDAO.updateOwner(plot.getId(), uuid);
+
+            int cx = (plot.getX1() + plot.getX2()) / 2;
+            int cy = Math.max(plot.getY1(), plot.getY2());
+            int cz = (plot.getZ1() + plot.getZ2()) / 2;
+            player.sendMessage(ChatColor.GREEN + "農家の畑区画 '" + plot.getPlotName()
+                    + "' が割り当てられました！ 場所: " + ChatColor.AQUA
+                    + plot.getWorldName() + " (" + cx + ", " + cy + ", " + cz + ")");
+        } catch (SQLException e) {
+            plugin.getLogger().severe("農家区画の割り当てエラー: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 離職/転職時の区画解放（UUIDベース＝オフライン対応）
+     */
+    public void releasePlot(UUID playerUuid) {
+        WorldGuardIntegration wg = wg();
+        String uuid = playerUuid.toString();
+        try {
+            FarmPlot plot = farmPlotDAO.getPlotByOwner(uuid);
+            if (plot == null) {
+                return;
+            }
+            World world = Bukkit.getWorld(plot.getWorldName());
+            if (wg != null && wg.isEnabled() && world != null && plot.getWorldguardRegionId() != null) {
+                wg.removeMember(plot.getWorldguardRegionId(), world, playerUuid);
+            }
+            farmPlotDAO.updateOwner(plot.getId(), null);
+
+            Player player = Bukkit.getPlayer(playerUuid);
+            if (player != null && player.isOnline()) {
+                player.sendMessage(ChatColor.YELLOW + "農家の畑区画 '" + plot.getPlotName() + "' が解放されました。");
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().severe("農家区画の解放エラー: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 管理者による手動割り当て（既存農家向け）。plotName が null の場合は空き区画から自動選択。
+     */
+    public boolean assignPlotManually(Player admin, Player target, String plotName) {
+        WorldGuardIntegration wg = wg();
+        if (wg == null || !wg.isEnabled()) {
+            admin.sendMessage(ChatColor.RED + "WorldGuardが無効です。");
+            return false;
+        }
+        String uuid = target.getUniqueId().toString();
+        try {
+            if (farmPlotDAO.getPlotByOwner(uuid) != null) {
+                admin.sendMessage(ChatColor.RED + target.getName() + " は既に区画を所有しています。");
+                return false;
+            }
+            FarmPlot plot = (plotName != null) ? farmPlotDAO.getPlotByName(plotName) : farmPlotDAO.findAvailablePlot();
+            if (plot == null) {
+                admin.sendMessage(ChatColor.RED + "割り当て可能な区画が見つかりません。");
+                return false;
+            }
+            if (plot.isAssigned()) {
+                admin.sendMessage(ChatColor.RED + "区画 '" + plot.getPlotName() + "' は既に割り当て済みです。");
+                return false;
+            }
+            World world = Bukkit.getWorld(plot.getWorldName());
+            if (world == null) {
+                admin.sendMessage(ChatColor.RED + "区画のワールドが見つかりません。");
+                return false;
+            }
+            wg.addMember(plot.getWorldguardRegionId(), world, target.getUniqueId());
+            farmPlotDAO.updateOwner(plot.getId(), uuid);
+            admin.sendMessage(ChatColor.GREEN + target.getName() + " に区画 '" + plot.getPlotName() + "' を割り当てました。");
+            target.sendMessage(ChatColor.GREEN + "農家の畑区画 '" + plot.getPlotName() + "' が割り当てられました。");
+            return true;
+        } catch (SQLException e) {
+            admin.sendMessage(ChatColor.RED + "割り当て中にエラーが発生しました。");
+            plugin.getLogger().severe("農家区画の手動割り当てエラー: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 管理者による手動解放
+     */
+    public boolean releasePlotManually(Player admin, Player target) {
+        try {
+            if (farmPlotDAO.getPlotByOwner(target.getUniqueId().toString()) == null) {
+                admin.sendMessage(ChatColor.RED + target.getName() + " は区画を所有していません。");
+                return false;
+            }
+            releasePlot(target.getUniqueId());
+            admin.sendMessage(ChatColor.GREEN + target.getName() + " の区画を解放しました。");
+            return true;
+        } catch (SQLException e) {
+            admin.sendMessage(ChatColor.RED + "解放中にエラーが発生しました。");
+            plugin.getLogger().severe("農家区画の手動解放エラー: " + e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/jobs/JobManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobManager.java
@@ -121,8 +121,46 @@ public class JobManager {
         if (!playerJobDAO.insertPlayerJob(playerJob)) {
             return JobJoinResult.DATABASE_ERROR;
         }
-        
+
+        // 農家就職時に畑区画を自動割り当て
+        onFarmerJobJoined(player, jobName);
+
         return JobJoinResult.SUCCESS;
+    }
+
+    /**
+     * 農家就職時に畑区画を自動割り当てする（farmer以外は何もしない）。
+     * FarmPlotManagerは遅延取得し、未初期化でも安全に無視する。
+     */
+    private void onFarmerJobJoined(Player player, String jobName) {
+        if (!"farmer".equalsIgnoreCase(jobName)) {
+            return;
+        }
+        try {
+            org.tofu.tofunomics.farming.FarmPlotManager fpm = TofuNomics.getInstance().getFarmPlotManager();
+            if (fpm != null) {
+                fpm.assignPlot(player);
+            }
+        } catch (Exception e) {
+            TofuNomics.getInstance().getLogger().warning("農家区画の自動割り当てに失敗しました: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 農家離職/転職時に畑区画を解放する（farmer以外は何もしない）。
+     */
+    private void onFarmerJobLeft(java.util.UUID playerUuid, String jobName) {
+        if (!"farmer".equalsIgnoreCase(jobName)) {
+            return;
+        }
+        try {
+            org.tofu.tofunomics.farming.FarmPlotManager fpm = TofuNomics.getInstance().getFarmPlotManager();
+            if (fpm != null) {
+                fpm.releasePlot(playerUuid);
+            }
+        } catch (Exception e) {
+            TofuNomics.getInstance().getLogger().warning("農家区画の解放に失敗しました: " + e.getMessage());
+        }
     }
     
     public enum JobLeaveResult {
@@ -165,15 +203,18 @@ public class JobManager {
         if (!playerJobDAO.deletePlayerJob(uuid, job.getId())) {
             return JobLeaveResult.DATABASE_ERROR;
         }
-        
+
         if (configManager.isDailyJobChangeLimitEnabled()) {
             jobChangeDAO.recordJobChangeToday(uuid);
         }
-        
+
+        // 農家離職時に畑区画を解放
+        onFarmerJobLeft(player.getUniqueId(), jobName);
+
         return JobLeaveResult.SUCCESS;
     }
 
-    
+
     /**
      * 管理者による強制辞職（レベル制限を無視）
      * @param player プレイヤー
@@ -209,11 +250,14 @@ public class JobManager {
         if (!playerJobDAO.deletePlayerJob(uuid, job.getId())) {
             return JobLeaveResult.DATABASE_ERROR;
         }
-        
+
         if (configManager.isDailyJobChangeLimitEnabled()) {
             jobChangeDAO.recordJobChangeToday(uuid);
         }
-        
+
+        // 農家強制離職時に畑区画を解放
+        onFarmerJobLeft(player.getUniqueId(), jobName);
+
         return JobLeaveResult.SUCCESS;
     }
     

--- a/src/main/java/org/tofu/tofunomics/models/FarmPlot.java
+++ b/src/main/java/org/tofu/tofunomics/models/FarmPlot.java
@@ -1,0 +1,99 @@
+package org.tofu.tofunomics.models;
+
+import org.bukkit.Location;
+
+import java.sql.Timestamp;
+
+/**
+ * 農家の畑区画（プロット）モデル
+ * 座標範囲とWorldGuardリージョン、所有者(農家)を保持する。
+ * owner_uuid が null の区画は「空き（未割り当て）」を表す。
+ */
+public class FarmPlot {
+
+    private int id;
+    private String plotName;
+    private String worldName;
+    private int x1, y1, z1;
+    private int x2, y2, z2;
+    private String worldguardRegionId;
+    private String ownerUuid; // null = 空き
+    private Timestamp createdAt;
+    private Timestamp updatedAt;
+
+    public FarmPlot() {
+    }
+
+    public FarmPlot(String plotName, String worldName, int x1, int y1, int z1,
+                    int x2, int y2, int z2, String worldguardRegionId) {
+        this.plotName = plotName;
+        this.worldName = worldName;
+        this.x1 = x1;
+        this.y1 = y1;
+        this.z1 = z1;
+        this.x2 = x2;
+        this.y2 = y2;
+        this.z2 = z2;
+        this.worldguardRegionId = worldguardRegionId;
+        this.ownerUuid = null;
+    }
+
+    /**
+     * 指定座標がこの区画の範囲内かを判定（立方体判定）
+     */
+    public boolean contains(Location location) {
+        if (location == null || location.getWorld() == null) {
+            return false;
+        }
+        if (!location.getWorld().getName().equals(worldName)) {
+            return false;
+        }
+        int x = location.getBlockX();
+        int y = location.getBlockY();
+        int z = location.getBlockZ();
+        return x >= Math.min(x1, x2) && x <= Math.max(x1, x2) &&
+               y >= Math.min(y1, y2) && y <= Math.max(y1, y2) &&
+               z >= Math.min(z1, z2) && z <= Math.max(z1, z2);
+    }
+
+    /**
+     * 区画が割り当て済み（所有者あり）か
+     */
+    public boolean isAssigned() {
+        return ownerUuid != null && !ownerUuid.isEmpty();
+    }
+
+    public int getId() { return id; }
+    public void setId(int id) { this.id = id; }
+
+    public String getPlotName() { return plotName; }
+    public void setPlotName(String plotName) { this.plotName = plotName; }
+
+    public String getWorldName() { return worldName; }
+    public void setWorldName(String worldName) { this.worldName = worldName; }
+
+    public int getX1() { return x1; }
+    public void setX1(int x1) { this.x1 = x1; }
+    public int getY1() { return y1; }
+    public void setY1(int y1) { this.y1 = y1; }
+    public int getZ1() { return z1; }
+    public void setZ1(int z1) { this.z1 = z1; }
+    public int getX2() { return x2; }
+    public void setX2(int x2) { this.x2 = x2; }
+    public int getY2() { return y2; }
+    public void setY2(int y2) { this.y2 = y2; }
+    public int getZ2() { return z2; }
+    public void setZ2(int z2) { this.z2 = z2; }
+
+    public String getWorldguardRegionId() { return worldguardRegionId; }
+    public void setWorldguardRegionId(String worldguardRegionId) { this.worldguardRegionId = worldguardRegionId; }
+
+    public String getOwnerUuid() { return ownerUuid; }
+    public void setOwnerUuid(String ownerUuid) { this.ownerUuid = ownerUuid; }
+
+    public Timestamp getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Timestamp createdAt) { this.createdAt = createdAt; }
+
+    public Timestamp getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Timestamp updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -65,6 +65,11 @@ commands:
     usage: /housing <list|info|rent|myrentals|extend|cancel|admin> [args]
     aliases: [house]
     permission: tofunomics.housing.use
+  farmplot:
+    description: 農家畑区画管理システム
+    usage: /farmplot <pos1|pos2|create|delete|list|info|assign|release> [args]
+    aliases: [plot, fp]
+    permission: tofunomics.farmplot.admin
   testmode:
     description: テストモード（権限なしユーザーの挙動をテスト）
     usage: /testmode <on|off|status>
@@ -250,7 +255,11 @@ permissions:
   tofunomics.housing.admin:
     description: 住居物件管理権限
     default: op
-  
+
+  tofunomics.farmplot.admin:
+    description: 農家畑区画管理コマンド使用権限
+    default: op
+
   tofunomics.testmode:
     description: テストモード切り替え権限
     default: op

--- a/src/test/java/org/tofu/tofunomics/farming/FarmPlotManagerTest.java
+++ b/src/test/java/org/tofu/tofunomics/farming/FarmPlotManagerTest.java
@@ -1,0 +1,76 @@
+package org.tofu.tofunomics.farming;
+
+import org.bukkit.entity.Player;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.FarmPlotDAO;
+import org.tofu.tofunomics.integration.WorldGuardIntegration;
+import org.tofu.tofunomics.models.FarmPlot;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * FarmPlotManager の割り当て分岐テスト（Bukkit静的依存を踏まない経路のみ）
+ */
+public class FarmPlotManagerTest {
+
+    @Mock private TofuNomics plugin;
+    @Mock private ConfigManager configManager;
+    @Mock private FarmPlotDAO farmPlotDAO;
+    @Mock private WorldGuardIntegration worldGuard;
+    @Mock private Player player;
+
+    private FarmPlotManager manager;
+    private final UUID uuid = UUID.randomUUID();
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(plugin.getWorldGuardIntegration()).thenReturn(worldGuard);
+        when(player.getUniqueId()).thenReturn(uuid);
+        manager = new FarmPlotManager(plugin, configManager, farmPlotDAO);
+    }
+
+    @Test
+    public void testAssignPlotSkipsWhenWorldGuardDisabled() throws Exception {
+        when(worldGuard.isEnabled()).thenReturn(false);
+
+        manager.assignPlot(player);
+
+        // WG無効なら一切DBに触れない
+        verifyNoInteractions(farmPlotDAO);
+    }
+
+    @Test
+    public void testAssignPlotSkipsWhenAlreadyOwning() throws Exception {
+        when(worldGuard.isEnabled()).thenReturn(true);
+        when(farmPlotDAO.getPlotByOwner(uuid.toString())).thenReturn(new FarmPlot());
+
+        manager.assignPlot(player);
+
+        // 既に所有しているので空き検索は行わない
+        verify(farmPlotDAO, never()).findAvailablePlot();
+        verify(farmPlotDAO, never()).updateOwner(anyInt(), anyString());
+    }
+
+    @Test
+    public void testAssignPlotSilentWhenNoPlotsRegistered() throws Exception {
+        when(worldGuard.isEnabled()).thenReturn(true);
+        when(farmPlotDAO.getPlotByOwner(uuid.toString())).thenReturn(null);
+        when(farmPlotDAO.findAvailablePlot()).thenReturn(null);
+        when(farmPlotDAO.getAllPlots()).thenReturn(Collections.emptyList());
+
+        manager.assignPlot(player);
+
+        // 区画未登録なら無言（所有者更新もメッセージもなし）
+        verify(farmPlotDAO, never()).updateOwner(anyInt(), anyString());
+        verify(player, never()).sendMessage(anyString());
+    }
+}

--- a/src/test/java/org/tofu/tofunomics/models/FarmPlotTest.java
+++ b/src/test/java/org/tofu/tofunomics/models/FarmPlotTest.java
@@ -1,0 +1,64 @@
+package org.tofu.tofunomics.models;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * FarmPlot の範囲判定・所有判定テスト
+ */
+public class FarmPlotTest {
+
+    private Location loc(String worldName, int x, int y, int z) {
+        World world = mock(World.class);
+        when(world.getName()).thenReturn(worldName);
+        Location location = mock(Location.class);
+        when(location.getWorld()).thenReturn(world);
+        when(location.getBlockX()).thenReturn(x);
+        when(location.getBlockY()).thenReturn(y);
+        when(location.getBlockZ()).thenReturn(z);
+        return location;
+    }
+
+    private FarmPlot plot() {
+        // (10,60,10) - (20,70,20) の立方体
+        return new FarmPlot("A", "world", 10, 60, 10, 20, 70, 20, "farmplot_a");
+    }
+
+    @Test
+    public void testContainsInside() {
+        assertTrue(plot().contains(loc("world", 15, 65, 15)));
+        assertTrue(plot().contains(loc("world", 10, 60, 10))); // 境界
+        assertTrue(plot().contains(loc("world", 20, 70, 20))); // 境界
+    }
+
+    @Test
+    public void testContainsOutside() {
+        assertFalse(plot().contains(loc("world", 9, 65, 15)));   // x範囲外
+        assertFalse(plot().contains(loc("world", 15, 59, 15)));  // y範囲外
+        assertFalse(plot().contains(loc("world", 15, 65, 21)));  // z範囲外
+    }
+
+    @Test
+    public void testContainsDifferentWorld() {
+        assertFalse(plot().contains(loc("nether", 15, 65, 15)));
+    }
+
+    @Test
+    public void testContainsNull() {
+        assertFalse(plot().contains(null));
+    }
+
+    @Test
+    public void testIsAssigned() {
+        FarmPlot p = plot();
+        assertFalse(p.isAssigned());
+        p.setOwnerUuid("");
+        assertFalse(p.isAssigned());
+        p.setOwnerUuid("abc-uuid");
+        assertTrue(p.isAssigned());
+    }
+}


### PR DESCRIPTION
## 概要
中心都市のオフィシャル畑を**区画（プロット）単位**で管理し、**各区画の所有者だけが収穫・植え付けできる**ようにして、他農家による窃盗を防止します（要望②）。

窃盗防止は **WorldGuardのメンバー機構**で実現（区画＝WGリージョン、所有者をmember登録 → 非メンバーの破壊/設置をWGが自動拒否）。プラグイン側に新規BlockBreak判定コードは不要。

## 仕様
- **区画登録**: 管理者がコマンドで角を指定 → `/farmplot pos1` `/farmplot pos2` → `/farmplot create <名前>`
- **農家就職時に空き区画を自動割り当て**、**離職/転職/強制離職時に自動解放**（1人1区画固定）
- 区画が未登録の段階では就職時に無言でスキップ（ロールアウト配慮）

## 変更内容
- `models/FarmPlot` ＋ `dao/FarmPlotDAO` ＋ `farm_plots` テーブル（`DatabaseManager`）
- `farming/FarmPlotManager`: 区画の作成/削除、割り当て/解放、手動割り当て。WorldGuard連携は初期化順序の都合で遅延取得
- `commands/FarmPlotCommand`: `/farmplot pos1|pos2|create|delete|list|info|assign|release`（`tofunomics.farmplot.admin`、OPデフォルト）
- `JobManager` の `joinJob`/`leaveJob`/`forceLeaveJob` のSUCCESS地点に割り当て/解放フックを集約（GUI・コマンド・強制離職の全経路を網羅）
- `TofuNomics` / `plugin.yml` 配線

## 既存実装の再利用
- `WorldGuardIntegration`（createRegion/addMember/removeMember/removeRegion）
- `HousingPropertyDAO` のDAOパターン、`HousingRentalManager` の「選択→WG作成→メンバー管理」フロー

## テスト
- `FarmPlotTest`（範囲判定/所有判定 5件）、`FarmPlotManagerTest`（割り当て分岐 3件）
- `mvn clean package` 成功、全324テストパス

## 窃盗防止の前提
- WorldGuard有効（住居システムで使用中＝有効済み）
- 補足: **未割り当て区画はメンバー0のためWG制限が効かず誰でも破壊可**。通常は離職で即解放＝再割り当て前提のため実用上の問題は小さい。完全ロックが必要なら将来フラグ対応（本PRスコープ外）

## 動作確認（デプロイ後・完全再起動推奨）
- [ ] 管理者が `/farmplot pos1`→`pos2`→`create A` で区画作成（WGリージョン `farmplot_a` 生成）
- [ ] 非OPの農家Xが就職 → 自動で区画割り当て＋座標通知
- [ ] X は自区画で植え付け・収穫可、別の農家Y（非メンバー）は破壊/植え付け不可（窃盗防止）
- [ ] X が離職 → 区画解放 → 再割り当て可能
- [ ] `/farmplot assign <既存農家>` で手動割り当て

🤖 Generated with [Claude Code](https://claude.com/claude-code)