### PR TITLE
feat: 賃貸物件の登録作業を効率化(クイック登録・登録GUI・WG確認)

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -58,6 +58,7 @@ public final class TofuNomics extends JavaPlugin {
     private org.tofu.tofunomics.housing.SelectionManager selectionManager;
     private org.tofu.tofunomics.housing.HousingListener housingListener;
     private org.tofu.tofunomics.housing.gui.HousingHubGUI housingHubGUI;
+    private org.tofu.tofunomics.housing.gui.HousingAdminRegisterGUI housingAdminRegisterGUI;
     private org.tofu.tofunomics.housing.gui.HousingGUIListener housingGUIListener;
     private org.tofu.tofunomics.integration.WorldGuardIntegration worldGuardIntegration;
     private org.tofu.tofunomics.protection.HostileMobRemovalManager hostileMobRemovalManager; // 敵対的モブ自動除去マネージャー
@@ -868,7 +869,8 @@ public final class TofuNomics extends JavaPlugin {
                         selectionManager,
                         testModeManager,
                         configManager,
-                        housingHubGUI
+                        housingHubGUI,
+                        housingAdminRegisterGUI
                     );
                 getCommand("housing").setExecutor(housingCommand);
                 getCommand("housing").setTabCompleter(housingCommand);
@@ -1431,6 +1433,8 @@ public final class TofuNomics extends JavaPlugin {
                 new org.tofu.tofunomics.housing.gui.MyRentalsGUI(this, configManager, housingRentalManager, housingGUIListener);
             org.tofu.tofunomics.housing.gui.RentalManageGUI manage =
                 new org.tofu.tofunomics.housing.gui.RentalManageGUI(this, configManager, housingRentalManager, chatInputManager, housingGUIListener);
+            org.tofu.tofunomics.housing.gui.HousingAdminRegisterGUI adminRegister =
+                new org.tofu.tofunomics.housing.gui.HousingAdminRegisterGUI(this, configManager, housingRentalManager, selectionManager, chatInputManager, housingGUIListener);
 
             // 相互参照を注入（循環依存の解決）
             hub.setGUIs(browse, myRentals);
@@ -1438,10 +1442,11 @@ public final class TofuNomics extends JavaPlugin {
             detail.setGUIs(hub, browse);
             myRentals.setGUIs(hub, manage);
             manage.setGUIs(hub, myRentals);
-            housingGUIListener.setGUIs(hub, browse, detail, myRentals, manage);
+            housingGUIListener.setGUIs(hub, browse, detail, myRentals, manage, adminRegister);
 
             getServer().getPluginManager().registerEvents(housingGUIListener, this);
             housingHubGUI = hub;
+            housingAdminRegisterGUI = adminRegister;
             getLogger().info("住居賃貸GUIを初期化しました");
         } catch (Exception e) {
             getLogger().severe("住居賃貸GUI初期化中にエラーが発生しました: " + e.getMessage());

--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -59,6 +59,7 @@ public final class TofuNomics extends JavaPlugin {
     private org.tofu.tofunomics.housing.HousingListener housingListener;
     private org.tofu.tofunomics.housing.gui.HousingHubGUI housingHubGUI;
     private org.tofu.tofunomics.housing.gui.HousingAdminRegisterGUI housingAdminRegisterGUI;
+    private org.tofu.tofunomics.housing.gui.HousingAdminListGUI housingAdminListGUI;
     private org.tofu.tofunomics.housing.gui.HousingGUIListener housingGUIListener;
     private org.tofu.tofunomics.integration.WorldGuardIntegration worldGuardIntegration;
     private org.tofu.tofunomics.protection.HostileMobRemovalManager hostileMobRemovalManager; // 敵対的モブ自動除去マネージャー
@@ -870,7 +871,8 @@ public final class TofuNomics extends JavaPlugin {
                         testModeManager,
                         configManager,
                         housingHubGUI,
-                        housingAdminRegisterGUI
+                        housingAdminRegisterGUI,
+                        housingAdminListGUI
                     );
                 getCommand("housing").setExecutor(housingCommand);
                 getCommand("housing").setTabCompleter(housingCommand);
@@ -1435,6 +1437,10 @@ public final class TofuNomics extends JavaPlugin {
                 new org.tofu.tofunomics.housing.gui.RentalManageGUI(this, configManager, housingRentalManager, chatInputManager, housingGUIListener);
             org.tofu.tofunomics.housing.gui.HousingAdminRegisterGUI adminRegister =
                 new org.tofu.tofunomics.housing.gui.HousingAdminRegisterGUI(this, configManager, housingRentalManager, selectionManager, chatInputManager, housingGUIListener);
+            org.tofu.tofunomics.housing.gui.HousingAdminListGUI adminList =
+                new org.tofu.tofunomics.housing.gui.HousingAdminListGUI(this, configManager, housingRentalManager, housingGUIListener);
+            org.tofu.tofunomics.housing.gui.HousingAdminEditGUI adminEdit =
+                new org.tofu.tofunomics.housing.gui.HousingAdminEditGUI(this, configManager, housingRentalManager, chatInputManager, housingGUIListener);
 
             // 相互参照を注入（循環依存の解決）
             hub.setGUIs(browse, myRentals);
@@ -1442,11 +1448,14 @@ public final class TofuNomics extends JavaPlugin {
             detail.setGUIs(hub, browse);
             myRentals.setGUIs(hub, manage);
             manage.setGUIs(hub, myRentals);
-            housingGUIListener.setGUIs(hub, browse, detail, myRentals, manage, adminRegister);
+            adminList.setGUIs(adminEdit);
+            adminEdit.setGUIs(adminList);
+            housingGUIListener.setGUIs(hub, browse, detail, myRentals, manage, adminRegister, adminList, adminEdit);
 
             getServer().getPluginManager().registerEvents(housingGUIListener, this);
             housingHubGUI = hub;
             housingAdminRegisterGUI = adminRegister;
+            housingAdminListGUI = adminList;
             getLogger().info("住居賃貸GUIを初期化しました");
         } catch (Exception e) {
             getLogger().severe("住居賃貸GUI初期化中にエラーが発生しました: " + e.getMessage());

--- a/src/main/java/org/tofu/tofunomics/commands/HousingCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/HousingCommand.java
@@ -10,6 +10,7 @@ import org.tofu.tofunomics.housing.HousingRentalManager;
 import org.tofu.tofunomics.housing.SelectionManager;
 import org.tofu.tofunomics.housing.gui.HousingHubGUI;
 import org.tofu.tofunomics.housing.gui.HousingAdminRegisterGUI;
+import org.tofu.tofunomics.housing.gui.HousingAdminListGUI;
 import org.tofu.tofunomics.models.HousingProperty;
 import org.tofu.tofunomics.models.HousingRental;
 import org.tofu.tofunomics.testing.TestModeManager;
@@ -29,8 +30,9 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
     private final org.tofu.tofunomics.config.ConfigManager configManager;
     private final HousingHubGUI housingHubGUI;
     private final HousingAdminRegisterGUI housingAdminRegisterGUI;
+    private final HousingAdminListGUI housingAdminListGUI;
 
-    public HousingCommand(TofuNomics plugin, HousingRentalManager rentalManager, SelectionManager selectionManager, TestModeManager testModeManager, org.tofu.tofunomics.config.ConfigManager configManager, HousingHubGUI housingHubGUI, HousingAdminRegisterGUI housingAdminRegisterGUI) {
+    public HousingCommand(TofuNomics plugin, HousingRentalManager rentalManager, SelectionManager selectionManager, TestModeManager testModeManager, org.tofu.tofunomics.config.ConfigManager configManager, HousingHubGUI housingHubGUI, HousingAdminRegisterGUI housingAdminRegisterGUI, HousingAdminListGUI housingAdminListGUI) {
         this.plugin = plugin;
         this.rentalManager = rentalManager;
         this.selectionManager = selectionManager;
@@ -38,6 +40,7 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
         this.configManager = configManager;
         this.housingHubGUI = housingHubGUI;
         this.housingAdminRegisterGUI = housingAdminRegisterGUI;
+        this.housingAdminListGUI = housingAdminListGUI;
     }
 
     @Override
@@ -338,6 +341,8 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
             case "registergui":
             case "gui":
                 return handleAdminRegisterGui(sender);
+            case "manage":
+                return handleAdminManage(sender);
             case "checkregion":
                 return handleAdminCheckRegion(sender, args);
             case "list":
@@ -573,6 +578,26 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
         }
 
         housingAdminRegisterGUI.open(player);
+        return true;
+    }
+
+    /**
+     * 管理者: 物件管理GUIを開く（一覧→編集）
+     */
+    private boolean handleAdminManage(CommandSender sender) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("§cこのコマンドはプレイヤーのみ実行できます");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (housingAdminListGUI == null) {
+            player.sendMessage("§c物件管理GUIが利用できません");
+            return true;
+        }
+
+        housingAdminListGUI.open(player);
         return true;
     }
 
@@ -967,6 +992,7 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
         sender.sendMessage("§e/housing admin register <名前> <日額> [--wg <領域名>] §7- 物件登録");
         sender.sendMessage("§e/housing admin quickregister [--name <名>] [--rent <日額>] §7- クイック登録(連番自動命名)");
         sender.sendMessage("§e/housing admin gui §7- 物件登録GUIを開く");
+        sender.sendMessage("§e/housing admin manage §7- 物件管理GUI(一覧→編集)を開く");
         sender.sendMessage("§e/housing admin checkregion [領域名] §7- WGリージョンの確認");
         sender.sendMessage("§e/housing admin list §7- 全物件一覧");
         sender.sendMessage("§e/housing admin setrent <ID> <日額> §7- 賃料変更");
@@ -994,7 +1020,7 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
                 completions.add("admin");
             }
         } else if (args.length == 2 && args[0].equalsIgnoreCase("admin")) {
-            completions.addAll(Arrays.asList("wand", "register", "quickregister", "gui", "checkregion", "list", "setrent", "remove"));
+            completions.addAll(Arrays.asList("wand", "register", "quickregister", "gui", "manage", "checkregion", "list", "setrent", "remove"));
         }
 
         return completions;

--- a/src/main/java/org/tofu/tofunomics/commands/HousingCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/HousingCommand.java
@@ -9,6 +9,7 @@ import org.tofu.tofunomics.TofuNomics;
 import org.tofu.tofunomics.housing.HousingRentalManager;
 import org.tofu.tofunomics.housing.SelectionManager;
 import org.tofu.tofunomics.housing.gui.HousingHubGUI;
+import org.tofu.tofunomics.housing.gui.HousingAdminRegisterGUI;
 import org.tofu.tofunomics.models.HousingProperty;
 import org.tofu.tofunomics.models.HousingRental;
 import org.tofu.tofunomics.testing.TestModeManager;
@@ -27,14 +28,16 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
     private final TestModeManager testModeManager;
     private final org.tofu.tofunomics.config.ConfigManager configManager;
     private final HousingHubGUI housingHubGUI;
+    private final HousingAdminRegisterGUI housingAdminRegisterGUI;
 
-    public HousingCommand(TofuNomics plugin, HousingRentalManager rentalManager, SelectionManager selectionManager, TestModeManager testModeManager, org.tofu.tofunomics.config.ConfigManager configManager, HousingHubGUI housingHubGUI) {
+    public HousingCommand(TofuNomics plugin, HousingRentalManager rentalManager, SelectionManager selectionManager, TestModeManager testModeManager, org.tofu.tofunomics.config.ConfigManager configManager, HousingHubGUI housingHubGUI, HousingAdminRegisterGUI housingAdminRegisterGUI) {
         this.plugin = plugin;
         this.rentalManager = rentalManager;
         this.selectionManager = selectionManager;
         this.testModeManager = testModeManager;
         this.configManager = configManager;
         this.housingHubGUI = housingHubGUI;
+        this.housingAdminRegisterGUI = housingAdminRegisterGUI;
     }
 
     @Override
@@ -327,6 +330,14 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
         switch (adminSubCommand) {
             case "register":
                 return handleAdminRegister(sender, args);
+            case "quickregister":
+            case "qr":
+                return handleAdminQuickRegister(sender, args);
+            case "registergui":
+            case "gui":
+                return handleAdminRegisterGui(sender);
+            case "checkregion":
+                return handleAdminCheckRegion(sender, args);
             case "list":
                 return handleAdminList(sender);
             case "setrent":
@@ -428,6 +439,151 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
 
         } catch (NumberFormatException e) {
             player.sendMessage("§c賃料は数値で指定してください");
+        }
+
+        return true;
+    }
+
+    /**
+     * 管理者: 物件のクイック登録（連番自動命名）
+     * 範囲選択さえ済んでいれば、物件名・家賃は省略可能。WG領域も自動作成する。
+     * 使用法: /housing admin quickregister [--name <名>] [--rent <日額>]
+     */
+    private boolean handleAdminQuickRegister(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("§cこのコマンドはプレイヤーのみ実行できます");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (!selectionManager.hasCompleteSelection(player)) {
+            player.sendMessage("§c範囲選択が完了していません");
+            player.sendMessage("§7木の斧で2点を選択してから実行してください");
+            return true;
+        }
+
+        // オプション解析（--name / --rent）
+        String propertyName = null;
+        Double dailyRent = null;
+        try {
+            for (int i = 1; i < args.length - 1; i++) {
+                if (args[i].equalsIgnoreCase("--name")) {
+                    propertyName = args[i + 1];
+                } else if (args[i].equalsIgnoreCase("--rent")) {
+                    dailyRent = Double.parseDouble(args[i + 1]);
+                }
+            }
+        } catch (NumberFormatException e) {
+            player.sendMessage("§c賃料は数値で指定してください");
+            return true;
+        }
+
+        // 省略時はデフォルト値
+        if (propertyName == null) {
+            propertyName = rentalManager.generateNextPropertyName();
+        }
+        if (dailyRent == null) {
+            dailyRent = configManager.getHousingDefaultDailyRent();
+        }
+
+        org.bukkit.Location pos1 = selectionManager.getFirstPosition(player.getUniqueId());
+        org.bukkit.Location pos2 = selectionManager.getSecondPosition(player.getUniqueId());
+
+        boolean createWg = configManager.isHousingAutoCreateWgRegion();
+
+        HousingRentalManager.RentalResult result = rentalManager.registerPropertyFromSelection(
+            propertyName, player.getWorld(), pos1, pos2, dailyRent, createWg
+        );
+
+        if (result.isSuccess()) {
+            player.sendMessage("§a物件 '" + propertyName + "' を登録しました（日額: " + dailyRent + "）");
+            player.sendMessage("§7" + result.getMessage());
+            selectionManager.clearSelection(player);
+        } else {
+            player.sendMessage("§c" + result.getMessage());
+        }
+
+        return true;
+    }
+
+    /**
+     * 管理者: 物件登録GUIを開く
+     */
+    private boolean handleAdminRegisterGui(CommandSender sender) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("§cこのコマンドはプレイヤーのみ実行できます");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (housingAdminRegisterGUI == null) {
+            player.sendMessage("§c登録GUIが利用できません");
+            return true;
+        }
+
+        if (!selectionManager.hasCompleteSelection(player)) {
+            player.sendMessage("§c範囲選択が完了していません");
+            player.sendMessage("§7木の斧で2点を選択してから実行してください");
+            return true;
+        }
+
+        housingAdminRegisterGUI.open(player);
+        return true;
+    }
+
+    /**
+     * 管理者: WorldGuardリージョンの確認
+     * 引数あり: 指定リージョン名が存在するか確認
+     * 引数なし: 選択範囲に重なる既存リージョン名を列挙
+     */
+    private boolean handleAdminCheckRegion(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("§cこのコマンドはプレイヤーのみ実行できます");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        org.tofu.tofunomics.integration.WorldGuardIntegration wgIntegration =
+            plugin.getWorldGuardIntegration();
+
+        if (wgIntegration == null || !wgIntegration.isEnabled()) {
+            player.sendMessage("§cWorldGuard統合が無効です");
+            return true;
+        }
+
+        // 引数ありなら名前指定の存在確認
+        if (args.length >= 2) {
+            String regionName = args[1];
+            boolean exists = wgIntegration.hasRegion(regionName, player.getWorld());
+            if (exists) {
+                player.sendMessage("§aリージョン '" + regionName + "' は存在します");
+            } else {
+                player.sendMessage("§eリージョン '" + regionName + "' は存在しません");
+            }
+            return true;
+        }
+
+        // 引数なしなら選択範囲に重なるリージョンを列挙
+        if (!selectionManager.hasCompleteSelection(player)) {
+            player.sendMessage("§c範囲選択が完了していません");
+            player.sendMessage("§7木の斧で2点を選択するか、/housing admin checkregion <領域名> で名前指定してください");
+            return true;
+        }
+
+        org.bukkit.Location pos1 = selectionManager.getFirstPosition(player.getUniqueId());
+        org.bukkit.Location pos2 = selectionManager.getSecondPosition(player.getUniqueId());
+        List<String> overlapping = wgIntegration.getOverlappingRegionNames(player.getWorld(), pos1, pos2);
+
+        if (overlapping.isEmpty()) {
+            player.sendMessage("§a選択範囲に重なる既存リージョンはありません");
+        } else {
+            player.sendMessage("§e選択範囲に重なる既存リージョン (" + overlapping.size() + "件):");
+            for (String name : overlapping) {
+                player.sendMessage("§7- §f" + name);
+            }
         }
 
         return true;
@@ -765,6 +921,9 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
     private void sendAdminUsage(CommandSender sender) {
         sender.sendMessage("§6===== 住居管理コマンド =====");
         sender.sendMessage("§e/housing admin register <名前> <日額> [--wg <領域名>] §7- 物件登録");
+        sender.sendMessage("§e/housing admin quickregister [--name <名>] [--rent <日額>] §7- クイック登録(連番自動命名)");
+        sender.sendMessage("§e/housing admin gui §7- 物件登録GUIを開く");
+        sender.sendMessage("§e/housing admin checkregion [領域名] §7- WGリージョンの確認");
         sender.sendMessage("§e/housing admin list §7- 全物件一覧");
         sender.sendMessage("§e/housing admin setrent <ID> <日額> §7- 賃料変更");
         sender.sendMessage("§e/housing admin remove <ID> §7- 物件削除");
@@ -791,7 +950,7 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
                 completions.add("admin");
             }
         } else if (args.length == 2 && args[0].equalsIgnoreCase("admin")) {
-            completions.addAll(Arrays.asList("register", "list", "setrent", "remove"));
+            completions.addAll(Arrays.asList("register", "quickregister", "gui", "checkregion", "list", "setrent", "remove"));
         }
 
         return completions;

--- a/src/main/java/org/tofu/tofunomics/commands/HousingCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/HousingCommand.java
@@ -330,6 +330,8 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
         switch (adminSubCommand) {
             case "register":
                 return handleAdminRegister(sender, args);
+            case "wand":
+                return handleAdminWand(sender);
             case "quickregister":
             case "qr":
                 return handleAdminQuickRegister(sender, args);
@@ -440,6 +442,47 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
         } catch (NumberFormatException e) {
             player.sendMessage("§c賃料は数値で指定してください");
         }
+
+        return true;
+    }
+
+    /**
+     * 管理者: 範囲選択ツール（木の斧）を配布する
+     */
+    private boolean handleAdminWand(CommandSender sender) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("§cこのコマンドはプレイヤーのみ実行できます");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        org.bukkit.Material tool = selectionManager.getSelectionTool();
+        org.bukkit.inventory.ItemStack wand = new org.bukkit.inventory.ItemStack(tool);
+        org.bukkit.inventory.meta.ItemMeta meta = wand.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName("§b§l賃貸選択ツール");
+            meta.setLore(Arrays.asList(
+                "§7左クリック: 第1座標を設定",
+                "§7右クリック: 第2座標を設定",
+                "§72点選択後 §f/housing admin qr §7または §f/housing admin gui"
+            ));
+            wand.setItemMeta(meta);
+        }
+
+        // インベントリに追加し、入りきらない分は足元にドロップ
+        java.util.Map<Integer, org.bukkit.inventory.ItemStack> leftover =
+            player.getInventory().addItem(wand);
+        if (!leftover.isEmpty()) {
+            for (org.bukkit.inventory.ItemStack item : leftover.values()) {
+                player.getWorld().dropItemNaturally(player.getLocation(), item);
+            }
+            player.sendMessage("§e範囲選択ツールを足元にドロップしました（インベントリが満杯）");
+        } else {
+            player.sendMessage("§a範囲選択ツール（"
+                + org.tofu.tofunomics.gui.GuiUtil.prettifyMaterial(tool.name()) + "）を配布しました");
+        }
+        player.sendMessage("§7左クリックで1点目、右クリックで2点目を選択してください");
 
         return true;
     }
