### PR TITLE
feat: 農家の経験値トリガーを追加（毛刈り・卵孵化・コンポスター）

### DIFF
--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -19,8 +19,10 @@ import org.bukkit.event.entity.EntityBreedEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.inventory.BrewEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
+import org.bukkit.event.player.PlayerEggThrowEvent;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerShearEntityEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -58,6 +60,7 @@ public class UnifiedEventHandler implements Listener {
     private final org.tofu.tofunomics.events.handlers.BreedingEventHandler breedingHandler;
     private final org.tofu.tofunomics.events.handlers.GrowthEventHandler growthHandler;
     private final org.tofu.tofunomics.events.handlers.BuildingEventHandler buildingHandler;
+    private final org.tofu.tofunomics.events.handlers.FarmingActivityEventHandler farmingActivityHandler;
     
     // 既存のハンドラ参照
     private final org.tofu.tofunomics.experience.JobExperienceManager experienceManager;
@@ -109,6 +112,9 @@ public class UnifiedEventHandler implements Listener {
             configManager, playerDAO, jobManager, asyncUpdater
         );
         this.buildingHandler = new org.tofu.tofunomics.events.handlers.BuildingEventHandler(
+            configManager, playerDAO, jobManager, asyncUpdater
+        );
+        this.farmingActivityHandler = new org.tofu.tofunomics.events.handlers.FarmingActivityEventHandler(
             configManager, playerDAO, jobManager, asyncUpdater
         );
     }
@@ -357,7 +363,54 @@ public class UnifiedEventHandler implements Listener {
         // キャッシュに記録
         eventCache.markAsProcessed(player, "player_fish");
     }
