### PR TITLE
feat: 職業レベルアップ報酬をツール付与からお金へ変更

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -489,6 +489,9 @@ public final class TofuNomics extends JavaPlugin {
                 experienceManager
             );
 
+            // レベルアップ時のお金報酬を注入
+            jobExperienceManager.setJobLevelRewardManager(jobLevelRewardManager);
+
             // 食事による職業経験値ブーストバフの初期化・注入
             foodBuffManager = new org.tofu.tofunomics.food.FoodBuffManager(configManager);
             jobExperienceManager.setFoodBuffManager(foodBuffManager);

--- a/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
+++ b/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
@@ -62,6 +62,9 @@ public class JobExperienceManager implements Listener {
     // 食事による経験値ブーストバフ用（setter注入。null許容）
     private org.tofu.tofunomics.food.FoodBuffManager foodBuffManager;
 
+    // レベルアップ時のお金報酬用（setter注入。null許容）
+    private org.tofu.tofunomics.rewards.JobLevelRewardManager jobLevelRewardManager;
+
     // 経験値テーブル
     private final Map<Material, Double> miningExperience;
     private final Map<Material, Double> loggingExperience;
@@ -106,6 +109,13 @@ public class JobExperienceManager implements Listener {
      */
     public void setFoodBuffManager(org.tofu.tofunomics.food.FoodBuffManager foodBuffManager) {
         this.foodBuffManager = foodBuffManager;
+    }
+
+    /**
+     * レベルアップ時のお金報酬管理を注入する
+     */
+    public void setJobLevelRewardManager(org.tofu.tofunomics.rewards.JobLevelRewardManager jobLevelRewardManager) {
+        this.jobLevelRewardManager = jobLevelRewardManager;
     }
 
     private void initializeExperienceTables() {
@@ -473,8 +483,11 @@ public class JobExperienceManager implements Listener {
                 notificationManager.playCelebrationEffect(player);
             }
 
-            // 新しいツールの付与チェック
-            jobToolManager.checkAndGiveNewTools(player, jobName, newLevel);
+            // レベルアップ報酬（お金）の付与。5レベルおき（Lv5,10,…）に付与される。
+            // while文で1レベルずつ処理されるため、複数レベル同時アップ時も各レベルで判定される。
+            if (jobLevelRewardManager != null) {
+                jobLevelRewardManager.giveJobLevelReward(player, jobName, newLevel);
+            }
 
             // 職業レベル最大値チェック
             Job job = jobDAO.getJobByNameSafe(jobName);

--- a/src/main/java/org/tofu/tofunomics/rewards/JobLevelRewardManager.java
+++ b/src/main/java/org/tofu/tofunomics/rewards/JobLevelRewardManager.java
@@ -1,379 +1,137 @@
 package org.tofu.tofunomics.rewards;
 
 import org.bukkit.ChatColor;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.tofu.tofunomics.config.ConfigManager;
 import org.tofu.tofunomics.dao.PlayerDAO;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
  * 職業レベルアップ報酬システム
+ *
+ * 報酬は「お金（通貨）」のみ。5レベルおき（Lv5, 10, …, 100）に付与する。
+ * 金額は職業別の基礎額にレベル段階（level / 5）を掛けた値。
+ * 人気職は優遇せず、手間のかかる専門職を厚めに設定している。
  */
 public class JobLevelRewardManager {
-    
+
+    /** 報酬を付与するレベル間隔 */
+    private static final int REWARD_INTERVAL = 5;
+
+    /** 報酬対象の最大レベル */
+    private static final int MAX_REWARD_LEVEL = 100;
+
+    /** 未知の職業に対するデフォルト基礎額 */
+    private static final double DEFAULT_BASE_REWARD = 40.0;
+
+    /** 職業別の基礎報酬額（Lv5時点の金額。以降は段階に比例して増加） */
+    private static final Map<String, Double> JOB_BASE_REWARD = new HashMap<>();
+    static {
+        JOB_BASE_REWARD.put("enchanter", 50.0);   // 地味・手間 → 優遇
+        JOB_BASE_REWARD.put("alchemist", 50.0);   // 地味・手間 → 優遇
+        JOB_BASE_REWARD.put("architect", 45.0);   // スキル要・地味
+        JOB_BASE_REWARD.put("blacksmith", 45.0);  // 手間
+        JOB_BASE_REWARD.put("miner", 40.0);       // 人気・中位
+        JOB_BASE_REWARD.put("farmer", 40.0);      // 人気・中位
+        JOB_BASE_REWARD.put("woodcutter", 40.0);  // 単純・中位
+        JOB_BASE_REWARD.put("fisherman", 35.0);   // 放置気味・人気
+    }
+
     private final ConfigManager configManager;
     private final PlayerDAO playerDAO;
-    
-    // 職業別レベル報酬設定
-    private final Map<String, Map<Integer, LevelReward>> jobRewards;
-    
+
     public JobLevelRewardManager(ConfigManager configManager, PlayerDAO playerDAO) {
         this.configManager = configManager;
         this.playerDAO = playerDAO;
-        this.jobRewards = new HashMap<>();
-        
-        initializeLevelRewards();
     }
-    
-    private void initializeLevelRewards() {
-        // 鉱夫の報酬設定
-        Map<Integer, LevelReward> minerRewards = new HashMap<>();
-        minerRewards.put(5, new LevelReward(100.0, 
-            Arrays.asList(
-                createRewardItem(Material.IRON_INGOT, "鉄インゴット", 16),
-                createRewardItem(Material.COAL, "石炭", 32)
-            ),
-            "鉱石探知能力開放"));
-        minerRewards.put(10, new LevelReward(50.0,
-            Arrays.asList(createRewardItem(Material.IRON_ORE, "鉄鉱石", 16)),
-            "採掘技術向上"));
-        minerRewards.put(15, new LevelReward(250.0,
-            Arrays.asList(
-                createRewardItem(Material.DIAMOND, "ダイヤモンド", 5),
-                createRewardItem(Material.GOLD_INGOT, "金インゴット", 16)
-            ),
-            "採掘効率大幅向上"));
-        minerRewards.put(30, new LevelReward(600.0,
-            Arrays.asList(
-                createRewardItem(Material.NETHERITE_INGOT, "ネザライトインゴット", 2),
-                createRewardItem(Material.DIAMOND, "ダイヤモンド", 10),
-                createRewardItem(Material.BEACON, "鉱夫の栄光", 1)
-            ),
-            "伝説的採掘能力獲得"));
-        jobRewards.put("miner", minerRewards);
-        
-        // 木こりの報酬設定
-        Map<Integer, LevelReward> woodcutterRewards = new HashMap<>();
-        woodcutterRewards.put(5, new LevelReward(100.0,
-            Arrays.asList(
-                createRewardItem(Material.OAK_LOG, "オークの原木", 32),
-                createRewardItem(Material.STICK, "棒", 64)
-            ),
-            "一括伐採能力開放"));
-        woodcutterRewards.put(15, new LevelReward(250.0,
-            Arrays.asList(
-                createRewardItem(Material.OAK_LOG, "オークの原木", 64),
-                createRewardItem(Material.OAK_SAPLING, "オークの苗木", 32)
-            ),
-            "伐採速度大幅向上"));
-        woodcutterRewards.put(30, new LevelReward(600.0,
-            Arrays.asList(
-                createRewardItem(Material.BAMBOO, "竹", 128),
-                createRewardItem(Material.OAK_LOG, "各種原木", 128),
-                createRewardItem(Material.TOTEM_OF_UNDYING, "森の守護者", 1)
-            ),
-            "自然回復能力獲得"));
-        jobRewards.put("woodcutter", woodcutterRewards);
-        
-        // 農家の報酬設定
-        Map<Integer, LevelReward> farmerRewards = new HashMap<>();
-        farmerRewards.put(5, new LevelReward(100.0,
-            Arrays.asList(
-                createRewardItem(Material.BONE_MEAL, "骨粉", 32),
-                createRewardItem(Material.WHEAT_SEEDS, "小麦の種", 16)
-            ),
-            "作物成長加速能力開放"));
-        farmerRewards.put(12, new LevelReward(50.0,
-            Arrays.asList(createRewardItem(Material.BONE_MEAL, "骨粉", 16)),
-            "収穫技術向上"));
-        farmerRewards.put(15, new LevelReward(250.0,
-            Arrays.asList(
-                createRewardItem(Material.BONE_MEAL, "特製肥料", 64),
-                createRewardItem(Material.WHEAT, "小麦", 32)
-            ),
-            "収穫量向上"));
-        farmerRewards.put(30, new LevelReward(600.0,
-            Arrays.asList(
-                createRewardItem(Material.ENCHANTED_GOLDEN_APPLE, "豊穣の果実", 5),
-                createRewardItem(Material.GOLDEN_CARROT, "金のニンジン", 16),
-                createRewardItem(Material.GOLDEN_HOE, "農家の証", 1)
-            ),
-            "動物繁殖効率大幅向上"));
-        jobRewards.put("farmer", farmerRewards);
-        
-        // 釣り人の報酬設定
-        Map<Integer, LevelReward> fishermanRewards = new HashMap<>();
-        fishermanRewards.put(5, new LevelReward(100.0,
-            Arrays.asList(
-                createRewardItem(Material.FISHING_ROD, "釣り竿", 3),
-                createRewardItem(Material.STRING, "糸", 32)
-            ),
-            "宝物発見能力開放"));
-        fishermanRewards.put(8, new LevelReward(50.0,
-            Arrays.asList(createRewardItem(Material.INK_SAC, "イカスミ", 16)),
-            "釣り運向上"));
-        fishermanRewards.put(15, new LevelReward(250.0,
-            Arrays.asList(
-                createRewardItem(Material.COD, "鱈", 32),
-                createRewardItem(Material.PRISMARINE, "プリズマリン", 16)
-            ),
-            "レア魚獲得確率向上"));
-        fishermanRewards.put(30, new LevelReward(600.0,
-            Arrays.asList(
-                createRewardItem(Material.TRIDENT, "海の守護者", 1),
-                createRewardItem(Material.HEART_OF_THE_SEA, "海の心", 1),
-                createRewardItem(Material.SEA_LANTERN, "海晶ブロック", 64)
-            ),
-            "伝説の釣り能力獲得"));
-        jobRewards.put("fisherman", fishermanRewards);
-        
-        // 鍛冶屋の報酬設定
-        Map<Integer, LevelReward> blacksmithRewards = new HashMap<>();
-        blacksmithRewards.put(5, new LevelReward(100.0,
-            Arrays.asList(
-                createRewardItem(Material.IRON_INGOT, "鉄インゴット", 32),
-                createRewardItem(Material.ANVIL, "金床", 1)
-            ),
-            "製作効率向上"));
-        blacksmithRewards.put(15, new LevelReward(250.0,
-            Arrays.asList(
-                createRewardItem(Material.DIAMOND, "ダイヤモンド", 5),
-                createRewardItem(Material.NETHERITE_SCRAP, "ネザライトの欠片", 4),
-                createRewardItem(Material.SMITHING_TABLE, "鍛冶台", 1)
-            ),
-            "高品質製作能力開放"));
-        blacksmithRewards.put(30, new LevelReward(600.0,
-            Arrays.asList(
-                createRewardItem(Material.NETHERITE_INGOT, "ネザライトインゴット", 3),
-                createRewardItem(Material.DIAMOND, "ダイヤモンド", 10),
-                createRewardItem(Material.ANVIL, "金床", 2)
-            ),
-            "伝説装備製作能力獲得"));
-        jobRewards.put("blacksmith", blacksmithRewards);
-        
-        // ポーション屋の報酬設定
-        Map<Integer, LevelReward> alchemistRewards = new HashMap<>();
-        alchemistRewards.put(5, new LevelReward(100.0,
-            Arrays.asList(
-                createRewardItem(Material.NETHER_WART, "ネザーウォート", 32),
-                createRewardItem(Material.GLASS_BOTTLE, "ガラス瓶", 64),
-                createRewardItem(Material.BREWING_STAND, "醸造台", 1)
-            ),
-            "ポーション効果延長"));
-        alchemistRewards.put(15, new LevelReward(250.0,
-            Arrays.asList(
-                createRewardItem(Material.GLOWSTONE_DUST, "グロウストーン", 32),
-                createRewardItem(Material.REDSTONE, "レッドストーン", 32),
-                createRewardItem(Material.FERMENTED_SPIDER_EYE, "発酵したクモの目", 16)
-            ),
-            "特殊ポーション製作開放"));
-        alchemistRewards.put(30, new LevelReward(600.0,
-            Arrays.asList(
-                createRewardItem(Material.DRAGON_BREATH, "ドラゴンの息", 16),
-                createRewardItem(Material.BLAZE_POWDER, "ブレイズパウダー", 32),
-                createRewardItem(Material.CAULDRON, "魔法の大釜", 1)
-            ),
-            "最上級ポーション製作能力"));
-        jobRewards.put("alchemist", alchemistRewards);
-        
-        // エンチャンターの報酬設定  
-        Map<Integer, LevelReward> enchanterRewards = new HashMap<>();
-        enchanterRewards.put(5, new LevelReward(100.0,
-            Arrays.asList(
-                createRewardItem(Material.LAPIS_LAZULI, "ラピスラズリ", 64),
-                createRewardItem(Material.BOOK, "本", 16),
-                createRewardItem(Material.ENCHANTING_TABLE, "エンチャントテーブル", 1)
-            ),
-            "エンチャント成功確率向上"));
-        enchanterRewards.put(15, new LevelReward(250.0,
-            Arrays.asList(
-                createRewardItem(Material.BOOKSHELF, "魔法書棚", 15),
-                createRewardItem(Material.OBSIDIAN, "黒曜石", 8),
-                createRewardItem(Material.BOOK, "本", 32)
-            ),
-            "高レベルエンチャント開放"));
-        enchanterRewards.put(30, new LevelReward(600.0,
-            Arrays.asList(
-                createRewardItem(Material.NETHER_STAR, "魔導師の星", 1),
-                createRewardItem(Material.LAPIS_BLOCK, "ラピスラズリブロック", 16),
-                createRewardItem(Material.BOOK, "本", 64)
-            ),
-            "最高レベルエンチャント能力"));
-        jobRewards.put("enchanter", enchanterRewards);
-        
-        // 建築家の報酬設定
-        Map<Integer, LevelReward> architectRewards = new HashMap<>();
-        architectRewards.put(5, new LevelReward(100.0,
-            Arrays.asList(
-                createRewardItem(Material.STONE, "石", 64),
-                createRewardItem(Material.GLASS, "ガラス", 64)
-            ),
-            "建築効率向上"));
-        architectRewards.put(15, new LevelReward(250.0,
-            Arrays.asList(
-                createRewardItem(Material.QUARTZ_BLOCK, "クォーツブロック", 32),
-                createRewardItem(Material.WHITE_STAINED_GLASS, "色付きガラス", 16)
-            ),
-            "材料節約能力開放"));
-        architectRewards.put(30, new LevelReward(600.0,
-            Arrays.asList(
-                createRewardItem(Material.END_STONE, "エンドストーン", 16),
-                createRewardItem(Material.SHULKER_BOX, "シュルカーボックス", 4),
-                createRewardItem(Material.BEACON, "建築の証", 1)
-            ),
-            "高速建築能力獲得"));
-        jobRewards.put("architect", architectRewards);
-    }
-    
-    private ItemStack createRewardItem(Material material, String name, int amount) {
-        ItemStack item = new ItemStack(material, amount);
-        ItemMeta meta = item.getItemMeta();
-        if (meta != null) {
-            meta.setDisplayName(ChatColor.GOLD + name);
-            meta.setLore(Arrays.asList(
-                ChatColor.GRAY + "職業レベルアップ報酬",
-                ChatColor.YELLOW + "TofuNomics特別アイテム"
-            ));
-            item.setItemMeta(meta);
-        }
-        return item;
-    }
-    
+
     /**
-     * レベルアップ報酬をプレイヤーに付与
+     * 指定職業・レベルのお金報酬額を返す。
+     * 報酬対象でないレベル（5の倍数でない、0以下、上限超過）は0を返す。
      */
-    public boolean giveJobLevelReward(org.bukkit.entity.Player player, String jobName, int level) {
-        Map<Integer, LevelReward> jobRewardMap = jobRewards.get(jobName.toLowerCase());
-        if (jobRewardMap == null) {
+    public double getRewardAmount(String jobName, int level) {
+        if (level <= 0 || level > MAX_REWARD_LEVEL || level % REWARD_INTERVAL != 0) {
+            return 0.0;
+        }
+        double base = JOB_BASE_REWARD.getOrDefault(
+            jobName == null ? "" : jobName.toLowerCase(), DEFAULT_BASE_REWARD);
+        return base * (level / REWARD_INTERVAL);
+    }
+
+    /**
+     * レベルアップ報酬（お金）をプレイヤーに付与する。
+     * 報酬対象レベルでなければ何もしない。
+     *
+     * @return 報酬を付与した場合true
+     */
+    public boolean giveJobLevelReward(Player player, String jobName, int level) {
+        double amount = getRewardAmount(jobName, level);
+        if (amount <= 0) {
             return false;
         }
-        
-        LevelReward reward = jobRewardMap.get(level);
-        if (reward == null) {
-            return false;
-        }
-        
-        // 金銭報酬
-        if (reward.moneyReward > 0) {
-            giveMoney(player, reward.moneyReward);
-        }
-        
-        // アイテム報酬
-        if (reward.itemRewards != null) {
-            giveItems(player, reward.itemRewards);
-        }
-        
-        // レベルアップメッセージ
-        sendLevelUpRewardMessage(player, jobName, level, reward);
-        
+
+        giveMoney(player, amount);
+        sendLevelUpRewardMessage(player, jobName, level, amount);
         return true;
     }
-    
-    private void giveMoney(org.bukkit.entity.Player player, double amount) {
+
+    private void giveMoney(Player player, double amount) {
         String uuid = player.getUniqueId().toString();
         org.tofu.tofunomics.models.Player tofuPlayer = playerDAO.getPlayerByUUID(uuid);
-        
+
         if (tofuPlayer == null) {
             tofuPlayer = new org.tofu.tofunomics.models.Player();
             tofuPlayer.setUuid(uuid);
             tofuPlayer.setBalance(configManager.getStartingBalance());
             playerDAO.insertPlayer(tofuPlayer);
         }
-        
+
         tofuPlayer.addBalance(amount);
         playerDAO.updatePlayerData(tofuPlayer);
     }
-    
-    private void giveItems(org.bukkit.entity.Player player, List<ItemStack> items) {
-        for (ItemStack item : items) {
-            if (player.getInventory().firstEmpty() == -1) {
-                player.getWorld().dropItemNaturally(player.getLocation(), item);
-                player.sendMessage(ChatColor.YELLOW + "インベントリが満杯のため、" + 
-                    item.getItemMeta().getDisplayName() + " を足元に落としました。");
-            } else {
-                player.getInventory().addItem(item);
-            }
-        }
-    }
-    
-    private void sendLevelUpRewardMessage(org.bukkit.entity.Player player, String jobName, int level, LevelReward reward) {
+
+    private void sendLevelUpRewardMessage(Player player, String jobName, int level, double amount) {
         player.sendMessage(ChatColor.LIGHT_PURPLE + "▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬");
-        player.sendMessage(ChatColor.GOLD + "★ " + configManager.getJobDisplayName(jobName) + 
+        player.sendMessage(ChatColor.GOLD + "★ " + configManager.getJobDisplayName(jobName) +
                           " レベル " + level + " 達成報酬 ★");
-        
-        if (reward.moneyReward > 0) {
-            player.sendMessage(ChatColor.GREEN + "金銭報酬: " + reward.moneyReward + " " + 
-                              configManager.getCurrencySymbol());
-        }
-        
-        if (reward.itemRewards != null && !reward.itemRewards.isEmpty()) {
-            player.sendMessage(ChatColor.AQUA + "アイテム報酬: " + reward.itemRewards.size() + "種類");
-        }
-        
-        if (reward.specialAbility != null && !reward.specialAbility.isEmpty()) {
-            player.sendMessage(ChatColor.LIGHT_PURPLE + "特殊能力: " + reward.specialAbility);
-        }
-        
+        player.sendMessage(ChatColor.GREEN + "報酬: " + formatAmount(amount) + " " +
+                          configManager.getCurrencySymbol());
         player.sendMessage(ChatColor.LIGHT_PURPLE + "▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬");
     }
-    
+
+    private String formatAmount(double amount) {
+        // 通貨は整数（金塊）単位。小数を切り捨てて表示する。
+        return String.valueOf((long) amount);
+    }
+
     /**
-     * 指定された職業の次の報酬レベルを取得
+     * 指定された職業の、現在レベルより先にある次の報酬レベルを返す。
+     * なければ-1。
      */
     public int getNextRewardLevel(String jobName, int currentLevel) {
-        Map<Integer, LevelReward> jobRewardMap = jobRewards.get(jobName.toLowerCase());
-        if (jobRewardMap == null) {
-            return -1;
-        }
-        
-        for (int level : jobRewardMap.keySet()) {
-            if (level > currentLevel) {
-                return level;
-            }
-        }
-        
-        return -1; // 次の報酬レベルなし
+        int next = ((currentLevel / REWARD_INTERVAL) + 1) * REWARD_INTERVAL;
+        return next <= MAX_REWARD_LEVEL ? next : -1;
     }
-    
+
     /**
-     * 指定された職業の全報酬レベル一覧を取得
+     * 全報酬レベルの一覧（Lv5, 10, …, 100）を返す。
      */
     public List<Integer> getAllRewardLevels(String jobName) {
-        Map<Integer, LevelReward> jobRewardMap = jobRewards.get(jobName.toLowerCase());
-        if (jobRewardMap == null) {
-            return Arrays.asList();
+        List<Integer> levels = new ArrayList<>();
+        for (int level = REWARD_INTERVAL; level <= MAX_REWARD_LEVEL; level += REWARD_INTERVAL) {
+            levels.add(level);
         }
-        
-        return Arrays.asList(jobRewardMap.keySet().toArray(new Integer[0]));
+        return levels;
     }
-    
+
     /**
-     * 指定レベルに報酬があるかチェック
+     * 指定レベルに報酬があるか（5の倍数かつ上限以内か）。
      */
     public boolean hasRewardAtLevel(String jobName, int level) {
-        Map<Integer, LevelReward> jobRewardMap = jobRewards.get(jobName.toLowerCase());
-        return jobRewardMap != null && jobRewardMap.containsKey(level);
-    }
-    
-    /**
-     * レベル報酬データクラス
-     */
-    private static class LevelReward {
-        final double moneyReward;
-        final List<ItemStack> itemRewards;
-        final String specialAbility;
-        
-        LevelReward(double moneyReward, List<ItemStack> itemRewards, String specialAbility) {
-            this.moneyReward = moneyReward;
-            this.itemRewards = itemRewards;
-            this.specialAbility = specialAbility;
-        }
+        return getRewardAmount(jobName, level) > 0;
     }
 }


### PR DESCRIPTION
## 概要
職業レベルアップ時に配られていた**エンチャント付き高性能ツール**(鉱夫Lv10=効率鉄ツルハシ、Lv25=ネザライト等)を廃止し、代わりに**控えめなお金報酬**を付与するように変更します。無償の高性能ツールが経済バランスを崩していた問題(「やりすぎ」)を解消します。

## 背景
- レベルアップ時に実際に配られていたのは `JobToolManager` のツール。これが過剰だった。
- 一方 `JobLevelRewardManager`(お金＋アイテム報酬)は実装済みだが**どこからも呼ばれていないデッドコード**だった。
- 今回これを「お金のみ」に作り直し、レベルアップ処理へ正式に統合した。

## 変更内容
- **ツール付与を廃止**: `JobExperienceManager.checkLevelUp` の `checkAndGiveNewTools` 呼び出しをお金報酬に置換。
- **5レベルおき(Lv5,10,…,100)にお金を付与**。`while`ループで1レベルずつ処理されるため複数レベル同時アップも各レベルで判定。
- **金額は職業別**: `reward = 職業別基礎額 × (level / 5)`。人気職は優遇せず、手間のかかる専門職を厚めに。

| 職業 | 基礎額 | Lv5 | Lv30 | Lv100 |
|---|---|---|---|---|
| enchanter / alchemist | 50 | 50 | 300 | 1000 |
| architect / blacksmith | 45 | 45 | 270 | 900 |
| miner / farmer / woodcutter | 40 | 40 | 240 | 800 |
| fisherman | 35 | 35 | 210 | 700 |

- アイテム報酬を全廃し `JobLevelRewardManager` を全面改修(基礎額は1つのMapに集約し調整容易)。
- `JobLevelRewardManager` を `setJobLevelRewardManager` でsetter注入し有効化。
- **就職時の基本ツール(Lv1)は別経路**(`JobManager.joinJob` → `giveJobToolsToPlayer`)のため影響なし。

## 動作確認
- `mvn clean package`(テスト含む)成功。
- 表示系(`JobStatsManager` の「次の報酬レベル」「取得済み報酬」)は新ロジックと互換。

## デプロイ後の確認項目
- [ ] 就職時に基本ツールが配られる(Lv1経路維持)
- [ ] 各職業Lv5で規定額のお金が入る
- [ ] レベルアップ時にツールが配られない

🤖 Generated with [Claude Code](https://claude.com/claude-code)