### PR TITLE
refactor: 売却処理のレビュー指摘対応（堅牢化・デッドコード除去・メッセージ整理）

### DIFF
--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -2735,9 +2735,11 @@ public class ConfigManager {
             // 取引NPC基本メッセージを確保
             ensureMessagePath("messages.npc.trading.no_job", 
                 "&c職業に就いていません。/jobs join <職業名> で職業に就いてからご利用ください。");
-            ensureMessagePath("messages.npc.trading.job_not_accepted", 
+            ensureMessagePath("messages.npc.trading.job_not_accepted",
                 "&c申し訳ありませんが、あなたの職業（%job%）では当店をご利用いただけません。");
-            
+            ensureMessagePath("messages.npc.trading.banked_overflow",
+                "&e%amount%枚は所持枠が満杯のため口座に入金しました。");
+
             // central_market固有メッセージを確保
             ensureMessageListPath("messages.npc.trading.npc_specific.central_market.no_job", 
                 java.util.Arrays.asList(

--- a/src/main/java/org/tofu/tofunomics/economy/CurrencyConverter.java
+++ b/src/main/java/org/tofu/tofunomics/economy/CurrencyConverter.java
@@ -313,7 +313,13 @@ public class CurrencyConverter {
 
         // 入りきらなかった分を銀行口座へ入金（金塊1枚=残高1の1:1換算）
         if (leftover > 0) {
-            addBalance(player.getUniqueId(), convertNuggetsToBalance(leftover));
+            boolean banked = addBalance(player.getUniqueId(), convertNuggetsToBalance(leftover));
+            if (!banked) {
+                // 口座未登録などで入金に失敗すると代金消失となるため警告ログを残す
+                org.bukkit.Bukkit.getLogger().warning(
+                    "[CurrencyConverter] 口座フォールバック入金に失敗しました（口座未登録の可能性）: "
+                    + player.getName() + " 金塊" + leftover + "枚");
+            }
         }
 
         return leftover;

--- a/src/main/java/org/tofu/tofunomics/economy/ItemManager.java
+++ b/src/main/java/org/tofu/tofunomics/economy/ItemManager.java
@@ -455,25 +455,31 @@ public class ItemManager {
         PlayerInventory inventory = player.getInventory();
         int remaining = amount;
 
-        while (remaining > 0) {
-            int stackSize = Math.min(remaining, Material.GOLD_NUGGET.getMaxStackSize());
-            ItemStack goldNugget = createGoldNugget(stackSize);
+        try {
+            while (remaining > 0) {
+                int stackSize = Math.min(remaining, Material.GOLD_NUGGET.getMaxStackSize());
+                ItemStack goldNugget = createGoldNugget(stackSize);
 
-            HashMap<Integer, ItemStack> leftover = inventory.addItem(goldNugget);
+                HashMap<Integer, ItemStack> leftover = inventory.addItem(goldNugget);
 
-            // このスタックで入りきらなかった枚数を集計
-            int notAdded = 0;
-            for (ItemStack item : leftover.values()) {
-                notAdded += item.getAmount();
+                // このスタックで入りきらなかった枚数を集計
+                int notAdded = 0;
+                for (ItemStack item : leftover.values()) {
+                    notAdded += item.getAmount();
+                }
+
+                // 実際にインベントリへ入った枚数を残数から減算
+                remaining -= (stackSize - notAdded);
+
+                // 入りきらない分が出た時点でインベントリは満杯。残りはすべて口座行き
+                if (notAdded > 0) {
+                    break;
+                }
             }
-
-            // 実際にインベントリへ入った枚数を残数から減算
-            remaining -= (stackSize - notAdded);
-
-            // 入りきらない分が出た時点でインベントリは満杯。残りはすべて口座行き
-            if (notAdded > 0) {
-                break;
-            }
+        } catch (RuntimeException e) {
+            // 金塊付与中の予期せぬ例外。インベントリへ入った分はそのまま維持し、未付与の
+            // 残数は呼び出し元（receiveCashWithBankFallback）で口座へ回し代金の取りこぼしを防ぐ
+            org.bukkit.Bukkit.getLogger().warning("[ItemManager] addGoldNuggetsWithLeftover failed with exception: " + e.getMessage());
         }
 
         return remaining;

--- a/src/main/java/org/tofu/tofunomics/economy/ItemManager.java
+++ b/src/main/java/org/tofu/tofunomics/economy/ItemManager.java
@@ -478,8 +478,10 @@ public class ItemManager {
             }
         } catch (RuntimeException e) {
             // 金塊付与中の予期せぬ例外。インベントリへ入った分はそのまま維持し、未付与の
-            // 残数は呼び出し元（receiveCashWithBankFallback）で口座へ回し代金の取りこぼしを防ぐ
-            org.bukkit.Bukkit.getLogger().warning("[ItemManager] addGoldNuggetsWithLeftover failed with exception: " + e.getMessage());
+            // 残数は呼び出し元（receiveCashWithBankFallback）で口座へ回し代金の取りこぼしを防ぐ。
+            // 障害調査のためスタックトレースも記録する。
+            org.bukkit.Bukkit.getLogger().log(java.util.logging.Level.WARNING,
+                "[ItemManager] addGoldNuggetsWithLeftover failed with exception", e);
         }
 
         return remaining;

--- a/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
@@ -658,62 +658,6 @@ public class TradingNPCManager {
         }
     }
 
-    // スペースチェックスキップオプション付きのアイテム売却処理
-    public TradeResult processItemSale(Player player, UUID npcId, List<ItemStack> items, boolean skipSpaceCheck) {
-        TradingPost tradingPost = getTradingPostByNPCId(npcId);
-        if (tradingPost == null) {
-            return new TradeResult(false, "取引所が見つかりません", 0.0, new HashMap<>());
-        }
-        
-        String playerJob = jobManager.getPlayerJob(player.getUniqueId());
-        if (!tradingPost.acceptsJob(playerJob)) {
-            return new TradeResult(false, "この取引所を利用する権限がありません", 0.0, new HashMap<>());
-        }
-        
-        Map<Material, Integer> soldItems = new HashMap<>();
-        double totalEarnings = 0.0;
-        
-        for (ItemStack item : items) {
-            if (item == null || item.getType() == Material.AIR) continue;
-            
-            Material material = item.getType();
-            double basePrice = tradingPost.getItemPrice(material);
-            
-            if (basePrice > 0) {
-                int amount = item.getAmount();
-                // 職業ボーナスは職業専用取引所でのみ適用（総合取引所では素のitem_prices×1.0）
-                String effectiveJob = tradingPost.isGeneralStore() ? null : playerJob;
-                double finalPrice = tradePriceManager.calculateFinalPrice(material.toString().toLowerCase(), effectiveJob, basePrice);
-
-                // 木こりが原木を売る場合は価格を2倍に（職業専用取引所のみ）
-                if (!tradingPost.isGeneralStore() && isWoodcutter(player) && isLogItem(material)) {
-                    finalPrice *= 2.0;
-                    plugin.getLogger().info("木こりボーナス適用: " + material + " の価格を2倍に");
-                }
-                
-                // アイテム単位では切り捨てず、合計に端数を累積する
-                // （安価アイテムが floor で0になり売却不能になるのを防ぐ）
-                totalEarnings += finalPrice * amount;
-                soldItems.put(material, soldItems.getOrDefault(material, 0) + amount);
-            }
-        }
-
-        // 累積した合計を通貨換算（四捨五入）。1コイン以上で売却成立
-        int payableNuggets = currencyConverter.convertBalanceToNuggets(totalEarnings);
-        if (payableNuggets > 0) {
-            // 入る分は金塊で受け取り、入りきらない分は口座へ自動入金（満杯でも代金を取りこぼさない）
-            // skipSpaceCheck は新方式では不要（部分追加＋口座フォールバックで満杯を吸収）
-            int bankedNuggets = currencyConverter.receiveCashWithBankFallback(player, payableNuggets);
-
-            return new TradeResult(true, "取引が完了しました", payableNuggets, soldItems, bankedNuggets);
-        } else if (!soldItems.isEmpty()) {
-            // 売却対象はあったが、合計額が安すぎて1コインに満たない
-            return new TradeResult(false, "売却額が少なすぎます。もう少しまとめて売却してください", 0.0, new HashMap<>());
-        } else {
-            return new TradeResult(false, "売却可能なアイテムがありませんでした", 0.0, new HashMap<>());
-        }
-    }
-    
     public static class TradeResult {
         private final boolean success;
         private final String message;

--- a/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
@@ -930,11 +930,9 @@ public class TradingGUI implements Listener {
         
         // 売却処理を実行（満杯分は口座へフォールバックするためスペースチェックは行わない）
         TradingNPCManager.TradeResult result = tradingNPCManager.processItemSale(
-            player, 
-            tradingPost.getNpcId(), 
-            itemsToSell,
-            true  // skipSpaceCheck = true
-        );
+            player,
+            tradingPost.getNpcId(),
+            itemsToSell);
         
         if (result.isSuccess()) {
             // 成功 - アイテムは既に削除済み
@@ -942,7 +940,8 @@ public class TradingGUI implements Listener {
             player.sendMessage(configManager.getMessage("npc.trading.sale_success", "total", earnings));
             // 所持枠が満杯で金塊が入りきらなかった分は口座へ入金済みであることを通知
             if (result.getBankedNuggets() > 0) {
-                player.sendMessage("§e" + result.getBankedNuggets() + "枚は所持枠が満杯のため口座に入金しました");
+                player.sendMessage(configManager.getMessage("npc.trading.banked_overflow",
+                    "amount", result.getBankedNuggets()));
             }
         } else {
             // 失敗 - アイテムをロールバック
@@ -1073,11 +1072,9 @@ public class TradingGUI implements Listener {
         
         // 売却処理を実行（満杯分は口座へフォールバックするためスペースチェックは行わない）
         TradingNPCManager.TradeResult result = tradingNPCManager.processItemSale(
-            player, 
-            tradingPost.getNpcId(), 
-            allItems,
-            true  // skipSpaceCheck = true
-        );
+            player,
+            tradingPost.getNpcId(),
+            allItems);
         
         if (result.isSuccess()) {
             // 成功 - アイテムは既に削除済み
@@ -1087,7 +1084,8 @@ public class TradingGUI implements Listener {
                 "count", String.valueOf(result.getSoldItems().values().stream().mapToInt(Integer::intValue).sum())));
             // 所持枠が満杯で金塊が入りきらなかった分は口座へ入金済みであることを通知
             if (result.getBankedNuggets() > 0) {
-                player.sendMessage("§e" + result.getBankedNuggets() + "枚は所持枠が満杯のため口座に入金しました");
+                player.sendMessage(configManager.getMessage("npc.trading.banked_overflow",
+                    "amount", result.getBankedNuggets()));
             }
         } else {
             // 失敗 - アイテムをロールバック

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2330,7 +2330,8 @@ messages:
       no_sellable_items: "&c売却可能なアイテムがありませんでした。"
       sale_success: "&a売却完了！ &f%total% &a獲得しました。"
       sell_all_success: "&a一括売却完了！ &f%count%個のアイテム &aを売却し、&f%total% &a獲得しました。"
-      
+      banked_overflow: "&e%amount%枚は所持枠が満杯のため口座に入金しました。"
+
       # 取引所別の個性的なメッセージ
       npc_specific:
         central_market:


### PR DESCRIPTION
## 概要
PR #87 のコードレビューで挙がったフォローアップ指摘に対応します。

### 要修正2: `addGoldNuggetsWithLeftover` の例外耐性
金塊付与ループを try-catch で囲み、`inventory.addItem` 等が予期せぬ実行時例外を投げた場合でも、インベントリに入った分は維持しつつ未付与の残数を返すようにしました。呼び出し元の `receiveCashWithBankFallback` がこの残数を口座へ入金するため、**代金（金塊）の消失を防止**します。例外時はログを出力。

### 軽微3: `skipSpaceCheck` デッドコード引数の整理
`processItemSale(player, npcId, items, boolean skipSpaceCheck)` は中身が3引数版と同一で `skipSpaceCheck` が未使用だったため、**オーバーロードを削除して3引数版へ統一**。呼び出し元（TradingGUI の個別売却・一括売却の2箇所）も更新。

### 軽微1: 口座入金通知メッセージの config 化
ハードコードしていた通知を `messages.npc.trading.banked_overflow` へ移行し、`configManager.getMessage` 経由に統一。`ensureNPCMessagesExist` に自動補完を追加したため、**サーバー側の手動 config 編集は不要**（reload 時に自動でキーが追加される）。

> 軽微2（`CAVE_VINES` 先端ブロックの挙動）はコードでなくゲーム内動作確認の事項のため対象外。

## テスト
- `mvn clean package` ビルド成功、全テスト Failures 0 / Errors 0
- 既存の売却・口座フォールバックの挙動は不変（リファクタ＋堅牢化のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)