### PR TITLE
feat: 中心都市までの距離・方角をサイドバーに常時表示

### DIFF
--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -1820,6 +1820,14 @@ public class ConfigManager {
         return (String) getCachedValue("scoreboard.toggle_hint.text", "&7/scoreboard off で非表示");
     }
 
+    /**
+     * スコアボードで中心都市までの距離・方角を表示するかどうか
+     * （中心都市の基準座標は spawn_location を流用する）
+     */
+    public boolean isScoreboardShowCenterCity() {
+        return config.getBoolean("scoreboard.display_settings.show_center_city", true);
+    }
+
     // ==================== 時刻放送システム設定 ====================
     
     /**

--- a/src/main/java/org/tofu/tofunomics/scoreboard/ScoreboardManager.java
+++ b/src/main/java/org/tofu/tofunomics/scoreboard/ScoreboardManager.java
@@ -270,6 +270,14 @@ public class ScoreboardManager implements Listener {
             if (showTradingHours && !tradingStatusText.isEmpty()) {
                 objective.getScore(ChatColor.GOLD + "💼 取引: " + tradingStatusText).setScore(score--);
             }
+
+            // 中心都市の距離・方角表示
+            if (configManager.isScoreboardShowCenterCity()) {
+                String centerCityText = buildCenterCityLine(player);
+                if (centerCityText != null) {
+                    objective.getScore(centerCityText).setScore(score--);
+                }
+            }
             
             // 職業経験値情報
             if (configManager.isScoreboardShowExperience() && !experienceInfo.isEmpty()) {
@@ -328,6 +336,38 @@ public class ScoreboardManager implements Listener {
     
     // 職業レベルの表示は JobLevelBossBarManager（BossBar）へ移設した。
     // XP バー（setLevel/setExp）には一切触れないことで、バニラ経験値を本来通り利用可能にしている。
+
+    /**
+     * 中心都市までの距離・方角の表示行を生成
+     * 中心都市の基準座標は spawn_location を流用する
+     * @return 表示行。プレイヤーが中心都市と別ワールドにいる場合はnull（行を出さない）
+     */
+    private String buildCenterCityLine(Player player) {
+        String cityWorld = configManager.getSpawnWorldName();
+        // 別ワールドでは距離・方角が計算できないため行を出さない
+        if (!player.getWorld().getName().equals(cityWorld)) {
+            return null;
+        }
+        double dx = configManager.getSpawnX() - player.getLocation().getX();
+        double dz = configManager.getSpawnZ() - player.getLocation().getZ();
+        long distance = Math.round(Math.sqrt(dx * dx + dz * dz));
+        String direction = getCompassDirection(dx, dz);
+        return ChatColor.LIGHT_PURPLE + "🏛 中心都市: "
+             + ChatColor.WHITE + distance + "m " + direction;
+    }
+
+    /**
+     * dx, dz から8方位（矢印＋名称）を算出
+     * Minecraft座標系: +X=東, -X=西, +Z=南, -Z=北
+     */
+    private String getCompassDirection(double dx, double dz) {
+        // 北を0とした時計回りの角度（度）
+        double angle = Math.toDegrees(Math.atan2(dx, -dz));
+        int index = (int) Math.round(angle / 45.0) & 7;
+        String[] arrows = {"↑", "↗", "→", "↘", "↓", "↙", "←", "↖"};
+        String[] names  = {"北", "北東", "東", "南東", "南", "南西", "西", "北西"};
+        return arrows[index] + names[index];
+    }
 
     /**
      * 時間をフォーマット（分 -> 時間:分）

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2147,7 +2147,9 @@ scoreboard:
     show_trading_hours: true
     # ルールコマンド表示
     show_rules_command: true
-  
+    # 中心都市までの距離・方角表示（基準座標は player_join.spawn_location を流用）
+    show_center_city: true
+
   # スコアボードに表示するルールコマンドテキスト
   rules_command_text: "&e/rules でルール確認"
 


### PR DESCRIPTION
## 概要
プレイヤーが中心都市の位置を常に把握できるよう、サイドバー（スコアボード）に「中心都市までの距離と方角」を1行で常時表示します。

例: `🏛 中心都市: 320m ↖北西`

## 背景
Minecraft 1.21.6 の本物の「ロケーターバー」へ任意地点を waypoint として追加する機能は Spigot API には存在しないため、既に全プレイヤーへ常時表示されているサイドバーへの1行追加で実現しています。

## 変更内容
- `ConfigManager.java`: `isScoreboardShowCenterCity()` getter を追加（デフォルト `true`）
- `ScoreboardManager.java`: 表示行 + 距離/方角計算ヘルパー（`buildCenterCityLine` / `getCompassDirection`）を追加
- `config.yml`: `scoreboard.display_settings.show_center_city` フラグを追加

## 仕様
- 中心都市の基準座標は既存の `player_join.spawn_location`（x:-96, y:76, z:-247 / world:tofuNomics）を流用
- 距離はY無視の水平距離、方角は8方位（矢印＋方位名）
- プレイヤーが中心都市と別ワールドにいる場合は行を出さない
- 表示 on/off は `show_center_city` で切替可能
- 計算は引き算と atan2 のみで、既存のスコアボード更新サイクルに乗せるため負荷増はほぼなし

## config 反映の注意
本プロジェクトの運用上 jar の config.yml は既存サーバーの config を上書きしません。新規キー `show_center_city` がサーバー側に無くても getter のデフォルト値 `true` で動作します。

## 検証
- [x] `mvn clean compile` 成功
- [x] config.yml YAML 構文チェック OK
- [ ] ゲーム内でサイドバー表示・距離/方角・別ワールド非表示・on/off 切替を確認（デプロイ後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)