### PR TITLE
feat: 毛刈り（羊毛・キノコ刈り）を農家のみに制限

### DIFF
--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -364,6 +364,29 @@ public class UnifiedEventHandler implements Listener {
         eventCache.markAsProcessed(player, "player_fish");
     }
 
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onPlayerShearRestriction(PlayerShearEntityEvent event) {
+        Player player = event.getPlayer();
+        org.bukkit.entity.Entity target = event.getEntity();
+
+        // 羊・キノコ牛以外（雪ゴーレム等）は制限対象外
+        if (!(target instanceof org.bukkit.entity.Sheep)
+                && !(target instanceof org.bukkit.entity.MushroomCow)) {
+            return;
+        }
+
+        // 管理者はバイパス（既存の採掘制限と同じ流儀）
+        if (player.hasPermission("tofunomics.admin.shear")) {
+            return;
+        }
+
+        // 農家でなければ毛刈りを拒否
+        if (!jobManager.hasJob(player, "farmer")) {
+            event.setCancelled(true);
+            player.sendMessage("§c毛刈りができるのは農家のみです。");
+        }
+    }
+
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerShear(PlayerShearEntityEvent event) {
         if (!shouldProcessEvent(event)) return;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -215,7 +215,11 @@ permissions:
   tofunomics.admin.performance:
     description: パフォーマンス統計表示権限（フェーズ6）
     default: op
-  
+
+  tofunomics.admin.shear:
+    description: 毛刈り制限をバイパスする権限
+    default: op
+
   tofunomics.scoreboard.*:
     description: スコアボード関連権限（全て）
     children:


### PR DESCRIPTION
## 概要

毛刈り（`PlayerShearEntityEvent`）を **農家のみ実行可能** に制限します。これまで毛刈りは誰でもでき、農家の場合だけ補助アクション経験値が付くだけでした。

## 変更内容

- `UnifiedEventHandler` に **HIGH優先度・ignoreCancelled=true** の制限ハンドラー `onPlayerShearRestriction` を追加
  - 対象: 羊（Sheep）＋ キノコ牛（MushroomCow）。雪ゴーレム等は対象外
  - 農家でないプレイヤーは毛刈りをキャンセルし `§c毛刈りができるのは農家のみです。` を表示
  - OPは `tofunomics.admin.shear` 権限でバイパス
- `plugin.yml` に `tofunomics.admin.shear`（default: op）を追加
- 既存の経験値付与ハンドラー `onPlayerShear`（MONITOR）はそのまま。HIGHでキャンセルされると農家以外には経験値も付かず整合

既存のブロック採掘・植え付け制限（`JobBlockPermissionManager`）と同じパターンを踏襲しています。config.yml本体・config/*.ymlには変更なし。

## テスト観点

- [ ] 非OP・非農家: 羊/キノコ牛を毛刈りできず、メッセージが出る
- [ ] 農家: 毛刈りでき、従来どおり経験値通知が出る
- [ ] OP: 職業に関わらず毛刈りできる
- [ ] 雪ゴーレム等: 影響を受けない

🤖 Generated with [Claude Code](https://claude.com/claude-code)