### PR TITLE
農家NPCの買取アイテムにhoney_blockを追加

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -835,6 +835,7 @@ npc_system:
     hay_block: 10
     honeycomb: 2
     honey_bottle: 2
+    honey_block: 8
     brown_mushroom: 0.5
     red_mushroom: 0.5
     poppy: 0.3


### PR DESCRIPTION
## 概要
農家NPCに売却できるアイテムへ `honey_block`（ハチミツブロック）を追加します。

## 背景
- `honey_bottle`（はちみつ瓶）と `honeycomb`（ハニカム）は既に売却可能（買取2金塊）。
- `honey_block` のみ未登録だったため追加。

## 変更内容
- `src/main/resources/config.yml` の `npc_system.item_prices` に `honey_block: 8` を追加。
- 価格根拠: `honey_bottle`（2金塊）×4本でクラフトするため、クラフト等価の8金塊。固めて売っても損得なしの中立バランス。
- `honey_bottle` / `honeycomb` の価格は据え置き。

## 残作業（サーバー側・本PR対象外）
農家NPCは `trading_posts` の `items` を明示列挙しているため、実際に売却可能にするにはサーバー上の `config.yml` の各farmer NPCの `items` リストにも `honey_block` を追記する必要あり（NPC座標等を含むサーバー固有設定のためssh経由でピンポイント編集）。

## 検証
- [x] YAML構文チェック（`yaml.safe_load` OK）
- [ ] ビルド（`mvn clean package`）
- [ ] ゲーム内で農家NPCに8金塊で売却できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)