### PR TITLE
fix: マーケット経験値の農家対象にパン等の農産加工品を追加

### DIFF
--- a/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
+++ b/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
@@ -354,6 +354,20 @@ public class JobExperienceManager implements Listener {
         marketSellExperience.put(Material.SUGAR_CANE, new MarketSellEntry("farmer", 1.0));
         marketSellExperience.put(Material.COCOA_BEANS, new MarketSellEntry("farmer", 2.5));
         marketSellExperience.put(Material.NETHER_WART, new MarketSellEntry("farmer", 3.0));
+        // 農産加工品（パン類）— 農家
+        marketSellExperience.put(Material.BREAD, new MarketSellEntry("farmer", 4.0));
+        marketSellExperience.put(Material.BAKED_POTATO, new MarketSellEntry("farmer", 1.5));
+        marketSellExperience.put(Material.COOKIE, new MarketSellEntry("farmer", 0.8));
+        marketSellExperience.put(Material.PUMPKIN_PIE, new MarketSellEntry("farmer", 4.0));
+        marketSellExperience.put(Material.CAKE, new MarketSellEntry("farmer", 8.0));
+        marketSellExperience.put(Material.HAY_BLOCK, new MarketSellEntry("farmer", 12.0));
+        marketSellExperience.put(Material.SUGAR, new MarketSellEntry("farmer", 0.5));
+        // 収穫素材の補完 — 農家
+        marketSellExperience.put(Material.MELON, new MarketSellEntry("farmer", 2.5));
+        marketSellExperience.put(Material.SWEET_BERRIES, new MarketSellEntry("farmer", 1.0));
+        marketSellExperience.put(Material.GLOW_BERRIES, new MarketSellEntry("farmer", 1.0));
+        marketSellExperience.put(Material.RED_MUSHROOM, new MarketSellEntry("farmer", 1.5));
+        marketSellExperience.put(Material.BROWN_MUSHROOM, new MarketSellEntry("farmer", 1.5));
 
         // 鍛冶屋（blacksmith）— 精錬・製作品
         marketSellExperience.put(Material.IRON_INGOT, new MarketSellEntry("blacksmith", 3.0));

--- a/src/test/java/org/tofu/tofunomics/experience/JobExperienceManagerMarketSellTest.java
+++ b/src/test/java/org/tofu/tofunomics/experience/JobExperienceManagerMarketSellTest.java
@@ -58,6 +58,12 @@ public class JobExperienceManagerMarketSellTest {
         // 農家の収穫物
         assertEquals("farmer", manager.getMarketSellJobName(Material.WHEAT));
         assertEquals("farmer", manager.getMarketSellJobName(Material.CARROT));
+        // 農産加工品も農家対象
+        assertEquals("farmer", manager.getMarketSellJobName(Material.BREAD));
+        assertEquals("farmer", manager.getMarketSellJobName(Material.BAKED_POTATO));
+        assertEquals("farmer", manager.getMarketSellJobName(Material.CAKE));
+        assertEquals("farmer", manager.getMarketSellJobName(Material.HAY_BLOCK));
+        assertEquals("farmer", manager.getMarketSellJobName(Material.PUMPKIN_PIE));
         // 鍛冶屋の製作品
         assertEquals("blacksmith", manager.getMarketSellJobName(Material.IRON_INGOT));
         assertEquals("blacksmith", manager.getMarketSellJobName(Material.DIAMOND_PICKAXE));


### PR DESCRIPTION
## 背景・原因

PR #76 でマーケット取引成立時の職業経験値付与を導入したが、農家がマーケットに**パン（BREAD）を売り出品**して別プレイヤーが購入しても農家経験値が入らない不具合があった。

原因は `JobExperienceManager.initializeMarketSellExperience()` の farmer マッピングが**収穫素材のみ**（WHEAT/POTATO/CARROT 等）で、パンのような**農産加工品が未登録**だったこと。マッピングに無いMaterialは対象外（null）として何も付与されないため。

## 変更内容

farmer マッピングに追加:

**農産加工品（パン類）**: BREAD(4.0) / BAKED_POTATO(1.5) / COOKIE(0.8) / PUMPKIN_PIE(4.0) / CAKE(8.0) / HAY_BLOCK(12.0) / SUGAR(0.5)

**収穫素材の漏れ補完**: MELON / SWEET_BERRIES / GLOW_BERRIES / RED_MUSHROOM / BROWN_MUSHROOM

**対象外（理由）**: GOLDEN_CARROT（金塊依存で鉱夫資源寄り）、DRIED_KELP/昆布系（漁師寄り）

## テスト

- `getMarketSellJobName` で農産加工品が farmer に対応することを検証するアサーションを追加
- 全329テストパス・ビルド成功

## 動作確認（デプロイ後）

- 農家アカAでパンを `/market sell` 出品 → 別アカBが購入 → アカAに農家経験値が入る
- 切り分けとして既存対象の小麦(WHEAT)でも入ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)