### PR TITLE
fix: 農家がメロン・カボチャのタネをクラフトできない問題を修正

### DIFF
--- a/src/main/java/org/tofu/tofunomics/jobs/JobCraftPermissionManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobCraftPermissionManager.java
@@ -83,6 +83,8 @@ public class JobCraftPermissionManager {
             Material.BREAD, Material.CAKE, Material.COOKIE, Material.PUMPKIN_PIE,
             Material.MUSHROOM_STEW, Material.RABBIT_STEW, Material.BEETROOT_SOUP,
             Material.SUSPICIOUS_STEW, Material.HONEY_BOTTLE,
+            // 農業のタネ類（バニラレシピでクラフト可能）
+            Material.MELON_SEEDS, Material.PUMPKIN_SEEDS,
             // 農業関連設備
             Material.COMPOSTER, Material.FLOWER_POT, Material.CAULDRON,
             Material.BARREL, Material.SMOKER,


### PR DESCRIPTION
## 概要

農家プレイヤーがバニラの標準レシピ「スイカの薄切り(MELON_SLICE) → メロンのタネ(MELON_SEEDS)」をクラフトできない不具合を修正しました。

## 原因

職業別クラフト制限の仕組みにおいて、`CraftRestrictionEventHandler`(優先度 `LOWEST`)が `JobCraftPermissionManager.canPlayerCraftItem()` の判定でクラフトをキャンセルしています。

農家(`farmer`)の許可リストに `MELON_SEEDS` が登録されていなかったため、農家であってもメロンのタネのクラフトが拒否されていました。同じ理由でカボチャの種(`PUMPKIN_SEEDS`)もクラフト不可の状態でした。

## 修正内容

`JobCraftPermissionManager.java` の農家許可リストにタネ類を追加:
- `Material.MELON_SEEDS` — スイカの薄切りからクラフト
- `Material.PUMPKIN_SEEDS` — カボチャからクラフト

※ WHEAT_SEEDS / BEETROOT_SEEDS はバニラにクラフトレシピが無い(草を壊して入手)ため対象外。

## 確認方法

- [ ] 農家プレイヤーで作業台にスイカの薄切りを置き、メロンのタネが取り出せること
- [ ] カボチャを置き、カボチャの種が取り出せること
- [ ] 非農家プレイヤーでは引き続きクラフトが拒否されること(制限が壊れていないこと)

🤖 Generated with [Claude Code](https://claude.com/claude-code)