### PR TITLE
fix: 農家の自作物収穫経験値と食事バフの無反応問題を修正

### DIFF
--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -3383,6 +3383,22 @@ public class ConfigManager {
     }
 
     /**
+     * 既により強いバフが有効なため弱い食事効果が無視された時のメッセージテンプレートを取得
+     */
+    public String getFoodBuffWeakerIgnoredMessage() {
+        return config.getString("food_buff.messages.buff_weaker_ignored",
+            "&7既により強い食事効果（%current%）が有効です");
+    }
+
+    /**
+     * 満腹で食料を食べられずバフが付かない時のヒントメッセージテンプレートを取得
+     */
+    public String getFoodBuffBlockedSatiatedMessage() {
+        return config.getString("food_buff.messages.buff_blocked_satiated",
+            "&7満腹のため食事効果が付きません。空腹時に食べてください");
+    }
+
+    /**
      * 食料NPCの設定リストを取得
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -469,7 +469,7 @@ public class UnifiedEventHandler implements Listener {
      * 経験値が得られる可能性のあるブロックのみ追跡
      * 注意: 鉱石ブロックは設置禁止のため追跡不要
      */
-    private boolean shouldTrackPlacedBlock(Material blockType) {
+    static boolean shouldTrackPlacedBlock(Material blockType) {
         // 鉱石類は設置禁止のため追跡不要（isOreBlockで判定）
         
         // STONE, COBBLESTONE（無限経験値防止）
@@ -493,14 +493,20 @@ public class UnifiedEventHandler implements Listener {
             return true;
         }
         
-        // 農作物類
-        if (blockType == Material.WHEAT || blockType == Material.POTATOES || 
-            blockType == Material.CARROTS || blockType == Material.BEETROOTS ||
-            blockType == Material.PUMPKIN || blockType == Material.MELON ||
-            blockType == Material.SUGAR_CANE || blockType == Material.NETHER_WART) {
+        // 農作物類（茎から自然成長したブロックを収穫するため、手動設置→破壊の悪用のみ防ぐ）
+        // カボチャ・スイカ・サトウキビは、収穫対象が「茎から自然成長したブロック」であり
+        // プレイヤー設置ブロックではないため、追跡しても正規の収穫には影響しない。
+        if (blockType == Material.PUMPKIN || blockType == Material.MELON ||
+            blockType == Material.SUGAR_CANE) {
             return true;
         }
-        
+
+        // 成熟度ゲートのある作物（小麦・ニンジン・ジャガイモ・ビートルート・ネザーウォート）は
+        // あえて追跡しない。これらはプレイヤーが種を植えた作物ブロックそのものを収穫するため、
+        // 追跡すると「自分で植えて収穫する」農業の基本ループで経験値が入らなくなる。
+        // 無限ファーミングは JobExperienceManager.isCropFullyGrown()（完全成長時のみ付与）で
+        // 既に防止済みのため、追跡対象から除外しても悪用は不可能。
+
         return false;
     }
     

--- a/src/main/java/org/tofu/tofunomics/food/FoodBuffManager.java
+++ b/src/main/java/org/tofu/tofunomics/food/FoodBuffManager.java
@@ -74,7 +74,9 @@ public class FoodBuffManager {
         boolean currentValid = current != null && current.expiresAtMillis > now;
 
         // 既存が有効かつ今回が弱い場合は何もしない（下げない・延長しない）
+        // 「食べたのに無反応」に見えるのを防ぐため、理由をプレイヤーに通知する
         if (currentValid && newFactor < current.factor) {
+            sendWeakerIgnoredMessage(player, current);
             return;
         }
 
@@ -126,6 +128,18 @@ public class FoodBuffManager {
             .replace("%category%", category.getDisplayName())
             .replace("%percent%", String.valueOf(bonusPercent))
             .replace("%duration%", String.valueOf(durationSeconds));
+        player.sendMessage(ChatColor.translateAlternateColorCodes('&', message));
+    }
+
+    /**
+     * 既により強いバフが有効なため、弱い食事効果が無視されたことを通知する。
+     */
+    private void sendWeakerIgnoredMessage(Player player, ActiveBuff current) {
+        String template = configManager.getFoodBuffWeakerIgnoredMessage();
+        if (template == null || template.isEmpty()) {
+            return;
+        }
+        String message = template.replace("%current%", current.displayName);
         player.sendMessage(ChatColor.translateAlternateColorCodes('&', message));
     }
 }

--- a/src/main/java/org/tofu/tofunomics/food/FoodConsumeListener.java
+++ b/src/main/java/org/tofu/tofunomics/food/FoodConsumeListener.java
@@ -1,22 +1,41 @@
 package org.tofu.tofunomics.food;
 
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
 import org.tofu.tofunomics.config.ConfigManager;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 食材を食べた時に職業経験値ブーストバフを付与するリスナー。
  *
  * PlayerItemConsumeEvent は実際に食料が食べられた時のみ発火するため、
  * 満腹時には通常食料でバフが付かない（自然な制約）。
+ * 満腹で「食べたのに無反応」に見えるのを防ぐため、満腹時に対象食料を
+ * 右クリックした場合はヒントメッセージのみ表示する（バフは付与しない）。
  */
 public class FoodConsumeListener implements Listener {
 
+    // 満腹時ヒントメッセージのスパム防止クールダウン（ミリ秒）
+    private static final long SATIATED_HINT_COOLDOWN_MILLIS = 5000L;
+    // 満腹判定の満腹度しきい値（最大値）
+    private static final int FULL_FOOD_LEVEL = 20;
+
     private final ConfigManager configManager;
     private final FoodBuffManager foodBuffManager;
+
+    // プレイヤーUUID -> 最後に満腹ヒントを送った時刻（クールダウン用）
+    private final Map<UUID, Long> lastSatiatedHintAt = new ConcurrentHashMap<>();
 
     public FoodConsumeListener(ConfigManager configManager, FoodBuffManager foodBuffManager) {
         this.configManager = configManager;
@@ -45,5 +64,70 @@ public class FoodConsumeListener implements Listener {
 
         Player player = event.getPlayer();
         foodBuffManager.applyBuff(player, category);
+    }
+
+    /**
+     * 満腹で食料を食べられずバフが付かない場合に、理由をヒントとして通知する。
+     *
+     * 満腹時は PlayerItemConsumeEvent が発火しないため検知できない。
+     * バフ対象食料を右クリックしたが満腹だった場合のみ、メッセージを表示する。
+     * （バフは付与せず、挙動は変えない。）
+     */
+    @EventHandler
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        // メインハンドのみ・右クリック動作のみを対象にする（重複発火防止）
+        if (event.getHand() != EquipmentSlot.HAND) {
+            return;
+        }
+        Action action = event.getAction();
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+
+        if (!configManager.isFoodBuffEnabled()) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        if (!configManager.isEconomyEnabledInWorld(player.getWorld().getName())) {
+            return;
+        }
+
+        // 満腹でない場合は通常通り食べられる（PlayerItemConsumeEvent でバフ付与）ので何もしない
+        if (player.getFoodLevel() < FULL_FOOD_LEVEL) {
+            return;
+        }
+
+        ItemStack item = event.getItem();
+        if (item == null) {
+            return;
+        }
+        FoodCategory category = FoodCategory.fromMaterial(item.getType());
+        if (category == null) {
+            // バフ対象外の食材
+            return;
+        }
+
+        sendSatiatedHint(player);
+    }
+
+    /**
+     * 満腹ヒントメッセージを送信する（クールダウン付き）。
+     */
+    private void sendSatiatedHint(Player player) {
+        long now = System.currentTimeMillis();
+        UUID uuid = player.getUniqueId();
+        Long last = lastSatiatedHintAt.get(uuid);
+        if (last != null && (now - last) < SATIATED_HINT_COOLDOWN_MILLIS) {
+            return;
+        }
+
+        String template = configManager.getFoodBuffBlockedSatiatedMessage();
+        if (template == null || template.isEmpty()) {
+            return;
+        }
+
+        lastSatiatedHintAt.put(uuid, now);
+        player.sendMessage(ChatColor.translateAlternateColorCodes('&', template));
     }
 }

--- a/src/main/resources/config/gameplay.yml
+++ b/src/main/resources/config/gameplay.yml
@@ -510,6 +510,9 @@ food_buff:
   messages:
     buff_applied: "&a食事の効果！ &e%category% &aで職業経験値 &e+%percent%%% &a（%duration%秒）"
     buff_replaced: "&aより強い食事効果に切り替わりました：&e%category% +%percent%%%"
+    # %current%=現在有効なより強いバフのカテゴリ名
+    buff_weaker_ignored: "&7既により強い食事効果（%current%）が有効です"
+    buff_blocked_satiated: "&7満腹のため食事効果が付きません。空腹時に食べてください"
 
 # ===================================
 # 職業ガイドブック設定

--- a/src/test/java/org/tofu/tofunomics/events/UnifiedEventHandlerTrackingTest.java
+++ b/src/test/java/org/tofu/tofunomics/events/UnifiedEventHandlerTrackingTest.java
@@ -1,0 +1,45 @@
+package org.tofu.tofunomics.events;
+
+import org.bukkit.Material;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@link UnifiedEventHandler#shouldTrackPlacedBlock(Material)} の追跡判定テスト。
+ *
+ * 農家が自分で植えた成熟度ゲート作物（小麦・ニンジン・ジャガイモ・ビートルート・ネザーウォート）は
+ * 設置追跡の対象外であり、収穫時に経験値が付与されることを保証する（回帰防止）。
+ * 一方、カボチャ・スイカ・サトウキビは手動設置→破壊の悪用防止のため追跡対象に残す。
+ */
+public class UnifiedEventHandlerTrackingTest {
+
+    @Test
+    public void 成熟度ゲート作物は追跡対象外() {
+        // これらはプレイヤーが植えた作物ブロックそのものを収穫するため、
+        // 追跡すると農業の基本ループで経験値が入らなくなる。
+        // 無限ファーミングは成熟度チェック（完全成長時のみ付与）で防止済み。
+        assertFalse("小麦は追跡対象外", UnifiedEventHandler.shouldTrackPlacedBlock(Material.WHEAT));
+        assertFalse("ニンジンは追跡対象外", UnifiedEventHandler.shouldTrackPlacedBlock(Material.CARROTS));
+        assertFalse("ジャガイモは追跡対象外", UnifiedEventHandler.shouldTrackPlacedBlock(Material.POTATOES));
+        assertFalse("ビートルートは追跡対象外", UnifiedEventHandler.shouldTrackPlacedBlock(Material.BEETROOTS));
+        assertFalse("ネザーウォートは追跡対象外", UnifiedEventHandler.shouldTrackPlacedBlock(Material.NETHER_WART));
+    }
+
+    @Test
+    public void 自然成長系作物は追跡対象に残す() {
+        // 収穫対象は茎から自然成長したブロックでありプレイヤー設置ブロックではないため、
+        // 追跡しても正規収穫には影響せず、手動設置→破壊の悪用のみ防ぐ。
+        assertTrue("カボチャは追跡対象", UnifiedEventHandler.shouldTrackPlacedBlock(Material.PUMPKIN));
+        assertTrue("スイカは追跡対象", UnifiedEventHandler.shouldTrackPlacedBlock(Material.MELON));
+        assertTrue("サトウキビは追跡対象", UnifiedEventHandler.shouldTrackPlacedBlock(Material.SUGAR_CANE));
+    }
+
+    @Test
+    public void 無限経験値防止系ブロックは追跡対象に残す() {
+        assertTrue("石は追跡対象", UnifiedEventHandler.shouldTrackPlacedBlock(Material.STONE));
+        assertTrue("丸石は追跡対象", UnifiedEventHandler.shouldTrackPlacedBlock(Material.COBBLESTONE));
+        assertTrue("原木は追跡対象", UnifiedEventHandler.shouldTrackPlacedBlock(Material.OAK_LOG));
+    }
+}

--- a/src/test/java/org/tofu/tofunomics/food/FoodBuffManagerTest.java
+++ b/src/test/java/org/tofu/tofunomics/food/FoodBuffManagerTest.java
@@ -32,6 +32,7 @@ public class FoodBuffManagerTest {
         when(configManager.isFoodBuffEnabled()).thenReturn(true);
         when(configManager.getFoodBuffAppliedMessage()).thenReturn("applied");
         when(configManager.getFoodBuffReplacedMessage()).thenReturn("replaced");
+        when(configManager.getFoodBuffWeakerIgnoredMessage()).thenReturn("ignored:%current%");
 
         // パン +10% / 180秒, 肉 +30% / 480秒
         when(configManager.getFoodBuffBonusPercent("bread")).thenReturn(10);
@@ -65,6 +66,14 @@ public class FoodBuffManagerTest {
         foodBuffManager.applyBuff(player, FoodCategory.MEAT);  // +30%
         foodBuffManager.applyBuff(player, FoodCategory.BREAD); // +10%（無視されるべき）
         assertEquals(1.30, foodBuffManager.getMultiplier(player), 0.0001);
+    }
+
+    @Test
+    public void weakerBuffSendsIgnoredMessage() {
+        foodBuffManager.applyBuff(player, FoodCategory.MEAT);  // +30%（現在有効: 肉）
+        foodBuffManager.applyBuff(player, FoodCategory.BREAD); // +10%（無視され通知される）
+        // 「食べたのに無反応」防止のため、現在有効なバフ名を含むメッセージが送られる
+        verify(player).sendMessage(contains("肉"));
     }
 
     @Test


### PR DESCRIPTION
## 背景

プレイヤーから以下の報告があり調査・修正した。
- 「食事をしても職業経験値ブーストの効果が出ない場合がある」
- 「農家が作物を収穫しても経験値が入らない場合がある」

## 修正① 農家の収穫経験値が入らない【コアバグ】

`UnifiedEventHandler` の「プレイヤー設置ブロックには経験値を付与しない」無限ファーミング防止機構が、農家が**自分で植えた作物**まで対象にしていた。植える→育つ→収穫という農業の基本ループそのものが経験値ゼロになっていた。

- `shouldTrackPlacedBlock` の追跡対象から成熟度ゲート作物（小麦・ニンジン・ジャガイモ・ビートルート・ネザーウォート）を除外
- これらは `JobExperienceManager.isCropFullyGrown()`（完全成長時のみ付与）で無限ファーミングを既に防止済みのため、追跡を外しても悪用不可
- カボチャ・スイカ・サトウキビは「茎から自然成長したブロック」を収穫する＝プレイヤー設置ブロックではないため、手動設置→破壊の悪用防止として追跡に残す

## 修正② 食事バフのフィードバック追加【挙動は不変】

バフ乗算ロジックは正常。「効果が出ない」のは満腹・対象外食料・既により強いバフ有効といった要因で、**フィードバックが無く「食べたのに無反応」に見える**ことが原因だった。挙動は変えず説明メッセージのみ追加。

- **弱いバフ無視時**: 既により強いバフが有効な間に弱い食料を食べた場合、理由を通知（`FoodBuffManager`）
- **満腹時**: 満腹で食料を右クリックしてもバフが付かない旨をヒント表示（`FoodConsumeListener` に `PlayerInteractEvent` ハンドラ追加。バフは付与しない）
- `config/gameplay.yml` にメッセージキー2件、`ConfigManager` にゲッター2件を追加（gameplay.yml はデプロイで上書き可能な静的設定）

## テスト

- `UnifiedEventHandlerTrackingTest`（新規）: 成熟度ゲート作物は追跡対象外、自然成長系/石/原木は追跡対象に残ることを検証
- `FoodBuffManagerTest`: 弱いバフ無視時に通知メッセージが送られることを追加検証
- `mvn clean test` → 全341件成功

## ゲーム内検証（デプロイ後に実施予定）

- [ ] 農家で小麦/ニンジン/ジャガイモ/ビートルート/ネザーウォートを植え→成長→収穫で経験値が入る
- [ ] 未成熟の作物を壊しても経験値が入らない（成熟度ゲートが効く）
- [ ] 満腹時に対象食料を右クリック→ヒント表示（バフは付かない）
- [ ] 強いバフ有効中に弱い食料を食べる→説明メッセージ表示
- [ ] 空腹時に食料を食べる→バフが付き職業活動で経験値増加

🤖 Generated with [Claude Code](https://claude.com/claude-code)