### PR TITLE
fix: 鉱夫の採掘経験値対象に黒曜石・グロウストーン等を追加

### DIFF
--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -404,6 +404,13 @@ public class UnifiedEventHandler implements Listener {
             blockType == Material.TUFF) {
             return true;
         }
+
+        // 黒曜石・グロウストーン・アメジスト（採掘経験値対象。建材として設置可能なため、
+        // 設置→採掘による無限経験値を防ぐべく追跡する）
+        if (blockType == Material.OBSIDIAN || blockType == Material.CRYING_OBSIDIAN ||
+            blockType == Material.GLOWSTONE || blockType == Material.AMETHYST_CLUSTER) {
+            return true;
+        }
         
         // 原木類
         if (blockType.name().endsWith("_LOG") || blockType.name().endsWith("_STEM")) {

--- a/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
+++ b/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
@@ -142,11 +142,15 @@ public class JobExperienceManager implements Listener {
         // 採掘経験値テーブル（レア度順。全鉱石が必ず STONE を上回るよう設計）
         miningExperience.put(Material.COAL_ORE, 2.5);
         miningExperience.put(Material.COPPER_ORE, 3.0);  // 1.17追加。安価な鉱石
+        miningExperience.put(Material.GLOWSTONE, 3.0);  // ネザーの採掘対象。容易だが採取手間あり
         miningExperience.put(Material.LAPIS_ORE, 4.0);
         miningExperience.put(Material.REDSTONE_ORE, 4.0);
+        miningExperience.put(Material.AMETHYST_CLUSTER, 4.0);  // ジオード収穫。シャードドロップ
         miningExperience.put(Material.IRON_ORE, 6.0);
         miningExperience.put(Material.NETHER_QUARTZ_ORE, 7.0);
         miningExperience.put(Material.NETHER_GOLD_ORE, 7.0);  // 1.16追加。金鉱石相当
+        miningExperience.put(Material.OBSIDIAN, 8.0);  // ダイヤピッケル必須・採掘約9.4秒の高労力
+        miningExperience.put(Material.CRYING_OBSIDIAN, 8.0);  // 黒曜石相当の労力
         miningExperience.put(Material.GOLD_ORE, 9.0);
         miningExperience.put(Material.EMERALD_ORE, 20.0);
         miningExperience.put(Material.DIAMOND_ORE, 25.0);


### PR DESCRIPTION
## 概要

鉱夫（miner）の採掘経験値テーブルから抜けていた採掘対象ブロックを追加し、採掘行為が正しく職業経験値に反映されるようにしました。あわせて、追加ブロックの設置→採掘による無限経験値ファームを防止しています。

## 背景

`JobExperienceManager` の `miningExperience` マップが鉱夫の採掘経験値対象の唯一の定義。ここに黒曜石（OBSIDIAN）等が含まれておらず、採掘できても経験値が一切入らない状態でした。

## 変更内容

### 1. 採掘経験値対象の追加（`JobExperienceManager.java`）
既存のレア度スケールに沿って4種を追加：

| ブロック | 経験値 |
|---|---|
| GLOWSTONE（グロウストーン） | 3.0 |
| AMETHYST_CLUSTER（アメジストの塊） | 4.0 |
| OBSIDIAN（黒曜石） | 8.0 |
| CRYING_OBSIDIAN（泣く黒曜石） | 8.0 |

### 2. 無限経験値ファーム防止（`UnifiedEventHandler.java`）
追加4種を `shouldTrackPlacedBlock` の追跡対象に追加。`STONE`/`COBBLESTONE` と同様、設置は可能だが**自分で設置したブロックを壊しても経験値は入らない**。

## 動作確認

- ✅ 自然生成の黒曜石/グロウストーン等を採掘 → 経験値が入る
- ✅ 設置した黒曜石を採掘 → 経験値が入らない（ファーム防止）
- ✅ 既存鉱石の経験値は従来通り（リグレッションなし）
- ✅ Lobby 1.21 サーバーへデプロイし実機確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)