### PR TITLE
fix: 鉱夫の採掘経験値を再バランス（石を最低値に）

### DIFF
--- a/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
+++ b/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
@@ -139,20 +139,20 @@ public class JobExperienceManager implements Listener {
     }
 
     private void initializeExperienceTables() {
-        // 採掘経験値テーブル
-        miningExperience.put(Material.COAL_ORE, 2.0);
-        miningExperience.put(Material.IRON_ORE, 5.0);
-        miningExperience.put(Material.GOLD_ORE, 8.0);
-        miningExperience.put(Material.DIAMOND_ORE, 25.0);
-        miningExperience.put(Material.EMERALD_ORE, 20.0);
+        // 採掘経験値テーブル（レア度順。全鉱石が必ず STONE を上回るよう設計）
+        miningExperience.put(Material.COAL_ORE, 2.5);
+        miningExperience.put(Material.COPPER_ORE, 3.0);  // 1.17追加。安価な鉱石
         miningExperience.put(Material.LAPIS_ORE, 4.0);
-        miningExperience.put(Material.REDSTONE_ORE, 3.0);
-        miningExperience.put(Material.NETHER_QUARTZ_ORE, 6.0);
-        miningExperience.put(Material.COPPER_ORE, 5.0);  // 1.17追加。鉄鉱石相当
+        miningExperience.put(Material.REDSTONE_ORE, 4.0);
+        miningExperience.put(Material.IRON_ORE, 6.0);
+        miningExperience.put(Material.NETHER_QUARTZ_ORE, 7.0);
+        miningExperience.put(Material.NETHER_GOLD_ORE, 7.0);  // 1.16追加。金鉱石相当
+        miningExperience.put(Material.GOLD_ORE, 9.0);
+        miningExperience.put(Material.EMERALD_ORE, 20.0);
+        miningExperience.put(Material.DIAMOND_ORE, 25.0);
         miningExperience.put(Material.ANCIENT_DEBRIS, 50.0);
-        miningExperience.put(Material.NETHER_GOLD_ORE, 6.0);  // 1.16追加。金鉱石相当
         // STONE: 自然生成のみ経験値獲得（プレイヤー設置はUnifiedEventHandlerで除外）
-        miningExperience.put(Material.STONE, 5.0);  // 0.5 → 5.0（メッセージ表示のため）
+        miningExperience.put(Material.STONE, 1.0);  // 地グラインドの最低基準。鉱石は必ずこれを上回る
         // COBBLESTONE: 経験値なし（設置→採掘での無限経験値防止）
         
         // 伐採経験値テーブル


### PR DESCRIPTION
## 概要
鉱夫(miner)職業で、**石(STONE)を掘ったときより石炭・鉄などの鉱石を掘ったときの方が職業経験値が低い**逆転を修正。

## 原因
経験値は `JobExperienceManager.initializeExperienceTables()` にハードコード。
`giveJobExperience()` で経験値メッセージは「5.0以上」のみ表示される仕様があり、過去に「石を掘ったときにメッセージを出す」目的で STONE を 0.5→5.0 に引き上げた結果、メッセージ閾値と石の価値が癒着し、安価な鉱石(石炭2.0/RS3.0/ラピス4.0)や鉄(5.0)・銅(5.0)が石以下になっていた。

## 修正
石を地グラインドの最低基準(1.0)に戻し、全鉱石がレア度順に必ず石を上回るよう再設計。

| ブロック | 旧 | 新 |
|---|---|---|
| STONE | 5.0 | 1.0 |
| COAL_ORE | 2.0 | 2.5 |
| COPPER_ORE | 5.0 | 3.0 |
| LAPIS_ORE | 4.0 | 4.0 |
| REDSTONE_ORE | 3.0 | 4.0 |
| IRON_ORE | 5.0 | 6.0 |
| NETHER_QUARTZ_ORE | 6.0 | 7.0 |
| NETHER_GOLD_ORE | 6.0 | 7.0 |
| GOLD_ORE | 8.0 | 9.0 |
| EMERALD/DIAMOND/ANCIENT_DEBRIS | 20/25/50 | 据置 |

## スコープ外（変更なし）
- メッセージ表示閾値(5.0) … 石グラインドのスパム防止のため据置
- 収入テーブル(JobIncomeManager。現在無効化中)・マーケット売却exp
- 深層岩系は BlockNormalizer で正規化されるため自動的に新値が適用

## 検証
- `mvn clean package` 成功
- 実機: STONE→exp入るが通知なし(1.0) / COAL_ORE→石より多い(2.5) / IRON_ORE→通知あり(6.0) を確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)