### PR TITLE
config: 農家作物の買取価格をレアリティ順に再設計

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1830,16 +1830,18 @@ npc_system:
     oak_planks: 0.12
     birch_planks: 0.12
     spruce_planks: 0.12
-    # 農作物系（リリース前バランス調整: 成長待機時間を考慮し増額）
-    wheat: 1.2
-    potato: 0.9
-    carrot: 0.9
-    beetroot: 1.2
-    pumpkin: 2
-    melon: 1.5
-    sugar_cane: 0.8
-    cocoa_beans: 1.5
-    nether_wart: 2
+    # 農作物系（バランス調整: レアリティ順の階段に再設計。小麦=最安基準）
+    # 最安(3): 小麦・ビートルート・サトウキビ / 中(4): じゃがいも・にんじん・メロン
+    # 上(5): かぼちゃ・カカオ豆 / 最高(6): ネザーウォート
+    wheat: 3
+    potato: 4
+    carrot: 4
+    beetroot: 3
+    pumpkin: 5
+    melon: 4
+    sugar_cane: 3
+    cocoa_beans: 5
+    nether_wart: 6
     # 畜産物
     beef: 2
     porkchop: 2
@@ -1933,8 +1935,9 @@ npc_system:
     cherry_sapling: 0.7
     mangrove_propagule: 0.7
     # --- farmer: 作物・種・畜産・染料植物 ---
-    melon_slice: 0.3
+    melon_slice: 1.0
     glow_berries: 1.0
+    sweet_berries: 1
     apple: 1.5
     wheat_seeds: 0.1
     beetroot_seeds: 0.1


### PR DESCRIPTION
## 概要
農家が売却する作物の買取価格が全職種で最安帯だったため、**小麦を最安の基準作物（鉱夫でいう石ポジション）とするレアリティ順の階段**に価格を組み直します。あわせてスイートベリーを売却可能化します。

## 背景
本番の売却単価は `最終単価 = 基本価格(item_prices) × 職業倍率 × グローバル倍率`。農家の職業倍率・グローバル倍率はともに 1.0 のため、**作物は `item_prices` の値がそのまま最終単価**になります。鉱夫（鉄7.2/ダイヤ42）等と比べ作物が極端に安く、成長待機・収穫の手間に見合っていませんでした。

## 価格設計（金塊/個）
| 段 | アイテム | 旧 → 新 |
|---|---|---|
| 最安(3) | 小麦 (wheat) | 1.2 → **3** |
| 最安(3) | ビートルート (beetroot) | 1.2 → **3** |
| 最安(3) | サトウキビ (sugar_cane) | 0.8 → **3** |
| 中(4) | じゃがいも (potato) | 0.9 → **4** |
| 中(4) | にんじん (carrot) | 0.9 → **4** |
| 中(4) | メロン塊 (melon) | 1.5 → **4** |
| 上(5) | かぼちゃ (pumpkin) | 2 → **5** |
| 上(5) | カカオ豆 (cocoa_beans) | 1.5 → **5** |
| 最高(6) | ネザーウォート (nether_wart) | 2 → **6** |
| - | スイカ片 (melon_slice) | 0.3 → **1.0** |
| - | スイートベリー (sweet_berries) | （価格なし）→ **1**（新規・売却可能化） |

- 序列の考え方: 小麦＝最も基本（最安基準）、ネザーウォート＝最レア（最高）。ビートルートは用途が少ないため最安段、サトウキビは入手容易なため最安段に配置。
- **sweet_berries** は取引所の `items` には載っていたが価格未定義で実質売却不可だった。価格を追加して売却可能にする。
- glow_berries(1.0)・honey系(honey_bottle 2 / honeycomb 2)は登録済みのため変更なし。
- 種・花・畜産物は据え置き。農家の職業倍率(1.0)は変更しない。

## 注意（本番反映）
jarのconfigは稼働中サーバーのconfig.ymlを上書きしないため、本変更は**ssh lobby（lobby-1.21）のサーバーconfig.ymlへ別途ピンポイント反映済み**です（要 `/tofunomics reload`）。

## 動作確認
- [x] YAML構文チェック（OK）
- [x] サーバー実値とリポジトリ値の一致を確認
- [ ] reload後、農家取引所で各作物が新単価で売却できること（例: 小麦64個 = 192金塊）
- [ ] スイートベリーが売却できること
- [ ] 種・花・畜産物が据え置きのままであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
