### PR TITLE
fix: 骨粉で成長させた作物の農家経験値が入らない問題を修正

### DIFF
--- a/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
+++ b/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
@@ -3,13 +3,16 @@ package org.tofu.tofunomics.experience;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.data.Ageable;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockFertilizeEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
@@ -488,6 +491,32 @@ public class JobExperienceManager implements Listener {
     }
 
     /**
+     * 骨粉（ボーンミール）による作物成長で農家経験値を付与する。
+     * 骨粉成長は BlockGrowEvent ではなく BlockFertilizeEvent を発火するため、
+     * 収穫経路（onBlockBreak）と同じ farmingExperience / 付与処理を再利用して経験値を与える。
+     * 完全成長に達した作物のみを対象とし、半端な骨粉連打による無限ファーミングと
+     * 収穫経験値との過度な二重取りを抑える（おおむね作物1サイクルあたり1回の付与）。
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockFertilize(BlockFertilizeEvent event) {
+        Player player = event.getPlayer();
+        // ディスペンサー等による自動骨粉（プレイヤー不在）は対象外
+        if (player == null || !jobManager.hasJob(player, "farmer")) {
+            return;
+        }
+
+        for (BlockState state : event.getBlocks()) {
+            // 深層岩鉱石等の正規化と同じ前処理（作物は通常そのまま）
+            Material material = org.tofu.tofunomics.util.BlockNormalizer.normalizeForJob(state.getType());
+            if (farmingExperience.containsKey(material) && isCropDataFullyGrown(material, state.getBlockData())) {
+                double baseExp = farmingExperience.get(material);
+                double multipliedExp = applyJobMultiplier(player, "farmer", baseExp);
+                giveJobExperience(player, "farmer", multipliedExp);
+            }
+        }
+    }
+
+    /**
      * 作物が「完全に成長した状態」かを判定する。
      * 成長段階を持つ作物（小麦・ニンジン・ジャガイモ・ビートルート・ネザーウォート・ココア）は
      * 最大成熟度に達している場合のみtrue。
@@ -497,10 +526,24 @@ public class JobExperienceManager implements Listener {
      * @return 収穫経験値の付与対象ならtrue
      */
     static boolean isCropFullyGrown(Block block) {
-        if (block == null || !MATURITY_REQUIRED_CROPS.contains(block.getType())) {
+        if (block == null) {
             return true;
         }
-        BlockData data = block.getBlockData();
+        return isCropDataFullyGrown(block.getType(), block.getBlockData());
+    }
+
+    /**
+     * 作物の種別と BlockData から「完全に成長した状態」かを判定する。
+     * BlockState（成長後の状態）からも判定できるよう、Block 依存を分離したヘルパー。
+     *
+     * @param material  作物の種別
+     * @param data      対象ブロックの BlockData
+     * @return 経験値付与対象（完全成長または成熟概念なし）ならtrue
+     */
+    static boolean isCropDataFullyGrown(Material material, BlockData data) {
+        if (material == null || !MATURITY_REQUIRED_CROPS.contains(material)) {
+            return true;
+        }
         if (data instanceof Ageable) {
             Ageable ageable = (Ageable) data;
             return ageable.getAge() >= ageable.getMaximumAge();

--- a/src/test/java/org/tofu/tofunomics/experience/JobExperienceManagerCropMaturityTest.java
+++ b/src/test/java/org/tofu/tofunomics/experience/JobExperienceManagerCropMaturityTest.java
@@ -3,6 +3,7 @@ package org.tofu.tofunomics.experience;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.Ageable;
+import org.bukkit.block.data.BlockData;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -60,5 +61,36 @@ public class JobExperienceManagerCropMaturityTest {
     @Test
     public void testNullBlockReturnsTrue() {
         assertTrue(JobExperienceManager.isCropFullyGrown(null));
+    }
+
+    private BlockData mockAgeable(int age, int maxAge) {
+        Ageable data = mock(Ageable.class);
+        when(data.getAge()).thenReturn(age);
+        when(data.getMaximumAge()).thenReturn(maxAge);
+        return data;
+    }
+
+    @Test
+    public void testCropDataFullyGrown_matureReturnsTrue() {
+        // 骨粉成長経路で使う BlockData ベースの成熟判定（完全成長）
+        assertTrue(JobExperienceManager.isCropDataFullyGrown(Material.WHEAT, mockAgeable(7, 7)));
+        assertTrue(JobExperienceManager.isCropDataFullyGrown(Material.CARROTS, mockAgeable(7, 7)));
+        assertTrue(JobExperienceManager.isCropDataFullyGrown(Material.BEETROOTS, mockAgeable(3, 3)));
+    }
+
+    @Test
+    public void testCropDataFullyGrown_immatureReturnsFalse() {
+        // 骨粉で半端に成長した作物は経験値対象外
+        assertFalse(JobExperienceManager.isCropDataFullyGrown(Material.WHEAT, mockAgeable(5, 7)));
+        assertFalse(JobExperienceManager.isCropDataFullyGrown(Material.POTATOES, mockAgeable(3, 7)));
+        assertFalse(JobExperienceManager.isCropDataFullyGrown(Material.NETHER_WART, mockAgeable(2, 3)));
+    }
+
+    @Test
+    public void testCropDataFullyGrown_nonMaturityCropAlwaysTrue() {
+        // 成熟概念のない作物・nullは常に対象（BlockDataを参照しない）
+        assertTrue(JobExperienceManager.isCropDataFullyGrown(Material.PUMPKIN, null));
+        assertTrue(JobExperienceManager.isCropDataFullyGrown(Material.SUGAR_CANE, null));
+        assertTrue(JobExperienceManager.isCropDataFullyGrown(null, null));
     }
 }


### PR DESCRIPTION
## 概要
農家が骨粉（ボーンミール）で作物を成長させても農家経験値が取得できない問題を修正します。

## 根本原因
農家経験値の付与経路は設計上2つあるが、骨粉はどちらにも乗っていなかった:

1. **収穫経路（実働）** `JobExperienceManager.onBlockBreak` — リスナー直接登録で動作する唯一の実働経路。
2. **成長経路（デッド）** `GrowthEventHandler#handleBlockGrow`（`BlockGrowEvent`）— `EventProcessor.extractPlayer()` が `BlockGrowEvent` から player を抽出できず常に弾かれ、実行されない。

骨粉成長は Minecraft 1.21 で **`BlockFertilizeEvent`** を発火する（`BlockGrowEvent` は発火しない）が、プラグイン全体にそのリスナーが存在しなかったため、骨粉成長は完全に無視されていた。

## 修正内容
- `JobExperienceManager` に `onBlockFertilize(BlockFertilizeEvent)` を追加。
- 実働している収穫経路と同じ `farmingExperience` / `applyJobMultiplier` / `giveJobExperience` を再利用し、DB更新・BossBar反映・レベルアップ判定・食事バフ倍率まで一貫させる。
- **完全成長に達した作物のみ** を対象にゲート（`isCropDataFullyGrown`）。半端な骨粉連打による無限ファーミングと収穫経験値との過度な二重取りを抑制。
- ディスペンサー等による自動骨粉（プレイヤー不在）は対象外。

## スコープ外
- デッドな `BlockGrowEvent` 自然成長経路（`EventProcessor.extractPlayer` の不備）は今回触らない。修正すると成長tickごとに大量の経験値が入りバランスが激変するため、別タスクとして切り離す。収穫経路が実働しているため自然成長作物の経験値は現状でも収穫時に正しく入る。

## テスト
- `JobExperienceManagerCropMaturityTest` に `isCropDataFullyGrown`（BlockDataベースの成熟判定）のテストを追加。全7テスト通過。
- `mvn clean package` ビルド成功。

## 動作確認（要ゲーム内）
- [ ] 農家で小麦の種を植え、骨粉で完全成長させる → 農家経験値が増加する
- [ ] 自然成長→収穫の経験値が従来通り入る（リグレッション確認）
- [ ] 非農家・クリエイティブで意図せぬ付与がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)