### PR TITLE
fix: 職業レベル報酬が付与されず反映されない問題を修正

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -482,7 +482,7 @@ public final class TofuNomics extends JavaPlugin {
             jobToolManager = new JobToolManager(configManager);
             
             // JobLevelRewardManagerの初期化
-            jobLevelRewardManager = new JobLevelRewardManager(configManager, playerDAO);
+            jobLevelRewardManager = new JobLevelRewardManager(configManager, currencyConverter);
             
             // JobExperienceManagerの初期化
             jobExperienceManager = new JobExperienceManager(

--- a/src/main/java/org/tofu/tofunomics/rewards/JobLevelRewardManager.java
+++ b/src/main/java/org/tofu/tofunomics/rewards/JobLevelRewardManager.java
@@ -3,7 +3,7 @@ package org.tofu.tofunomics.rewards;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.tofu.tofunomics.config.ConfigManager;
-import org.tofu.tofunomics.dao.PlayerDAO;
+import org.tofu.tofunomics.economy.CurrencyConverter;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -42,11 +42,11 @@ public class JobLevelRewardManager {
     }
 
     private final ConfigManager configManager;
-    private final PlayerDAO playerDAO;
+    private final CurrencyConverter currencyConverter;
 
-    public JobLevelRewardManager(ConfigManager configManager, PlayerDAO playerDAO) {
+    public JobLevelRewardManager(ConfigManager configManager, CurrencyConverter currencyConverter) {
         this.configManager = configManager;
-        this.playerDAO = playerDAO;
+        this.currencyConverter = currencyConverter;
     }
 
     /**
@@ -74,24 +74,29 @@ public class JobLevelRewardManager {
             return false;
         }
 
-        giveMoney(player, amount);
+        // 残高付与が成功した場合のみメッセージを送る（DBとキャッシュの整合を保つ）
+        if (!giveMoney(player, amount)) {
+            return false;
+        }
         sendLevelUpRewardMessage(player, jobName, level, amount);
         return true;
     }
 
-    private void giveMoney(Player player, double amount) {
-        String uuid = player.getUniqueId().toString();
-        org.tofu.tofunomics.models.Player tofuPlayer = playerDAO.getPlayerByUUID(uuid);
-
-        if (tofuPlayer == null) {
-            tofuPlayer = new org.tofu.tofunomics.models.Player();
-            tofuPlayer.setUuid(uuid);
-            tofuPlayer.setBalance(configManager.getStartingBalance());
-            playerDAO.insertPlayer(tofuPlayer);
+    /**
+     * お金報酬を付与する。CurrencyConverter経由で付与し、DBとメモリキャッシュの
+     * 両方を更新する（直接DBを書き換えるとオンライン中の残高キャッシュと食い違う）。
+     *
+     * @return 付与に成功した場合true
+     */
+    private boolean giveMoney(Player player, double amount) {
+        boolean ok = currencyConverter.addBalance(player.getUniqueId(), amount);
+        if (!ok) {
+            // 残高上限到達やプレイヤー未登録などで付与できなかった場合
+            org.bukkit.Bukkit.getLogger().warning(
+                "[TofuNomics] レベルアップ報酬の付与に失敗しました: " +
+                player.getName() + " amount=" + amount);
         }
-
-        tofuPlayer.addBalance(amount);
-        playerDAO.updatePlayerData(tofuPlayer);
+        return ok;
     }
 
     private void sendLevelUpRewardMessage(Player player, String jobName, int level, double amount) {


### PR DESCRIPTION
## 概要
職業がレベルアップ（5レベルおき）した際、「★ 達成報酬 ★」メッセージは表示されるのに、報酬（お金=金塊）がプレイヤーの残高に反映されないバグを修正。

## 根本原因
`JobLevelRewardManager.giveMoney()` が `PlayerDAO` でDBを直接更新しており、`CurrencyConverter` のメモリ残高キャッシュ（`balanceCache`）を無視していた。

- オンラインプレイヤーの残高表示（`/balance` 等）はキャッシュを読むため、DBだけ更新しても**反映されない**
- さらに次の経済操作（売却・送金等）が `CurrencyConverter.addBalance()` を呼ぶと、**古いキャッシュ値ベースで再計算してDBを上書き**し、付与済みの報酬がDBからも消える

## 修正内容
- `JobLevelRewardManager` のコンストラクタを `(ConfigManager, CurrencyConverter)` に変更（未使用となる `PlayerDAO` 依存を削除）
- `giveMoney()` を `CurrencyConverter.addBalance()` 経由に置換し、DBとキャッシュの両方を更新
- 付与に成功した場合のみ報酬メッセージを送出。失敗時は警告ログを出力
- `TofuNomics.java` の初期化を新コンストラクタに合わせて更新（`currencyConverter` は既に先行生成済み）

## 検証
- `mvn clean package` でビルド成功を確認
- 実機確認手順（要サーバーデプロイ）:
  1. 就職済みプレイヤーで `/balance` を記録
  2. Lv5到達 → 報酬メッセージ表示後に残高が報酬分増えることを確認
  3. その後の売却等の経済操作で残高が巻き戻らない（報酬が消えない）ことを確認

## 影響範囲
変更は2ファイルのみ。config.yml変更なし。他機能への副作用なし（むしろ残高整合性が改善）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)