@@ -920,6 +963,7 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
      */
     private void sendAdminUsage(CommandSender sender) {
         sender.sendMessage("§6===== 住居管理コマンド =====");
+        sender.sendMessage("§e/housing admin wand §7- 範囲選択ツール(木の斧)を配布");
         sender.sendMessage("§e/housing admin register <名前> <日額> [--wg <領域名>] §7- 物件登録");
         sender.sendMessage("§e/housing admin quickregister [--name <名>] [--rent <日額>] §7- クイック登録(連番自動命名)");
         sender.sendMessage("§e/housing admin gui §7- 物件登録GUIを開く");
@@ -950,7 +994,7 @@ public class HousingCommand implements CommandExecutor, TabCompleter {
                 completions.add("admin");
             }
         } else if (args.length == 2 && args[0].equalsIgnoreCase("admin")) {
-            completions.addAll(Arrays.asList("register", "quickregister", "gui", "checkregion", "list", "setrent", "remove"));
+            completions.addAll(Arrays.asList("wand", "register", "quickregister", "gui", "checkregion", "list", "setrent", "remove"));
         }
 
         return completions;

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -4542,6 +4542,27 @@ public class ConfigManager {
     }
     
     /**
+     * 物件一括登録: 家賃省略時の既定日額を取得
+     */
+    public double getHousingDefaultDailyRent() {
+        return config.getDouble("housing_rental.default_daily_rent", 100);
+    }
+
+    /**
+     * 物件一括登録: 登録時にWorldGuard領域も自動作成するか
+     */
+    public boolean isHousingAutoCreateWgRegion() {
+        return config.getBoolean("housing_rental.auto_create_wg_region", true);
+    }
+
+    /**
+     * 物件一括登録: 連番自動命名の接頭辞を取得
+     */
+    public String getHousingAutoNamingPrefix() {
+        return config.getString("housing_rental.auto_naming.prefix", "house-");
+    }
+
+    /**
      * デフォルトの親リージョン名を取得（city_protection.region_nameが優先）
      */
     public String getDefaultParentRegion() {

--- a/src/main/java/org/tofu/tofunomics/housing/HousingRentalManager.java
+++ b/src/main/java/org/tofu/tofunomics/housing/HousingRentalManager.java
@@ -78,6 +78,71 @@ public class HousingRentalManager {
     }
 
     /**
+     * 連番自動命名で次の物件名を生成する。
+     * config の接頭辞 + 最小の未使用番号（1始まり）を返す。
+     * 既存の物件名とWorldGuardリージョン名の両方で衝突を回避する
+     * （リージョン名が重複するとWG領域作成が失敗するため）。
+     *
+     * @return 衝突しない新しい物件名（例: house-1）
+     */
+    public String generateNextPropertyName() {
+        String prefix = configManager.getHousingAutoNamingPrefix();
+        java.util.Set<String> used = new java.util.HashSet<>();
+        for (HousingProperty property : getAllProperties()) {
+            if (property.getPropertyName() != null) {
+                used.add(property.getPropertyName());
+            }
+            if (property.getWorldguardRegionId() != null) {
+                used.add(property.getWorldguardRegionId());
+            }
+        }
+
+        int n = 1;
+        while (used.contains(prefix + n)) {
+            n++;
+        }
+        return prefix + n;
+    }
+
+    /**
+     * 選択範囲から物件を登録する（quickregister / 登録GUI共通の中核処理）。
+     * createWg が true の場合、物件名と同名のWorldGuard領域を自動作成し、親リージョン継承・フラグ設定も行う。
+     *
+     * @param propertyName 物件名
+     * @param world ワールド
+     * @param pos1 第1座標
+     * @param pos2 第2座標
+     * @param dailyRent 日額賃料
+     * @param createWg WorldGuard領域も自動作成するか
+     * @return 登録結果
+     */
+    public RentalResult registerPropertyFromSelection(String propertyName, World world,
+                                                      Location pos1, Location pos2,
+                                                      double dailyRent, boolean createWg) {
+        HousingProperty property = new HousingProperty(
+            propertyName,
+            world.getName(),
+            pos1.getBlockX(), pos1.getBlockY(), pos1.getBlockZ(),
+            pos2.getBlockX(), pos2.getBlockY(), pos2.getBlockZ(),
+            null,
+            dailyRent
+        );
+
+        // WorldGuard領域を物件名と同じIDで自動作成
+        if (createWg && worldGuardIntegration != null && worldGuardIntegration.isEnabled()) {
+            boolean regionCreated = createWorldGuardRegion(propertyName, world, pos1, pos2);
+            if (regionCreated) {
+                property.setWorldguardRegionId(propertyName);
+            } else {
+                // 領域作成に失敗しても座標範囲で登録は続行する（既存registerと同方針）
+                logger.warning("WorldGuard領域 '" + propertyName + "' の作成に失敗したため座標範囲のみで登録します");
+            }
+        }
+
+        return registerProperty(property);
+    }
+
+    /**
      * WorldGuard領域を作成
      * config.ymlで親リージョンが設定されている場合、自動的に子リージョンとして設定
      */

--- a/src/main/java/org/tofu/tofunomics/housing/HousingRentalManager.java
+++ b/src/main/java/org/tofu/tofunomics/housing/HousingRentalManager.java
@@ -699,6 +699,129 @@ public class HousingRentalManager {
     }
 
     /**
+     * 物件からWorldGuard領域の紐付けを解除する（運営用）。
+     *
+     * @param propertyId 物件ID
+     * @param alsoDeleteRegion true の場合、実際のWorldGuard領域も削除する
+     * @return 処理結果
+     */
+    public RentalResult unlinkWorldGuardRegion(int propertyId, boolean alsoDeleteRegion) {
+        try {
+            HousingProperty property = propertyDAO.getProperty(propertyId);
+            if (property == null) {
+                return new RentalResult(false, "物件が見つかりません");
+            }
+            if (!property.hasWorldGuardRegion()) {
+                return new RentalResult(false, "この物件にはWG領域が設定されていません");
+            }
+            if (!property.hasCoordinates()) {
+                return new RentalResult(false, "座標範囲がないためWG領域を解除できません（位置特定不可になります）");
+            }
+
+            String regionId = property.getWorldguardRegionId();
+
+            // 実領域も削除する場合
+            if (alsoDeleteRegion && worldGuardIntegration != null && worldGuardIntegration.isEnabled()) {
+                World world = Bukkit.getWorld(property.getWorldName());
+                if (world != null) {
+                    boolean removed = worldGuardIntegration.removeRegion(regionId, world);
+                    if (!removed) {
+                        logger.warning("WG領域 " + regionId + " の削除に失敗しました（紐付けは解除します）");
+                    }
+                }
+            }
+
+            // 物件側の紐付けを解除
+            property.setWorldguardRegionId(null);
+            propertyDAO.updateProperty(property);
+
+            logger.info("物件 " + propertyId + " のWG領域紐付けを解除しました (領域削除: " + alsoDeleteRegion + ")");
+            return new RentalResult(true, alsoDeleteRegion
+                ? "WG領域 '" + regionId + "' を削除し、紐付けを解除しました"
+                : "WG領域 '" + regionId + "' の紐付けを解除しました（領域は残存）");
+        } catch (SQLException e) {
+            logger.severe("WG領域の紐付け解除に失敗しました: " + e.getMessage());
+            return new RentalResult(false, "データベースエラーが発生しました");
+        }
+    }
+
+    /**
+     * 物件のWorldGuard領域IDを別の既存リージョンに再紐付けする（運営用）。
+     *
+     * @param propertyId 物件ID
+     * @param newRegionId 新しいWGリージョンID（実在する必要がある）
+     * @return 処理結果
+     */
+    public RentalResult relinkWorldGuardRegion(int propertyId, String newRegionId) {
+        try {
+            HousingProperty property = propertyDAO.getProperty(propertyId);
+            if (property == null) {
+                return new RentalResult(false, "物件が見つかりません");
+            }
+            if (worldGuardIntegration == null || !worldGuardIntegration.isEnabled()) {
+                return new RentalResult(false, "WorldGuard統合が無効です");
+            }
+
+            World world = Bukkit.getWorld(property.getWorldName());
+            if (world == null) {
+                return new RentalResult(false, "ワールド '" + property.getWorldName() + "' が見つかりません");
+            }
+
+            // 指定リージョンの存在チェック
+            if (!worldGuardIntegration.hasRegion(newRegionId, world)) {
+                return new RentalResult(false, "リージョン '" + newRegionId + "' が存在しません");
+            }
+
+            property.setWorldguardRegionId(newRegionId);
+            propertyDAO.updateProperty(property);
+
+            logger.info("物件 " + propertyId + " のWG領域を " + newRegionId + " に再紐付けしました");
+            return new RentalResult(true, "WG領域を '" + newRegionId + "' に再紐付けしました");
+        } catch (SQLException e) {
+            logger.severe("WG領域の再紐付けに失敗しました: " + e.getMessage());
+            return new RentalResult(false, "データベースエラーが発生しました");
+        }
+    }
+
+    /**
+     * 物件のWorldGuard領域に親リージョンを設定する（運営用）。
+     *
+     * @param propertyId 物件ID
+     * @param parentRegionId 親リージョンID
+     * @return 処理結果
+     */
+    public RentalResult setPropertyParentRegion(int propertyId, String parentRegionId) {
+        HousingProperty property = propertyDAO != null ? getProperty(propertyId) : null;
+        if (property == null) {
+            return new RentalResult(false, "物件が見つかりません");
+        }
+        if (!property.hasWorldGuardRegion()) {
+            return new RentalResult(false, "この物件にはWG領域が設定されていません");
+        }
+        if (worldGuardIntegration == null || !worldGuardIntegration.isEnabled()) {
+            return new RentalResult(false, "WorldGuard統合が無効です");
+        }
+
+        World world = Bukkit.getWorld(property.getWorldName());
+        if (world == null) {
+            return new RentalResult(false, "ワールド '" + property.getWorldName() + "' が見つかりません");
+        }
+
+        if (!worldGuardIntegration.hasRegion(parentRegionId, world)) {
+            return new RentalResult(false, "親リージョン '" + parentRegionId + "' が存在しません");
+        }
+
+        boolean ok = worldGuardIntegration.setParentRegion(
+            property.getWorldguardRegionId(), parentRegionId, world);
+        if (ok) {
+            logger.info("物件 " + propertyId + " のWG領域 " + property.getWorldguardRegionId()
+                + " を親リージョン " + parentRegionId + " の子に設定しました");
+            return new RentalResult(true, "親リージョンを '" + parentRegionId + "' に設定しました");
+        }
+        return new RentalResult(false, "親リージョンの設定に失敗しました（循環参照や保存失敗の可能性）");
+    }
+
+    /**
      * 賃貸処理結果
      */
     public static class RentalResult {

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingAdminEditGUI.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingAdminEditGUI.java
@@ -1,0 +1,330 @@
+package org.tofu.tofunomics.housing.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.gui.ChatInputManager;
+import org.tofu.tofunomics.gui.GuiUtil;
+import org.tofu.tofunomics.housing.HousingRentalManager;
+import org.tofu.tofunomics.models.HousingProperty;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 管理者向けの物件編集 GUI。
+ *
+ * 物件の賃料変更（チャット入力）・テレポート・WorldGuard情報表示・削除（確認画面あり）を提供する。
+ * チャット入力でGUIを開き直しても対象物件を保持するため、編集中の物件IDをプレイヤーごとに
+ * {@link #editing} で保持する（GUIセッションはクローズ時に破棄されるため）。
+ */
+public class HousingAdminEditGUI {
+
+    private static final int SIZE = 27;
+    private static final int SLOT_INFO = 4;
+    private static final int SLOT_RENT = 10;
+    private static final int SLOT_TELEPORT = 12;
+    private static final int SLOT_WG = 14;
+    private static final int SLOT_DELETE = 16;
+    private static final int SLOT_BACK = 18;
+    private static final int SLOT_CLOSE = 26;
+
+    // 削除確認画面
+    private static final int SLOT_CONFIRM_YES = 11;
+    private static final int SLOT_CONFIRM_NO = 15;
+
+    private static final int INPUT_TIMEOUT_SECONDS = 60;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final HousingRentalManager rentalManager;
+    private final ChatInputManager chatInput;
+    private final HousingGUIListener listener;
+
+    private HousingAdminListGUI listGUI;
+
+    /** 編集中の物件ID（プレイヤーごと、reopen時の保持用） */
+    private final Map<UUID, Integer> editing = new ConcurrentHashMap<>();
+
+    public HousingAdminEditGUI(TofuNomics plugin, ConfigManager configManager,
+                               HousingRentalManager rentalManager, ChatInputManager chatInput,
+                               HousingGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.rentalManager = rentalManager;
+        this.chatInput = chatInput;
+        this.listener = listener;
+    }
+
+    public void setGUIs(HousingAdminListGUI listGUI) {
+        this.listGUI = listGUI;
+    }
+
+    public void open(Player player, int propertyId) {
+        editing.put(player.getUniqueId(), propertyId);
+        render(player);
+    }
+
+    private void render(Player player) {
+        Integer propertyId = editing.get(player.getUniqueId());
+        if (propertyId == null) {
+            backToList(player);
+            return;
+        }
+        HousingProperty property = rentalManager.getProperty(propertyId);
+        if (property == null) {
+            player.sendMessage("§c物件が見つかりません（削除された可能性があります）");
+            editing.remove(player.getUniqueId());
+            backToList(player);
+            return;
+        }
+
+        try {
+            Inventory gui = Bukkit.createInventory(null, SIZE, "§6物件編集 - " + property.getPropertyName());
+            HousingGUISession session = new HousingGUISession(
+                    player.getUniqueId(), HousingGUISession.Type.ADMIN_EDIT, gui);
+            session.setSelectedPropertyId(propertyId);
+            renderItems(gui, property);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("物件編集GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage("§c処理中にエラーが発生しました。");
+        }
+    }
+
+    private void renderItems(Inventory gui, HousingProperty property) {
+        gui.setItem(SLOT_INFO, GuiUtil.createButton(Material.PAPER, "§f§l" + property.getPropertyName(),
+                Arrays.asList(
+                        "§7ID: §f" + property.getId(),
+                        "§7ワールド: §f" + property.getWorldName(),
+                        "§7状態: " + (property.isAvailable() ? "§a利用可能" : "§c賃貸中"),
+                        "",
+                        "§7日額: §a" + GuiUtil.formatPrice(property.getDailyRent()),
+                        "§7週額: §a" + GuiUtil.formatPrice(property.getWeeklyRent()),
+                        "§7月額: §a" + GuiUtil.formatPrice(property.getMonthlyRent())
+                )));
+
+        gui.setItem(SLOT_RENT, GuiUtil.createButton(Material.GOLD_INGOT, "§e§l賃料変更",
+                Arrays.asList(
+                        "§7現在の日額: §a" + GuiUtil.formatPrice(property.getDailyRent()),
+                        "§7クリックで新しい日額をチャット入力",
+                        "§7（週額・月額は自動再計算）"
+                )));
+
+        gui.setItem(SLOT_TELEPORT, GuiUtil.createButton(Material.ENDER_PEARL, "§b§lテレポート",
+                property.hasCoordinates()
+                        ? Collections.singletonList("§7物件の位置へ移動します")
+                        : Collections.singletonList("§8座標情報がないため移動できません")));
+
+        gui.setItem(SLOT_WG, GuiUtil.createButton(Material.SPYGLASS, "§b§lWorldGuard情報",
+                buildWgInfoLore(property)));
+
+        gui.setItem(SLOT_DELETE, GuiUtil.createButton(Material.RED_CONCRETE, "§c§l物件を削除",
+                Arrays.asList(
+                        "§7この物件を削除します（確認あり）",
+                        property.isAvailable() ? "§7WG領域も併せて削除されます" : "§c賃貸中の物件は削除できません"
+                )));
+
+        gui.setItem(SLOT_BACK, GuiUtil.createButton(Material.BARRIER, "§e戻る",
+                Collections.singletonList("§7物件一覧へ戻ります")));
+        gui.setItem(SLOT_CLOSE, GuiUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        decorate(gui);
+    }
+
+    private List<String> buildWgInfoLore(HousingProperty property) {
+        List<String> lore = new ArrayList<>();
+        if (property.hasWorldGuardRegion()) {
+            lore.add("§7WG領域ID: §f" + property.getWorldguardRegionId());
+        } else {
+            lore.add("§7WG領域: §8未設定");
+        }
+        if (property.hasCoordinates()) {
+            lore.add("§7座標1: §f" + property.getX1() + ", " + property.getY1() + ", " + property.getZ1());
+            lore.add("§7座標2: §f" + property.getX2() + ", " + property.getY2() + ", " + property.getZ2());
+            lore.add("§7面積(XZ): §f" + property.getArea() + " ブロック");
+        } else {
+            lore.add("§7座標範囲: §8未設定");
+        }
+        lore.add("§7状態: " + (property.isAvailable() ? "§a利用可能" : "§c賃貸中"));
+        return lore;
+    }
+
+    private void openDeleteConfirm(Player player, HousingProperty property) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, SIZE, "§c物件削除の確認");
+            HousingGUISession session = new HousingGUISession(
+                    player.getUniqueId(), HousingGUISession.Type.ADMIN_EDIT_DELETE_CONFIRM, gui);
+            session.setSelectedPropertyId(property.getId());
+
+            gui.setItem(SLOT_INFO, GuiUtil.createButton(Material.RED_CONCRETE, "§c§l本当に削除しますか？",
+                    Arrays.asList("§7対象: §f" + property.getPropertyName() + " (ID:" + property.getId() + ")",
+                            "§7WG領域がある場合は併せて削除されます")));
+            gui.setItem(SLOT_CONFIRM_YES, GuiUtil.createButton(Material.LIME_CONCRETE, "§a§lはい、削除する",
+                    Collections.singletonList("§7物件を削除します")));
+            gui.setItem(SLOT_CONFIRM_NO, GuiUtil.createButton(Material.RED_CONCRETE, "§c§lいいえ",
+                    Collections.singletonList("§7削除をやめて編集画面へ戻ります")));
+            decorate(gui);
+
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("物件削除確認GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage("§c処理中にエラーが発生しました。");
+        }
+    }
+
+    private void decorate(Inventory gui) {
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = GuiUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = 0; i < SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    public void handleClick(Player player, HousingGUISession session, int slot, ClickType clickType) {
+        if (session.getType() == HousingGUISession.Type.ADMIN_EDIT_DELETE_CONFIRM) {
+            handleConfirmClick(player, session, slot);
+            return;
+        }
+
+        switch (slot) {
+            case SLOT_RENT:
+                startRentInput(player, session.getSelectedPropertyId());
+                break;
+            case SLOT_TELEPORT:
+                teleport(player, session.getSelectedPropertyId());
+                break;
+            case SLOT_DELETE:
+                HousingProperty property = rentalManager.getProperty(session.getSelectedPropertyId());
+                if (property == null) {
+                    player.sendMessage("§c物件が見つかりません");
+                    backToList(player);
+                    break;
+                }
+                if (!property.isAvailable()) {
+                    player.sendMessage("§c賃貸中の物件は削除できません。先に契約をキャンセルしてください。");
+                    break;
+                }
+                openDeleteConfirm(player, property);
+                break;
+            case SLOT_BACK:
+                editing.remove(player.getUniqueId());
+                backToList(player);
+                break;
+            case SLOT_WG:
+                // 情報表示のみ（クリック操作なし）
+                break;
+            case SLOT_CLOSE:
+                editing.remove(player.getUniqueId());
+                player.closeInventory();
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void handleConfirmClick(Player player, HousingGUISession session, int slot) {
+        if (slot == SLOT_CONFIRM_YES) {
+            HousingRentalManager.RentalResult result =
+                    rentalManager.removeProperty(session.getSelectedPropertyId());
+            player.sendMessage((result.isSuccess() ? "§a" : "§c") + result.getMessage());
+            editing.remove(player.getUniqueId());
+            backToList(player);
+        } else if (slot == SLOT_CONFIRM_NO) {
+            render(player);
+        }
+    }
+
+    private void startRentInput(Player player, int propertyId) {
+        player.closeInventory();
+        chatInput.prompt(player,
+                "§e新しい日額賃料を数値で入力してください。",
+                input -> {
+                    Double rent = parsePositiveDouble(player, input);
+                    if (rent != null) {
+                        HousingRentalManager.RentalResult result =
+                                rentalManager.updatePropertyRent(propertyId, rent);
+                        player.sendMessage((result.isSuccess() ? "§a" : "§c") + result.getMessage());
+                    }
+                    reopenLater(player);
+                },
+                () -> reopenLater(player), INPUT_TIMEOUT_SECONDS);
+    }
+
+    private void teleport(Player player, int propertyId) {
+        HousingProperty property = rentalManager.getProperty(propertyId);
+        if (property == null) {
+            player.sendMessage("§c物件が見つかりません");
+            return;
+        }
+        if (!property.hasCoordinates()) {
+            player.sendMessage("§c座標情報がないためテレポートできません");
+            return;
+        }
+        World world = Bukkit.getWorld(property.getWorldName());
+        if (world == null) {
+            player.sendMessage("§cワールド '" + property.getWorldName() + "' が見つかりません");
+            return;
+        }
+
+        // 座標範囲の中心(XZ)・低い方のYへ移動
+        double cx = (property.getX1() + property.getX2()) / 2.0 + 0.5;
+        double cz = (property.getZ1() + property.getZ2()) / 2.0 + 0.5;
+        double y = Math.min(property.getY1(), property.getY2());
+        Location target = new Location(world, cx, y, cz);
+
+        player.closeInventory();
+        player.teleport(target);
+        player.sendMessage("§a物件 '" + property.getPropertyName() + "' へテレポートしました");
+    }
+
+    private Double parsePositiveDouble(Player player, String input) {
+        double value;
+        try {
+            value = Double.parseDouble(input.trim());
+        } catch (NumberFormatException e) {
+            player.sendMessage(configManager.getMarketMessage("input_invalid_number"));
+            return null;
+        }
+        if (value <= 0) {
+            player.sendMessage(configManager.getMarketMessage("input_invalid_number"));
+            return null;
+        }
+        return value;
+    }
+
+    private void reopenLater(Player player) {
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (player.isOnline()) {
+                render(player);
+            }
+        }, 1L);
+    }
+
+    private void backToList(Player player) {
+        if (listGUI != null) {
+            listGUI.open(player);
+        } else {
+            player.closeInventory();
+        }
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingAdminEditGUI.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingAdminEditGUI.java
@@ -152,6 +152,16 @@ public class HousingAdminEditGUI {
         List<String> lore = new ArrayList<>();
         if (property.hasWorldGuardRegion()) {
             lore.add("§7WG領域ID: §f" + property.getWorldguardRegionId());
+
+            // 親リージョンの設定状況を表示
+            org.tofu.tofunomics.integration.WorldGuardIntegration wg = plugin.getWorldGuardIntegration();
+            if (wg != null && wg.isEnabled()) {
+                org.bukkit.World world = Bukkit.getWorld(property.getWorldName());
+                if (world != null) {
+                    String parent = wg.getParentRegionName(property.getWorldguardRegionId(), world);
+                    lore.add("§7親リージョン: " + (parent != null ? "§f" + parent : "§8未設定"));
+                }
+            }
         } else {
             lore.add("§7WG領域: §8未設定");
         }

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingAdminEditGUI.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingAdminEditGUI.java
@@ -129,8 +129,10 @@ public class HousingAdminEditGUI {
                         ? Collections.singletonList("§7物件の位置へ移動します")
                         : Collections.singletonList("§8座標情報がないため移動できません")));
 
-        gui.setItem(SLOT_WG, GuiUtil.createButton(Material.SPYGLASS, "§b§lWorldGuard情報",
-                buildWgInfoLore(property)));
+        List<String> wgLore = new ArrayList<>(buildWgInfoLore(property));
+        wgLore.add("");
+        wgLore.add("§eクリックでWG情報を編集");
+        gui.setItem(SLOT_WG, GuiUtil.createButton(Material.SPYGLASS, "§b§lWorldGuard情報", wgLore));
 
         gui.setItem(SLOT_DELETE, GuiUtil.createButton(Material.RED_CONCRETE, "§c§l物件を削除",
                 Arrays.asList(
@@ -205,6 +207,10 @@ public class HousingAdminEditGUI {
             handleConfirmClick(player, session, slot);
             return;
         }
+        if (session.getType() == HousingGUISession.Type.ADMIN_EDIT_WG) {
+            handleWgEditClick(player, session, slot);
+            return;
+        }
 
         switch (slot) {
             case SLOT_RENT:
@@ -231,7 +237,7 @@ public class HousingAdminEditGUI {
                 backToList(player);
                 break;
             case SLOT_WG:
-                // 情報表示のみ（クリック操作なし）
+                openWgEdit(player, session.getSelectedPropertyId());
                 break;
             case SLOT_CLOSE:
                 editing.remove(player.getUniqueId());
@@ -240,6 +246,161 @@ public class HousingAdminEditGUI {
             default:
                 break;
         }
+    }
+
+    // ===== WG情報編集サブ画面 =====
+
+    private static final int SLOT_WG_RELINK = 10;
+    private static final int SLOT_WG_PARENT = 12;
+    private static final int SLOT_WG_UNLINK = 14;
+    private static final int SLOT_WG_UNLINK_DELETE = 16;
+
+    private void openWgEdit(Player player, int propertyId) {
+        HousingProperty property = rentalManager.getProperty(propertyId);
+        if (property == null) {
+            player.sendMessage("§c物件が見つかりません");
+            backToList(player);
+            return;
+        }
+        try {
+            Inventory gui = Bukkit.createInventory(null, SIZE, "§6WG情報編集 - " + property.getPropertyName());
+            HousingGUISession session = new HousingGUISession(
+                    player.getUniqueId(), HousingGUISession.Type.ADMIN_EDIT_WG, gui);
+            session.setSelectedPropertyId(propertyId);
+
+            gui.setItem(SLOT_INFO, GuiUtil.createButton(Material.SPYGLASS, "§f§lWorldGuard情報",
+                    buildWgInfoLore(property)));
+
+            gui.setItem(SLOT_WG_RELINK, GuiUtil.createButton(Material.NAME_TAG, "§e§lリージョンID変更・再紐付け",
+                    Arrays.asList(
+                            "§7既存の別WGリージョンに紐付け直します",
+                            "§7クリックでリージョンIDをチャット入力"
+                    )));
+
+            gui.setItem(SLOT_WG_PARENT, GuiUtil.createButton(Material.CHEST, "§e§l親リージョン設定",
+                    Arrays.asList(
+                            property.hasWorldGuardRegion() ? "§7この物件のWG領域を子に設定します" : "§8WG領域未設定のため使用不可",
+                            "§7クリックで親リージョンIDをチャット入力"
+                    )));
+
+            gui.setItem(SLOT_WG_UNLINK, GuiUtil.createButton(Material.SHEARS, "§6§l紐付け解除のみ",
+                    Arrays.asList(
+                            property.hasWorldGuardRegion() ? "§7物件からWG領域IDを外します" : "§8WG領域未設定のため使用不可",
+                            "§7WG領域自体は残します"
+                    )));
+
+            gui.setItem(SLOT_WG_UNLINK_DELETE, GuiUtil.createButton(Material.RED_CONCRETE, "§c§l紐付け解除＋領域削除",
+                    Arrays.asList(
+                            property.hasWorldGuardRegion() ? "§7WG領域を削除し紐付けも外します" : "§8WG領域未設定のため使用不可",
+                            "§cこの操作は元に戻せません"
+                    )));
+
+            gui.setItem(SLOT_BACK, GuiUtil.createButton(Material.BARRIER, "§e戻る",
+                    Collections.singletonList("§7物件編集へ戻ります")));
+            gui.setItem(SLOT_CLOSE, GuiUtil.createButton(Material.BARRIER, "§c閉じる",
+                    Collections.singletonList("§7GUIを閉じます")));
+
+            decorate(gui);
+
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("WG情報編集GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage("§c処理中にエラーが発生しました。");
+        }
+    }
+
+    private void handleWgEditClick(Player player, HousingGUISession session, int slot) {
+        int propertyId = session.getSelectedPropertyId();
+        HousingProperty property = rentalManager.getProperty(propertyId);
+        if (property == null) {
+            player.sendMessage("§c物件が見つかりません");
+            backToList(player);
+            return;
+        }
+
+        switch (slot) {
+            case SLOT_WG_RELINK:
+                startRelinkInput(player, propertyId);
+                break;
+            case SLOT_WG_PARENT:
+                if (!property.hasWorldGuardRegion()) {
+                    player.sendMessage("§cWG領域が未設定です");
+                    break;
+                }
+                startParentInput(player, propertyId);
+                break;
+            case SLOT_WG_UNLINK:
+                if (!property.hasWorldGuardRegion()) {
+                    player.sendMessage("§cWG領域が未設定です");
+                    break;
+                }
+                doUnlink(player, propertyId, false);
+                break;
+            case SLOT_WG_UNLINK_DELETE:
+                if (!property.hasWorldGuardRegion()) {
+                    player.sendMessage("§cWG領域が未設定です");
+                    break;
+                }
+                doUnlink(player, propertyId, true);
+                break;
+            case SLOT_BACK:
+                render(player);
+                break;
+            case SLOT_CLOSE:
+                editing.remove(player.getUniqueId());
+                player.closeInventory();
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void doUnlink(Player player, int propertyId, boolean alsoDelete) {
+        HousingRentalManager.RentalResult result =
+                rentalManager.unlinkWorldGuardRegion(propertyId, alsoDelete);
+        player.sendMessage((result.isSuccess() ? "§a" : "§c") + result.getMessage());
+        openWgEdit(player, propertyId);
+    }
+
+    private void startRelinkInput(Player player, int propertyId) {
+        player.closeInventory();
+        chatInput.prompt(player,
+                "§e紐付けるWGリージョンIDをチャット入力してください（実在する領域）。",
+                input -> {
+                    String regionId = input.trim();
+                    if (!regionId.isEmpty()) {
+                        HousingRentalManager.RentalResult result =
+                                rentalManager.relinkWorldGuardRegion(propertyId, regionId);
+                        player.sendMessage((result.isSuccess() ? "§a" : "§c") + result.getMessage());
+                    }
+                    reopenWgLater(player, propertyId);
+                },
+                () -> reopenWgLater(player, propertyId), INPUT_TIMEOUT_SECONDS);
+    }
+
+    private void startParentInput(Player player, int propertyId) {
+        player.closeInventory();
+        chatInput.prompt(player,
+                "§e親リージョンIDをチャット入力してください（実在する領域）。",
+                input -> {
+                    String parentId = input.trim();
+                    if (!parentId.isEmpty()) {
+                        HousingRentalManager.RentalResult result =
+                                rentalManager.setPropertyParentRegion(propertyId, parentId);
+                        player.sendMessage((result.isSuccess() ? "§a" : "§c") + result.getMessage());
+                    }
+                    reopenWgLater(player, propertyId);
+                },
+                () -> reopenWgLater(player, propertyId), INPUT_TIMEOUT_SECONDS);
+    }
+
+    private void reopenWgLater(Player player, int propertyId) {
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (player.isOnline()) {
+                openWgEdit(player, propertyId);
+            }
+        }, 1L);
     }
 
     private void handleConfirmClick(Player player, HousingGUISession session, int slot) {

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingAdminListGUI.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingAdminListGUI.java
@@ -1,0 +1,169 @@
+package org.tofu.tofunomics.housing.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.gui.GuiUtil;
+import org.tofu.tofunomics.housing.HousingRentalManager;
+import org.tofu.tofunomics.models.HousingProperty;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 管理者向けの全物件一覧 GUI（ページング）。
+ * 賃貸中も含む全物件を表示し、物件をクリックすると編集画面（{@link HousingAdminEditGUI}）へ遷移する。
+ */
+public class HousingAdminListGUI {
+
+    private static final int INVENTORY_SIZE = 54;
+    private static final int ITEM_START_SLOT = 9;
+    private static final int ITEM_END_SLOT = 44;
+    private static final int ITEMS_PER_PAGE = ITEM_END_SLOT - ITEM_START_SLOT + 1; // 36
+    private static final int SLOT_PREV = 48;
+    private static final int SLOT_INFO = 49;
+    private static final int SLOT_NEXT = 50;
+    private static final int SLOT_CLOSE = 53;
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final HousingRentalManager rentalManager;
+    private final HousingGUIListener listener;
+
+    private HousingAdminEditGUI editGUI;
+
+    public HousingAdminListGUI(TofuNomics plugin, ConfigManager configManager,
+                               HousingRentalManager rentalManager, HousingGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.rentalManager = rentalManager;
+        this.listener = listener;
+    }
+
+    public void setGUIs(HousingAdminEditGUI editGUI) {
+        this.editGUI = editGUI;
+    }
+
+    public void open(Player player) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, INVENTORY_SIZE, "§6物件管理 - 一覧");
+            HousingGUISession session = new HousingGUISession(
+                    player.getUniqueId(), HousingGUISession.Type.ADMIN_LIST, gui);
+            render(session);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("物件管理一覧GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage("§c処理中にエラーが発生しました。");
+        }
+    }
+
+    public void render(HousingGUISession session) {
+        Inventory gui = session.getInventory();
+        gui.clear();
+        session.clearSlots();
+
+        List<HousingProperty> properties = rentalManager.getAllProperties();
+
+        int totalPages = Math.max(1, (int) Math.ceil(properties.size() / (double) ITEMS_PER_PAGE));
+        if (session.getPage() >= totalPages) {
+            session.setPage(totalPages - 1);
+        }
+        if (session.getPage() < 0) {
+            session.setPage(0);
+        }
+
+        int start = session.getPage() * ITEMS_PER_PAGE;
+        int end = Math.min(start + ITEMS_PER_PAGE, properties.size());
+
+        int slot = ITEM_START_SLOT;
+        for (int i = start; i < end; i++) {
+            HousingProperty property = properties.get(i);
+            gui.setItem(slot, buildPropertyItem(property));
+            session.putSlotProperty(slot, property);
+            slot++;
+        }
+
+        setupNavigation(gui, session, properties.size(), totalPages);
+    }
+
+    private ItemStack buildPropertyItem(HousingProperty property) {
+        List<String> lore = new ArrayList<>();
+        lore.add("§7ID: §f" + property.getId());
+        lore.add("§7ワールド: §f" + property.getWorldName());
+        lore.add("§7状態: " + (property.isAvailable() ? "§a利用可能" : "§c賃貸中"));
+        lore.add("");
+        lore.add("§7日額: §a" + GuiUtil.formatPrice(property.getDailyRent()));
+        if (property.hasWorldGuardRegion()) {
+            lore.add("§7WG領域: §f" + property.getWorldguardRegionId());
+        }
+        lore.add("");
+        lore.add("§eクリックで編集");
+
+        // 賃貸中は赤系、利用可能は通常のドアで色分け
+        Material icon = property.isAvailable() ? Material.OAK_DOOR : Material.RED_CONCRETE;
+        return GuiUtil.createButton(icon, "§f§l" + property.getPropertyName(), lore);
+    }
+
+    private void setupNavigation(Inventory gui, HousingGUISession session, int total, int totalPages) {
+        if (session.getPage() > 0) {
+            gui.setItem(SLOT_PREV, GuiUtil.createButton(Material.ARROW, "§a前のページ",
+                    Collections.singletonList("§7ページ " + session.getPage() + " へ")));
+        }
+        if (session.getPage() < totalPages - 1) {
+            gui.setItem(SLOT_NEXT, GuiUtil.createButton(Material.ARROW, "§a次のページ",
+                    Collections.singletonList("§7ページ " + (session.getPage() + 2) + " へ")));
+        }
+
+        gui.setItem(SLOT_INFO, GuiUtil.createButton(Material.BOOK, "§6物件情報",
+                Arrays.asList(
+                        "§f登録物件数: §a" + total + " 件",
+                        "§fページ: §e" + (session.getPage() + 1) + " / " + totalPages
+                )));
+
+        gui.setItem(SLOT_CLOSE, GuiUtil.createButton(Material.BARRIER, "§c閉じる",
+                Collections.singletonList("§7GUIを閉じます")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = GuiUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = 45; i < INVENTORY_SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    public void handleClick(Player player, HousingGUISession session, int slot, ClickType clickType) {
+        if (slot == SLOT_CLOSE) {
+            player.closeInventory();
+            return;
+        }
+        if (slot == SLOT_PREV) {
+            session.setPage(session.getPage() - 1);
+            render(session);
+            return;
+        }
+        if (slot == SLOT_NEXT) {
+            session.setPage(session.getPage() + 1);
+            render(session);
+            return;
+        }
+
+        HousingProperty property = session.getPropertyAtSlot(slot);
+        if (property == null) {
+            return;
+        }
+        if (editGUI != null) {
+            editGUI.open(player, property.getId());
+        }
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingAdminRegisterGUI.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingAdminRegisterGUI.java
@@ -1,0 +1,301 @@
+package org.tofu.tofunomics.housing.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.gui.ChatInputManager;
+import org.tofu.tofunomics.gui.GuiUtil;
+import org.tofu.tofunomics.housing.HousingRentalManager;
+import org.tofu.tofunomics.housing.SelectionManager;
+import org.tofu.tofunomics.integration.WorldGuardIntegration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 管理者向け物件登録 GUI。
+ *
+ * 事前に木の斧で範囲選択した状態で開く。物件名・日額賃料の既定値（連番自動命名・config値）を表示し、
+ * クリックでチャット入力による上書きができる。WorldGuard領域の自動作成トグルと、
+ * 選択範囲に重なる既存リージョンの確認も提供する。登録ボタンで {@code quickregister} と同じ中核処理を呼ぶ。
+ *
+ * チャット入力でGUIを開き直す際も入力中の値を保持するため、編集中の状態はプレイヤーごとに
+ * {@link #pendingStates} で保持する（GUIセッションはクローズ時に破棄されるため）。
+ */
+public class HousingAdminRegisterGUI {
+
+    private static final int SIZE = 27;
+    private static final int SLOT_INFO = 4;
+    private static final int SLOT_NAME = 10;
+    private static final int SLOT_RENT = 12;
+    private static final int SLOT_WG_TOGGLE = 14;
+    private static final int SLOT_WG_CHECK = 16;
+    private static final int SLOT_REGISTER = 22;
+    private static final int SLOT_CLOSE = 26;
+
+    private static final int INPUT_TIMEOUT_SECONDS = 60;
+
+    /** 編集中の入力値（プレイヤーごと） */
+    private static class PendingState {
+        String propertyName;
+        double dailyRent;
+        boolean createWg;
+    }
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final HousingRentalManager rentalManager;
+    private final SelectionManager selectionManager;
+    private final ChatInputManager chatInput;
+    private final HousingGUIListener listener;
+
+    private final Map<UUID, PendingState> pendingStates = new ConcurrentHashMap<>();
+
+    public HousingAdminRegisterGUI(TofuNomics plugin, ConfigManager configManager,
+                                   HousingRentalManager rentalManager, SelectionManager selectionManager,
+                                   ChatInputManager chatInput, HousingGUIListener listener) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.rentalManager = rentalManager;
+        this.selectionManager = selectionManager;
+        this.chatInput = chatInput;
+        this.listener = listener;
+    }
+
+    /**
+     * 登録GUIを新規に開く（既定値で初期化）。コマンドからの入口。
+     */
+    public void open(Player player) {
+        if (!selectionManager.hasCompleteSelection(player)) {
+            player.sendMessage("§c範囲選択が完了していません");
+            player.sendMessage("§7木の斧で2点を選択してから開いてください");
+            return;
+        }
+
+        PendingState state = new PendingState();
+        state.propertyName = rentalManager.generateNextPropertyName();
+        state.dailyRent = configManager.getHousingDefaultDailyRent();
+        state.createWg = configManager.isHousingAutoCreateWgRegion();
+        pendingStates.put(player.getUniqueId(), state);
+
+        render(player, state);
+    }
+
+    /**
+     * 編集中の状態を保ったままGUIを開き直す（チャット入力後の戻り用）。
+     */
+    private void reopen(Player player) {
+        PendingState state = pendingStates.get(player.getUniqueId());
+        if (state == null) {
+            open(player);
+            return;
+        }
+        render(player, state);
+    }
+
+    private void render(Player player, PendingState state) {
+        try {
+            Inventory gui = Bukkit.createInventory(null, SIZE, "§6物件登録");
+            HousingGUISession session = new HousingGUISession(
+                    player.getUniqueId(), HousingGUISession.Type.ADMIN_REGISTER, gui);
+            renderItems(gui, player, state);
+            listener.registerSession(player.getUniqueId(), session);
+            player.openInventory(gui);
+        } catch (Exception e) {
+            plugin.getLogger().severe("物件登録GUIの表示に失敗しました: " + e.getMessage());
+            player.sendMessage("§c処理中にエラーが発生しました。");
+        }
+    }
+
+    private void renderItems(Inventory gui, Player player, PendingState state) {
+        int volume = selectionManager.getSelectionVolume(player);
+        int area = selectionManager.getSelectionArea(player);
+
+        gui.setItem(SLOT_INFO, GuiUtil.createButton(Material.MAP, "§f§l選択範囲",
+                Arrays.asList(
+                        "§7ワールド: §f" + player.getWorld().getName(),
+                        "§7体積: §f" + volume + " ブロック",
+                        "§7面積(XZ): §f" + area + " ブロック"
+                )));
+
+        gui.setItem(SLOT_NAME, GuiUtil.createButton(Material.NAME_TAG, "§e§l物件名",
+                Arrays.asList(
+                        "§7現在: §f" + state.propertyName,
+                        "§7クリックでチャット入力して変更"
+                )));
+
+        gui.setItem(SLOT_RENT, GuiUtil.createButton(Material.GOLD_INGOT, "§e§l日額賃料",
+                Arrays.asList(
+                        "§7現在: §a" + GuiUtil.formatPrice(state.dailyRent),
+                        "§7クリックでチャット入力して変更"
+                )));
+
+        gui.setItem(SLOT_WG_TOGGLE, GuiUtil.createButton(
+                state.createWg ? Material.LIME_DYE : Material.GRAY_DYE,
+                "§e§lWorldGuard領域の自動作成",
+                Arrays.asList(
+                        "§7現在: " + (state.createWg ? "§a有効" : "§c無効"),
+                        "§7クリックで切り替え",
+                        "§7有効時は物件名と同名の領域を作成します"
+                )));
+
+        gui.setItem(SLOT_WG_CHECK, GuiUtil.createButton(Material.SPYGLASS, "§b§lWGリージョン確認",
+                buildWgCheckLore(player)));
+
+        gui.setItem(SLOT_REGISTER, GuiUtil.createButton(Material.EMERALD_BLOCK, "§a§l登録する",
+                Collections.singletonList("§7この内容で物件を登録します")));
+        gui.setItem(SLOT_CLOSE, GuiUtil.createButton(Material.BARRIER, "§cキャンセル",
+                Collections.singletonList("§7登録せずに閉じます")));
+
+        if (configManager.isGuiDecorationEnabled()) {
+            ItemStack glass = GuiUtil.createButton(
+                    Material.GRAY_STAINED_GLASS_PANE, "§r", Collections.emptyList());
+            for (int i = 0; i < SIZE; i++) {
+                if (gui.getItem(i) == null) {
+                    gui.setItem(i, glass);
+                }
+            }
+        }
+    }
+
+    private List<String> buildWgCheckLore(Player player) {
+        List<String> lore = new ArrayList<>();
+        WorldGuardIntegration wg = plugin.getWorldGuardIntegration();
+        if (wg == null || !wg.isEnabled()) {
+            lore.add("§8WorldGuard統合が無効です");
+            return lore;
+        }
+
+        Location pos1 = selectionManager.getFirstPosition(player.getUniqueId());
+        Location pos2 = selectionManager.getSecondPosition(player.getUniqueId());
+        if (pos1 == null || pos2 == null) {
+            lore.add("§8選択範囲が未設定です");
+            return lore;
+        }
+        List<String> overlapping = wg.getOverlappingRegionNames(player.getWorld(), pos1, pos2);
+
+        if (overlapping.isEmpty()) {
+            lore.add("§a選択範囲に重なる既存リージョンはありません");
+        } else {
+            lore.add("§e重なる既存リージョン (" + overlapping.size() + "件):");
+            int shown = 0;
+            for (String name : overlapping) {
+                if (shown >= 8) {
+                    lore.add("§7...他 " + (overlapping.size() - shown) + " 件");
+                    break;
+                }
+                lore.add("§7- §f" + name);
+                shown++;
+            }
+        }
+        return lore;
+    }
+
+    public void handleClick(Player player, HousingGUISession session, int slot, ClickType clickType) {
+        PendingState state = pendingStates.get(player.getUniqueId());
+        if (state == null) {
+            player.closeInventory();
+            return;
+        }
+
+        switch (slot) {
+            case SLOT_NAME:
+                startNameInput(player, state);
+                break;
+            case SLOT_RENT:
+                startRentInput(player, state);
+                break;
+            case SLOT_WG_TOGGLE:
+                state.createWg = !state.createWg;
+                reopen(player);
+                break;
+            case SLOT_REGISTER:
+                doRegister(player, state);
+                break;
+            case SLOT_CLOSE:
+                pendingStates.remove(player.getUniqueId());
+                player.closeInventory();
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void startNameInput(Player player, PendingState state) {
+        player.closeInventory();
+        chatInput.prompt(player,
+                "§e物件名をチャットで入力してください。",
+                input -> {
+                    String name = input.trim();
+                    if (!name.isEmpty()) {
+                        state.propertyName = name;
+                    }
+                    reopen(player);
+                },
+                () -> reopen(player), INPUT_TIMEOUT_SECONDS);
+    }
+
+    private void startRentInput(Player player, PendingState state) {
+        player.closeInventory();
+        chatInput.prompt(player,
+                "§e日額賃料を数値で入力してください。",
+                input -> {
+                    Double rent = parsePositiveDouble(player, input);
+                    if (rent != null) {
+                        state.dailyRent = rent;
+                    }
+                    reopen(player);
+                },
+                () -> reopen(player), INPUT_TIMEOUT_SECONDS);
+    }
+
+    private void doRegister(Player player, PendingState state) {
+        player.closeInventory();
+        pendingStates.remove(player.getUniqueId());
+
+        if (!selectionManager.hasCompleteSelection(player)) {
+            player.sendMessage("§c範囲選択が解除されています。再度選択してください。");
+            return;
+        }
+
+        Location pos1 = selectionManager.getFirstPosition(player.getUniqueId());
+        Location pos2 = selectionManager.getSecondPosition(player.getUniqueId());
+
+        HousingRentalManager.RentalResult result = rentalManager.registerPropertyFromSelection(
+                state.propertyName, player.getWorld(), pos1, pos2, state.dailyRent, state.createWg);
+
+        if (result.isSuccess()) {
+            player.sendMessage("§a物件 '" + state.propertyName + "' を登録しました（日額: " + state.dailyRent + "）");
+            player.sendMessage("§7" + result.getMessage());
+            selectionManager.clearSelection(player);
+        } else {
+            player.sendMessage("§c" + result.getMessage());
+        }
+    }
+
+    private Double parsePositiveDouble(Player player, String input) {
+        double value;
+        try {
+            value = Double.parseDouble(input.trim());
+        } catch (NumberFormatException e) {
+            player.sendMessage(configManager.getMarketMessage("input_invalid_number"));
+            return null;
+        }
+        if (value <= 0) {
+            player.sendMessage(configManager.getMarketMessage("input_invalid_number"));
+            return null;
+        }
+        return value;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUIListener.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUIListener.java
@@ -122,6 +122,7 @@ public class HousingGUIListener implements Listener {
                 break;
             case ADMIN_EDIT:
             case ADMIN_EDIT_DELETE_CONFIRM:
+            case ADMIN_EDIT_WG:
                 if (adminEditGUI != null) adminEditGUI.handleClick(player, session, slot, clickType);
                 break;
             default:

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUIListener.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUIListener.java
@@ -34,6 +34,8 @@ public class HousingGUIListener implements Listener {
     private MyRentalsGUI myRentalsGUI;
     private RentalManageGUI manageGUI;
     private HousingAdminRegisterGUI adminRegisterGUI;
+    private HousingAdminListGUI adminListGUI;
+    private HousingAdminEditGUI adminEditGUI;
 
     public HousingGUIListener(TofuNomics plugin) {
         this.plugin = plugin;
@@ -44,13 +46,16 @@ public class HousingGUIListener implements Listener {
      */
     public void setGUIs(HousingHubGUI hubGUI, HousingBrowseGUI browseGUI, HousingDetailGUI detailGUI,
                         MyRentalsGUI myRentalsGUI, RentalManageGUI manageGUI,
-                        HousingAdminRegisterGUI adminRegisterGUI) {
+                        HousingAdminRegisterGUI adminRegisterGUI,
+                        HousingAdminListGUI adminListGUI, HousingAdminEditGUI adminEditGUI) {
         this.hubGUI = hubGUI;
         this.browseGUI = browseGUI;
         this.detailGUI = detailGUI;
         this.myRentalsGUI = myRentalsGUI;
         this.manageGUI = manageGUI;
         this.adminRegisterGUI = adminRegisterGUI;
+        this.adminListGUI = adminListGUI;
+        this.adminEditGUI = adminEditGUI;
     }
 
     /**
@@ -111,6 +116,13 @@ public class HousingGUIListener implements Listener {
                 break;
             case ADMIN_REGISTER:
                 if (adminRegisterGUI != null) adminRegisterGUI.handleClick(player, session, slot, clickType);
+                break;
+            case ADMIN_LIST:
+                if (adminListGUI != null) adminListGUI.handleClick(player, session, slot, clickType);
+                break;
+            case ADMIN_EDIT:
+            case ADMIN_EDIT_DELETE_CONFIRM:
+                if (adminEditGUI != null) adminEditGUI.handleClick(player, session, slot, clickType);
                 break;
             default:
                 break;

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUIListener.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUIListener.java
@@ -33,6 +33,7 @@ public class HousingGUIListener implements Listener {
     private HousingDetailGUI detailGUI;
     private MyRentalsGUI myRentalsGUI;
     private RentalManageGUI manageGUI;
+    private HousingAdminRegisterGUI adminRegisterGUI;
 
     public HousingGUIListener(TofuNomics plugin) {
         this.plugin = plugin;
@@ -42,12 +43,14 @@ public class HousingGUIListener implements Listener {
      * GUI 参照を注入する（循環依存を避けるためセッターで後から設定）。
      */
     public void setGUIs(HousingHubGUI hubGUI, HousingBrowseGUI browseGUI, HousingDetailGUI detailGUI,
-                        MyRentalsGUI myRentalsGUI, RentalManageGUI manageGUI) {
+                        MyRentalsGUI myRentalsGUI, RentalManageGUI manageGUI,
+                        HousingAdminRegisterGUI adminRegisterGUI) {
         this.hubGUI = hubGUI;
         this.browseGUI = browseGUI;
         this.detailGUI = detailGUI;
         this.myRentalsGUI = myRentalsGUI;
         this.manageGUI = manageGUI;
+        this.adminRegisterGUI = adminRegisterGUI;
     }
 
     /**
@@ -105,6 +108,9 @@ public class HousingGUIListener implements Listener {
             case MANAGE:
             case CANCEL_CONFIRM:
                 if (manageGUI != null) manageGUI.handleClick(player, session, slot, clickType);
+                break;
+            case ADMIN_REGISTER:
+                if (adminRegisterGUI != null) adminRegisterGUI.handleClick(player, session, slot, clickType);
                 break;
             default:
                 break;

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUISession.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUISession.java
@@ -23,7 +23,8 @@ public class HousingGUISession {
         DETAIL,         // 物件詳細（借りる）
         MY_RENTALS,     // 自分の契約一覧
         MANAGE,         // 契約管理（延長・解約）
-        CANCEL_CONFIRM  // 解約の確認
+        CANCEL_CONFIRM, // 解約の確認
+        ADMIN_REGISTER  // 管理者: 物件登録
     }
 
     private final UUID playerId;

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUISession.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUISession.java
@@ -24,7 +24,10 @@ public class HousingGUISession {
         MY_RENTALS,     // 自分の契約一覧
         MANAGE,         // 契約管理（延長・解約）
         CANCEL_CONFIRM, // 解約の確認
-        ADMIN_REGISTER  // 管理者: 物件登録
+        ADMIN_REGISTER, // 管理者: 物件登録
+        ADMIN_LIST,     // 管理者: 物件一覧
+        ADMIN_EDIT,     // 管理者: 物件編集
+        ADMIN_EDIT_DELETE_CONFIRM // 管理者: 物件削除の確認
     }
 
     private final UUID playerId;

--- a/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUISession.java
+++ b/src/main/java/org/tofu/tofunomics/housing/gui/HousingGUISession.java
@@ -27,7 +27,8 @@ public class HousingGUISession {
         ADMIN_REGISTER, // 管理者: 物件登録
         ADMIN_LIST,     // 管理者: 物件一覧
         ADMIN_EDIT,     // 管理者: 物件編集
-        ADMIN_EDIT_DELETE_CONFIRM // 管理者: 物件削除の確認
+        ADMIN_EDIT_DELETE_CONFIRM, // 管理者: 物件削除の確認
+        ADMIN_EDIT_WG   // 管理者: WG情報の編集
     }
 
     private final UUID playerId;

--- a/src/main/java/org/tofu/tofunomics/integration/WorldGuardIntegration.java
+++ b/src/main/java/org/tofu/tofunomics/integration/WorldGuardIntegration.java
@@ -378,8 +378,52 @@ public class WorldGuardIntegration {
     }
 
     /**
+     * 選択範囲(pos1〜pos2)に重なる既存リージョンのID一覧を取得
+     * 一時的なCuboid領域を作り、それに適用されるリージョンを列挙する（リージョンは登録しない）
+     *
+     * @param world ワールド
+     * @param pos1 第1座標
+     * @param pos2 第2座標
+     * @return 重なる既存リージョンIDのリスト（重なりがなければ空リスト）
+     */
+    public java.util.List<String> getOverlappingRegionNames(World world, Location pos1, Location pos2) {
+        java.util.List<String> result = new java.util.ArrayList<>();
+        if (!enabled) {
+            return result;
+        }
+
+        try {
+            RegionManager regionManager = regionContainer.get(BukkitAdapter.adapt(world));
+            if (regionManager == null) {
+                return result;
+            }
+
+            BlockVector3 min = BlockVector3.at(
+                Math.min(pos1.getBlockX(), pos2.getBlockX()),
+                Math.min(pos1.getBlockY(), pos2.getBlockY()),
+                Math.min(pos1.getBlockZ(), pos2.getBlockZ())
+            );
+            BlockVector3 max = BlockVector3.at(
+                Math.max(pos1.getBlockX(), pos2.getBlockX()),
+                Math.max(pos1.getBlockY(), pos2.getBlockY()),
+                Math.max(pos1.getBlockZ(), pos2.getBlockZ())
+            );
+
+            // 一時的な領域を作って重なりを判定（登録はしない）
+            ProtectedCuboidRegion tempRegion = new ProtectedCuboidRegion("__tofunomics_temp__", min, max);
+            for (ProtectedRegion region : regionManager.getApplicableRegions(tempRegion)) {
+                result.add(region.getId());
+            }
+        } catch (Exception e) {
+            logger.warning("重なるリージョンの取得に失敗しました: " + e.getMessage());
+        }
+
+        return result;
+    }
+
+    /**
      * 子リージョンに親リージョンを設定
-     * 
+     *
      * @param childRegionId 子リージョンID
      * @param parentRegionId 親リージョンID
      * @param world ワールド

--- a/src/main/java/org/tofu/tofunomics/integration/WorldGuardIntegration.java
+++ b/src/main/java/org/tofu/tofunomics/integration/WorldGuardIntegration.java
@@ -485,8 +485,40 @@ public class WorldGuardIntegration {
 
 
     /**
+     * リージョンの親リージョンIDを取得する。
+     *
+     * @param regionId 対象リージョンID
+     * @param world ワールド
+     * @return 親リージョンID。親が未設定／リージョンが存在しない／WG無効の場合は null
+     */
+    public String getParentRegionName(String regionId, World world) {
+        if (!enabled) {
+            return null;
+        }
+
+        try {
+            RegionManager regionManager = regionContainer.get(BukkitAdapter.adapt(world));
+            if (regionManager == null) {
+                return null;
+            }
+
+            ProtectedRegion region = regionManager.getRegion(regionId);
+            if (region == null) {
+                return null;
+            }
+
+            ProtectedRegion parent = region.getParent();
+            return parent != null ? parent.getId() : null;
+
+        } catch (Exception e) {
+            logger.warning("親リージョンの取得に失敗しました: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
      * リージョンにフラグを設定
-     * 
+     *
      * @param regionId リージョンID
      * @param world ワールド
      * @param flagName フラグ名（"build", "use", "pvp"など）

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3142,9 +3142,15 @@ housing_rental:
   
   # プレイヤーあたりの最大賃貸契約数
   max_rentals_per_player: 3
-  
+
   # 範囲選択ツール（WorldEditライク）
   selection_tool: WOODEN_AXE
+
+  # 物件一括登録の効率化設定（quickregister / 登録GUIで使用）
+  default_daily_rent: 100        # 家賃省略時の既定日額（整数推奨: 通貨は金塊）
+  auto_create_wg_region: true    # 登録時にWorldGuard領域も自動作成するか
+  auto_naming:
+    prefix: "house-"             # 連番自動命名の接頭辞（例: house-1, house-2）
   
   # 賃貸期間設定
   rental_periods:


### PR DESCRIPTION
## 背景

賃貸システムに登録する家がかなりの数あり、現状の登録フロー（木の斧で範囲選択 → `/housing admin register <物件名> <日額> [--wg <領域名>]` を1物件ずつ実行）が手間でした。物件名・家賃を毎回入力し、WG領域作成も別オプション指定が必要です。

家賃は「ほぼ一律」のため既定値で省略できるようにし、最小操作で登録が完結する手段を追加します。

## 変更内容

### 1. クイック登録 `/housing admin quickregister`（別名 `qr`）
- 範囲選択さえ済んでいれば物件名・家賃の指定不要で登録完了
- 物件名は連番自動命名（既定 `house-1`, `house-2`...、既存物件名・WGリージョン名と衝突回避）
- 家賃は config の `default_daily_rent` を使用
- WorldGuard領域も物件名と同名で自動作成（親リージョン継承・フラグ設定込み）
- `--name <名>` `--rent <日額>` で任意に上書き可能

### 2. 物件登録GUI `/housing admin gui`
- 範囲選択後に開く管理者向け登録画面
- 物件名・日額賃料をチャット入力で編集（既定値表示）、WG自動作成のON/OFFトグル
- 選択範囲に重なる既存WGリージョンを一覧表示（リージョン化済みか一目で確認）

### 3. WGリージョン確認 `/housing admin checkregion [領域名]`
- 引数あり: 指定リージョン名の存在確認
- 引数なし: 選択範囲に重なる既存リージョンを列挙

### 設計
- 登録の中核処理は `HousingRentalManager`（`generateNextPropertyName` / `registerPropertyFromSelection`）に集約し、コマンドとGUIで再利用
- WG重なり判定は `WorldGuardIntegration.getOverlappingRegionNames` を新設
- config は jar テンプレートのみ追記（既存サーバーconfigは上書きしない）

## テスト
- `mvn clean package` ビルド成功
- `mvn test` 全329テストパス（Failures: 0, Errors: 0）
- config.yml YAML構文チェックOK

## デプロイ後のゲーム内確認項目
- [ ] 未選択で `qr` 実行 → エラー表示
- [ ] 範囲選択 → `qr` で `house-1` 登録（家賃=既定・WG領域自動作成）、連続実行で連番が進む
- [ ] `qr --name villa-a --rent 250` で上書き反映
- [ ] `gui` で範囲情報・既定値表示、名前/家賃のチャット編集、登録ボタンで作成＋選択クリア
- [ ] `checkregion` の名前指定/選択範囲モード
- [ ] 登録物件を通常GUIで借りられる（既存契約フロー回帰）

🤖 Generated with [Claude Code](https://claude.com/claude-code)