-    
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerShear(PlayerShearEntityEvent event) {
+        if (!shouldProcessEvent(event)) return;
+
+        Player player = event.getPlayer();
+
+        // キャッシュチェック
+        if (eventCache.isRecentlyProcessed(player, "player_shear", 500)) {
+            return;
+        }
+
+        // 農家専用処理（羊毛・キノコ牛の刈り取り）
+        farmingActivityHandler.handleShear(event);
+
+        // キャッシュに記録
+        eventCache.markAsProcessed(player, "player_shear");
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerEggThrow(PlayerEggThrowEvent event) {
+        if (!shouldProcessEvent(event)) return;
+
+        Player player = event.getPlayer();
+
+        // キャッシュチェック
+        if (eventCache.isRecentlyProcessed(player, "egg_throw", 500)) {
+            return;
+        }
+
+        // 農家専用処理（卵の孵化）
+        farmingActivityHandler.handleEggHatch(event);
+
+        // キャッシュに記録
+        eventCache.markAsProcessed(player, "egg_throw");
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerInteractComposter(PlayerInteractEvent event) {
+        if (!shouldProcessEvent(event)) return;
+
+        // 農家専用処理（コンポスターの骨粉生成）
+        // 満杯(LEVEL 8)の取り出し時のみ成立し、取り出すとLEVEL 0になるため
+        // 1操作で1回しか経験値が入らない。材料消費も伴うためキャッシュ不要。
+        // 両手分の二重発火はハンドラ側でメインハンド限定にして防ぐ。
+        farmingActivityHandler.handleComposterHarvest(event);
+    }
+
     // ========== ユーティリティメソッド ==========
     
     /**

--- a/src/main/java/org/tofu/tofunomics/events/handlers/FarmingActivityEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/handlers/FarmingActivityEventHandler.java
@@ -1,0 +1,182 @@
+package org.tofu.tofunomics.events.handlers;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Levelled;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.MushroomCow;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Sheep;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerEggThrowEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerShearEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.PlayerDAO;
+import org.tofu.tofunomics.events.AsyncEventUpdater;
+import org.tofu.tofunomics.jobs.JobManager;
+import org.tofu.tofunomics.models.PlayerJob;
+
+/**
+ * 農家の補助アクション経験値ハンドラ
+ * 羊毛の毛刈り・卵の孵化・コンポスターでの骨粉生成を処理する。
+ * 既存の BreedingEventHandler / GrowthEventHandler と同じく
+ * AsyncEventUpdater 経由で農家の経験値を非同期付与する。
+ */
+public class FarmingActivityEventHandler {
+
+    private final ConfigManager configManager;
+    private final PlayerDAO playerDAO;
+    private final JobManager jobManager;
+    private final AsyncEventUpdater asyncUpdater;
+
+    // 各アクションの基準経験値（farmingExperience テーブルと同じ流儀のハードコード）
+    private static final double SHEAR_SHEEP_EXP = 1.5;       // 羊毛の毛刈り
+    private static final double SHEAR_MUSHROOM_COW_EXP = 1.5; // キノコ牛のキノコ刈り
+    private static final double EGG_HATCH_EXP = 2.0;          // 卵の孵化（1匹あたり）
+    private static final double COMPOSTER_EXP = 2.0;          // コンポスター骨粉生成
+
+    // コンポスター満杯（骨粉が取り出せる状態）のレベル
+    private static final int COMPOSTER_READY_LEVEL = 8;
+
+    public FarmingActivityEventHandler(ConfigManager configManager, PlayerDAO playerDAO,
+                                       JobManager jobManager, AsyncEventUpdater asyncUpdater) {
+        this.configManager = configManager;
+        this.playerDAO = playerDAO;
+        this.jobManager = jobManager;
+        this.asyncUpdater = asyncUpdater;
+    }
+
+    /**
+     * 毛刈りイベントの処理（羊毛・キノコ牛）
+     */
+    public void handleShear(PlayerShearEntityEvent event) {
+        Player player = event.getPlayer();
+        Entity target = event.getEntity();
+
+        double baseExp;
+        String displayName;
+
+        if (target instanceof Sheep) {
+            Sheep sheep = (Sheep) target;
+            // 既に毛が刈られている羊は対象外（スパム防止。草を食べて再生後に再取得可能）
+            if (sheep.isSheared()) {
+                return;
+            }
+            baseExp = SHEAR_SHEEP_EXP;
+            displayName = "羊毛の刈り取り";
+        } else if (target instanceof MushroomCow) {
+            baseExp = SHEAR_MUSHROOM_COW_EXP;
+            displayName = "キノコの刈り取り";
+        } else {
+            // 羊・キノコ牛以外（雪ゴーレム等）は対象外
+            return;
+        }
+
+        PlayerJob farmerJob = getActiveFarmerJob(player);
+        if (farmerJob == null) {
+            return;
+        }
+
+        double finalExp = baseExp * getLevelMultiplier(farmerJob);
+        giveFarmerExperience(player, finalExp, displayName);
+    }
+
+    /**
+     * 卵の孵化イベントの処理
+     */
+    public void handleEggHatch(PlayerEggThrowEvent event) {
+        // 投げた卵が孵化しなかった場合は対象外
+        if (!event.isHatching() || event.getNumHatches() <= 0) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        PlayerJob farmerJob = getActiveFarmerJob(player);
+        if (farmerJob == null) {
+            return;
+        }
+
+        // 孵化した匹数を加味（getNumHatches は byte）
+        double baseExp = EGG_HATCH_EXP * event.getNumHatches();
+        double finalExp = baseExp * getLevelMultiplier(farmerJob);
+        giveFarmerExperience(player, finalExp, "卵の孵化");
+    }
+
+    /**
+     * コンポスターの骨粉取り出しイベントの処理
+     * 満杯（LEVEL 8）のコンポスターを右クリックした時を「骨粉生成」とみなす。
+     */
+    public void handleComposterHarvest(PlayerInteractEvent event) {
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+        // 両手分の二重発火を防ぐためメインハンドのみ処理
+        if (event.getHand() != EquipmentSlot.HAND) {
+            return;
+        }
+
+        Block block = event.getClickedBlock();
+        if (block == null || block.getType() != Material.COMPOSTER) {
+            return;
+        }
+
+        // 満杯（骨粉が取り出せる）状態のみ対象
+        BlockData data = block.getBlockData();
+        if (!(data instanceof Levelled)) {
+            return;
+        }
+        if (((Levelled) data).getLevel() != COMPOSTER_READY_LEVEL) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        PlayerJob farmerJob = getActiveFarmerJob(player);
+        if (farmerJob == null) {
+            return;
+        }
+
+        double finalExp = COMPOSTER_EXP * getLevelMultiplier(farmerJob);
+        giveFarmerExperience(player, finalExp, "堆肥づくり");
+    }
+
+    /**
+     * アクティブな農家職業を取得（非農家・非アクティブは null）
+     */
+    private PlayerJob getActiveFarmerJob(Player player) {
+        PlayerJob farmerJob = jobManager.getPlayerJob(player, "farmer");
+        if (farmerJob == null || !farmerJob.isActive()) {
+            return null;
+        }
+        return farmerJob;
+    }
+
+    /**
+     * レベルボーナス倍率（レベル毎に2%。BreedingEventHandler の流儀に準拠）
+     */
+    private double getLevelMultiplier(PlayerJob farmerJob) {
+        return 1.0 + (farmerJob.getLevel() * 0.02);
+    }
+
+    /**
+     * 農家経験値を非同期付与し、一定量以上で通知する
+     */
+    private void giveFarmerExperience(Player player, double experience, String displayName) {
+        if (experience <= 0) {
+            return;
+        }
+
+        asyncUpdater.updateJobExperience(player.getUniqueId().toString(), "farmer", experience);
+
+        // 経験値5以上の場合のみ通知（小さな獲得でチャットを埋めない）
+        if (experience >= 5.0) {
+            player.sendMessage(String.format(
+                "%s%s成功！ §a+%.1f経験値",
+                ChatColor.GREEN, displayName, experience
+            ));
+        }
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/events/handlers/FarmingActivityEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/handlers/FarmingActivityEventHandler.java
@@ -171,12 +171,11 @@ public class FarmingActivityEventHandler {
 
         asyncUpdater.updateJobExperience(player.getUniqueId().toString(), "farmer", experience);
 
-        // 経験値5以上の場合のみ通知（小さな獲得でチャットを埋めない）
-        if (experience >= 5.0) {
-            player.sendMessage(String.format(
-                "%s%s成功！ §a+%.1f経験値",
-                ChatColor.GREEN, displayName, experience
-            ));
-        }
+        // 毛刈り・卵孵化・コンポスターは頻度の低い意図的アクションのため、
+        // 獲得量に関わらず必ず通知する（BreedingEventHandler と同じ挙動）。
+        player.sendMessage(String.format(
+            "%s%s成功！ §a+%.1f経験値",
+            ChatColor.GREEN, displayName, experience
+        ));
     }
 }


### PR DESCRIPTION
## 概要

農家職業の経験値取得アクションを拡張し、畜産・農業の自然なアクションを経験値に反映します。

## 背景

農家は現在、作物収穫・骨粉成長・右クリック採取・マーケット売却・**動物の繁殖**（既存実装）で経験値を得られますが、毛刈り・卵孵化・堆肥化では経験値が入らず、農家プレイの幅が成長に反映されていませんでした。

## 追加したトリガー

| トリガー | Bukkitイベント | 対象 | 基準経験値 |
|---|---|---|---|
| 羊毛の毛刈り | `PlayerShearEntityEvent` | 羊（毛あり時のみ）・キノコ牛 | 1.5 |
| 鶏の卵の孵化 | `PlayerEggThrowEvent` | 孵化した時（匹数を加味） | 2.0 × 匹数 |
| コンポスター骨粉生成 | `PlayerInteractEvent` | 満杯(LEVEL 8)からの取り出し | 2.0 |

- いずれも農家就業者のみ対象、レベルボーナス（`1.0 + level*0.02`）適用
- `AsyncEventUpdater` 経由で非同期付与（既存 `BreedingEventHandler` と同じ流儀）
- スパム対策: 毛刈り/卵は `EventCache` 500msクールダウン、コンポスターは `level==8`判定＋メインハンド限定で1操作1回

## 対象外

- **搾乳**: 同じ牛から連続取得でき経験値スパムになるため未実装（ユーザー確認済み）
- **動物の繁殖**: `BreedingEventHandler` で既に実装済み

## 変更ファイル

- 新規: `events/handlers/FarmingActivityEventHandler.java`
- 編集: `events/UnifiedEventHandler.java`（import・フィールド・初期化・`@EventHandler` 3メソッド）

## 動作確認

- [x] `mvn clean package` ビルド成功
- [ ] ゲーム内（非OP・農家就業）で各トリガーの経験値付与を確認
- [ ] 毛のない羊・孵化しなかった卵・空コンポスターで経験値が入らないことを確認
- [ ] 既存トリガー（作物収穫・繁殖）の回帰がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)