### PR TITLE
feat: 食事バフを職業マッチ制に変更

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -498,7 +498,7 @@ public final class TofuNomics extends JavaPlugin {
             jobExperienceManager.setJobLevelRewardManager(jobLevelRewardManager);
 
             // 食事による職業経験値ブーストバフの初期化・注入
-            foodBuffManager = new org.tofu.tofunomics.food.FoodBuffManager(configManager);
+            foodBuffManager = new org.tofu.tofunomics.food.FoodBuffManager(configManager, jobManager);
             jobExperienceManager.setFoodBuffManager(foodBuffManager);
             foodConsumeListener = new org.tofu.tofunomics.food.FoodConsumeListener(configManager, foodBuffManager);
 

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -3353,17 +3353,25 @@ public class ConfigManager {
     }
 
     /**
-     * 指定カテゴリ（bread/vegetable/fish/meat）の経験値ボーナス割合(%)を取得
+     * 全職業共通の経験値ボーナス割合(%)を取得
      */
-    public int getFoodBuffBonusPercent(String categoryKey) {
-        return config.getInt("food_buff.categories." + categoryKey + ".bonus_percent", 0);
+    public int getFoodBuffBonusPercent() {
+        return config.getInt("food_buff.bonus_percent", 0);
     }
 
     /**
-     * 指定カテゴリ（bread/vegetable/fish/meat）のバフ持続時間(秒)を取得
+     * 全職業共通のバフ持続時間(秒)を取得
      */
-    public int getFoodBuffDurationSeconds(String categoryKey) {
-        return config.getInt("food_buff.categories." + categoryKey + ".duration_seconds", 0);
+    public int getFoodBuffDurationSeconds() {
+        return config.getInt("food_buff.duration_seconds", 0);
+    }
+
+    /**
+     * 指定カテゴリ（bread/vegetable/fish/meat）に対応する職業（内部名）のリストを取得。
+     * このリストに含まれる職業のときだけ、そのカテゴリの食材ブーストが効く。
+     */
+    public java.util.List<String> getFoodBuffCategoryJobs(String categoryKey) {
+        return config.getStringList("food_buff.categories." + categoryKey + ".jobs");
     }
 
     /**
@@ -3375,19 +3383,11 @@ public class ConfigManager {
     }
 
     /**
-     * より強いバフへ上書きされた時のメッセージテンプレートを取得
+     * 自分の職業に合わない食材を食べた時のヒントメッセージテンプレートを取得
      */
-    public String getFoodBuffReplacedMessage() {
-        return config.getString("food_buff.messages.buff_replaced",
-            "&aより強い食事効果に切り替わりました：&e%category% +%percent%%%");
-    }
-
-    /**
-     * 既により強いバフが有効なため弱い食事効果が無視された時のメッセージテンプレートを取得
-     */
-    public String getFoodBuffWeakerIgnoredMessage() {
-        return config.getString("food_buff.messages.buff_weaker_ignored",
-            "&7既により強い食事効果（%current%）が有効です");
+    public String getFoodBuffNoMatchMessage() {
+        return config.getString("food_buff.messages.buff_no_match",
+            "&7%category%は今の職業（%job%）には効果がありません");
     }
 
     /**

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -3379,7 +3379,7 @@ public class ConfigManager {
      */
     public String getFoodBuffAppliedMessage() {
         return config.getString("food_buff.messages.buff_applied",
-            "&a食事の効果！ &e%category% &aで職業経験値 &e+%percent%%% &a（%duration%秒）");
+            "&a食事の効果！ &e%category% &aで職業経験値 &e+%percent%% &a（%duration%秒）");
     }
 
     /**

--- a/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
+++ b/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
@@ -805,9 +805,9 @@ public class JobExperienceManager implements Listener {
         double configMultiplier = job != null ?
             configManager.getJobExpMultiplier(jobName) : 1.0;
 
-        // 食事バフ倍率を適用（バフ無し・失効時は1.0で従来と同一）
+        // 食事バフ倍率を適用（職業マッチ制: 対応食材を食べた職業のみ。非マッチ・バフ無し・失効時は1.0）
         double foodBuffMultiplier = (foodBuffManager != null) ?
-            foodBuffManager.getMultiplier(player) : 1.0;
+            foodBuffManager.getMultiplier(player, jobName) : 1.0;
 
         return baseExperience * levelPenalty * configMultiplier * foodBuffMultiplier;
     }
@@ -829,9 +829,9 @@ public class JobExperienceManager implements Listener {
             return false;
         }
 
-        // 食事バフ倍率を適用（Mob討伐経験値などの経路でも一貫して反映。バフ無し時は1.0）
+        // 食事バフ倍率を適用（職業マッチ制。Mob討伐経験値などの経路でも一貫して反映。非マッチ・バフ無し時は1.0）
         double foodBuffMultiplier = (foodBuffManager != null) ?
-            foodBuffManager.getMultiplier(player) : 1.0;
+            foodBuffManager.getMultiplier(player, jobName) : 1.0;
 
         giveJobExperience(player, jobName, amount * foodBuffMultiplier);
         return true;

--- a/src/main/java/org/tofu/tofunomics/food/FoodBuffManager.java
+++ b/src/main/java/org/tofu/tofunomics/food/FoodBuffManager.java
@@ -3,6 +3,7 @@ package org.tofu.tofunomics.food;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.jobs.JobManager;
 
 import java.util.Map;
 import java.util.UUID;
@@ -11,42 +12,48 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * 食事による職業経験値ブーストバフの管理クラス。
  *
- * 食材を食べると、そのカテゴリ（パン/野菜/魚/肉）に応じた一定時間の
- * 職業経験値倍率バフを付与する。倍率は経験値獲得時（JobExperienceManager）に乗算される。
+ * 「職業マッチ制」: 食材カテゴリ（パン/野菜/魚/肉）にはそれぞれ対応職業が設定されており、
+ * 自分の職業に対応した食材を食べたときだけ経験値ブーストが効く。対応しない食材を
+ * 食べてもブーストは付かない（倍率1.0）。ボーナス量・持続時間は全職業共通。
  *
- * 重複挙動: 上書き（一番強いものが有効）。
- *   - より強い（または同等の）バフを食べた場合は上書き（持続時間もリセット）。
- *   - 既存より弱いバフを食べても無視（下げない・延長しない）。
+ * 重複挙動: 1バフ上書き式（最後に食べた食材のカテゴリを保持）。
+ * マッチ判定の正本は {@link #getMultiplier(Player, String)} 側に置く
+ * （食後の転職や経験値経路ごとの職業差に正しく追従するため）。
  */
 public class FoodBuffManager {
 
     private final ConfigManager configManager;
+    // applyBuff 時のマッチ/非マッチ メッセージ出し分け用（倍率算出には不要）
+    private final JobManager jobManager;
 
     // プレイヤーUUID -> 有効中のバフ
     private final Map<UUID, ActiveBuff> activeBuffs = new ConcurrentHashMap<>();
 
-    public FoodBuffManager(ConfigManager configManager) {
+    public FoodBuffManager(ConfigManager configManager, JobManager jobManager) {
         this.configManager = configManager;
+        this.jobManager = jobManager;
     }
 
     /**
      * 有効中のバフ情報
      */
     private static class ActiveBuff {
-        final double factor;       // 経験値倍率（例: +30% -> 1.30）
+        final double factor;        // 経験値倍率（例: +25% -> 1.25）
         final long expiresAtMillis; // 失効時刻（エポックミリ秒）
-        final String displayName;  // カテゴリ表示名
+        final String categoryKey;   // 対応職業を引くためのカテゴリキー（bread/vegetable/fish/meat）
 
-        ActiveBuff(double factor, long expiresAtMillis, String displayName) {
+        ActiveBuff(double factor, long expiresAtMillis, String categoryKey) {
             this.factor = factor;
             this.expiresAtMillis = expiresAtMillis;
-            this.displayName = displayName;
+            this.categoryKey = categoryKey;
         }
     }
 
     /**
      * 食材カテゴリに応じたバフを付与する。
-     * 既に有効なバフより弱い場合は何もしない（一番強いものが有効）。
+     * バフ自体は常に最後に食べたカテゴリで上書きするが、実際にブーストが効くかは
+     * 経験値獲得時のマッチ判定（getMultiplier）に委ねる。
+     * ここでは現在の職業に対応するかでメッセージのみ出し分ける。
      */
     public void applyBuff(Player player, FoodCategory category) {
         if (player == null || category == null) {
@@ -56,42 +63,38 @@ public class FoodBuffManager {
             return;
         }
 
-        String key = category.getConfigKey();
-        int bonusPercent = configManager.getFoodBuffBonusPercent(key);
-        int durationSeconds = configManager.getFoodBuffDurationSeconds(key);
+        int bonusPercent = configManager.getFoodBuffBonusPercent();
+        int durationSeconds = configManager.getFoodBuffDurationSeconds();
 
         // 効果が無い設定（0%や0秒）の場合はバフを付与しない
         if (bonusPercent <= 0 || durationSeconds <= 0) {
             return;
         }
 
+        String key = category.getConfigKey();
         double newFactor = 1.0 + (bonusPercent / 100.0);
-        long now = System.currentTimeMillis();
-        long expiresAt = now + (durationSeconds * 1000L);
+        long expiresAt = System.currentTimeMillis() + (durationSeconds * 1000L);
 
-        UUID uuid = player.getUniqueId();
-        ActiveBuff current = activeBuffs.get(uuid);
-        boolean currentValid = current != null && current.expiresAtMillis > now;
+        activeBuffs.put(player.getUniqueId(), new ActiveBuff(newFactor, expiresAt, key));
 
-        // 既存が有効かつ今回が弱い場合は何もしない（下げない・延長しない）
-        // 「食べたのに無反応」に見えるのを防ぐため、理由をプレイヤーに通知する
-        if (currentValid && newFactor < current.factor) {
-            sendWeakerIgnoredMessage(player, current);
-            return;
+        // 現在の職業がこのカテゴリにマッチするか判定し、メッセージを出し分ける
+        String jobName = (jobManager != null) ? jobManager.getPlayerJob(player.getUniqueId()) : null;
+        boolean matches = jobName != null
+            && configManager.getFoodBuffCategoryJobs(key).contains(jobName);
+
+        if (matches) {
+            sendBuffMessage(player, category, bonusPercent, durationSeconds);
+        } else {
+            sendNoMatchMessage(player, category, jobName);
         }
-
-        boolean replaced = currentValid;
-        activeBuffs.put(uuid, new ActiveBuff(newFactor, expiresAt, category.getDisplayName()));
-
-        sendBuffMessage(player, replaced, category, bonusPercent, durationSeconds);
     }
 
     /**
-     * プレイヤーの現在の経験値倍率を取得する。
-     * 有効なバフが無い、または失効済みの場合は 1.0 を返す（遅延失効）。
+     * プレイヤーの指定職業に対する経験値倍率を取得する（マッチ判定の正本）。
+     * 有効なバフが無い・失効済み・現在のバフカテゴリが jobName に対応しない場合は 1.0 を返す。
      */
-    public double getMultiplier(Player player) {
-        if (player == null) {
+    public double getMultiplier(Player player, String jobName) {
+        if (player == null || jobName == null) {
             return 1.0;
         }
         UUID uuid = player.getUniqueId();
@@ -102,6 +105,10 @@ public class FoodBuffManager {
         if (buff.expiresAtMillis <= System.currentTimeMillis()) {
             // 失効済みは破棄
             activeBuffs.remove(uuid);
+            return 1.0;
+        }
+        // 保持カテゴリの対応職業に jobName が含まれるときだけブースト
+        if (!configManager.getFoodBuffCategoryJobs(buff.categoryKey).contains(jobName)) {
             return 1.0;
         }
         return buff.factor;
@@ -116,11 +123,9 @@ public class FoodBuffManager {
         }
     }
 
-    private void sendBuffMessage(Player player, boolean replaced, FoodCategory category,
+    private void sendBuffMessage(Player player, FoodCategory category,
                                  int bonusPercent, int durationSeconds) {
-        String template = replaced
-            ? configManager.getFoodBuffReplacedMessage()
-            : configManager.getFoodBuffAppliedMessage();
+        String template = configManager.getFoodBuffAppliedMessage();
         if (template == null || template.isEmpty()) {
             return;
         }
@@ -132,14 +137,18 @@ public class FoodBuffManager {
     }
 
     /**
-     * 既により強いバフが有効なため、弱い食事効果が無視されたことを通知する。
+     * 食べた食材が現在の職業に対応しないため、ブーストが効かないことを通知する。
      */
-    private void sendWeakerIgnoredMessage(Player player, ActiveBuff current) {
-        String template = configManager.getFoodBuffWeakerIgnoredMessage();
+    private void sendNoMatchMessage(Player player, FoodCategory category, String jobName) {
+        String template = configManager.getFoodBuffNoMatchMessage();
         if (template == null || template.isEmpty()) {
             return;
         }
-        String message = template.replace("%current%", current.displayName);
+        // 無職時は「無職」と表示。就職済みは職業の日本語表示名を表示。
+        String jobLabel = (jobName != null) ? configManager.getJobDisplayName(jobName) : "無職";
+        String message = template
+            .replace("%category%", category.getDisplayName())
+            .replace("%job%", jobLabel);
         player.sendMessage(ChatColor.translateAlternateColorCodes('&', message));
     }
 }

--- a/src/main/resources/config/gameplay.yml
+++ b/src/main/resources/config/gameplay.yml
@@ -509,7 +509,7 @@ food_buff:
 
   # メッセージ設定（%category%=カテゴリ名, %percent%=上昇割合, %duration%=秒, %job%=職業名）
   messages:
-    buff_applied: "&a食事の効果！ &e%category% &aで職業経験値 &e+%percent%%% &a（%duration%秒）"
+    buff_applied: "&a食事の効果！ &e%category% &aで職業経験値 &e+%percent%% &a（%duration%秒）"
     # 自分の職業に合わない食材を食べたときのヒント
     buff_no_match: "&7%category%は今の職業（%job%）には効果がありません"
     buff_blocked_satiated: "&7満腹のため食事効果が付きません。空腹時に食べてください"

--- a/src/main/resources/config/gameplay.yml
+++ b/src/main/resources/config/gameplay.yml
@@ -482,36 +482,36 @@ market:
 # 食事による職業経験値ブーストバフ設定
 # ===================================
 # 食材を食べると、一定時間その職業の経験値が上がりやすくなる。
-# カテゴリ（パン/野菜/魚/肉）ごとに効果量・持続時間を設定でき、
-# 高価な食材ほど強く・長いバフにすることで「高い食材を買う動機」を作る。
-# 重複時は一番強いバフが有効（弱い食材を食べても下がらない・延長されない）。
+# 「職業マッチ制」: 自分の現在の職業に対応した食材を食べたときだけブーストが効く。
+# 対応しない食材を食べてもブーストは付かない（倍率1.0）。
+# これにより各職業に固有の食生活が生まれ、食料NPCの需要が分散する。
 food_buff:
   # 機能の有効化（false で従来通りバフ無し）
   enabled: true
 
-  # カテゴリ別のバフ設定
+  # 全職業共通のブースト設定（職業間の有利不利をなくすため統一）
   #   bonus_percent: 経験値の上昇割合(%)
   #   duration_seconds: バフ持続時間(秒)
+  bonus_percent: 25
+  duration_seconds: 300
+
+  # カテゴリ別の対応職業（この職業のときだけブーストが効く）
+  #   jobs: 内部職業名のリスト（miner/woodcutter/farmer/fisherman/blacksmith/alchemist/enchanter/architect）
   categories:
     bread:
-      bonus_percent: 10
-      duration_seconds: 180
+      jobs: [woodcutter, architect]
     vegetable:
-      bonus_percent: 15
-      duration_seconds: 240
+      jobs: [farmer, alchemist]
     fish:
-      bonus_percent: 25
-      duration_seconds: 360
+      jobs: [fisherman, enchanter]
     meat:
-      bonus_percent: 30
-      duration_seconds: 480
+      jobs: [miner, blacksmith]
 
-  # メッセージ設定（%category%=カテゴリ名, %percent%=上昇割合, %duration%=秒）
+  # メッセージ設定（%category%=カテゴリ名, %percent%=上昇割合, %duration%=秒, %job%=職業名）
   messages:
     buff_applied: "&a食事の効果！ &e%category% &aで職業経験値 &e+%percent%%% &a（%duration%秒）"
-    buff_replaced: "&aより強い食事効果に切り替わりました：&e%category% +%percent%%%"
-    # %current%=現在有効なより強いバフのカテゴリ名
-    buff_weaker_ignored: "&7既により強い食事効果（%current%）が有効です"
+    # 自分の職業に合わない食材を食べたときのヒント
+    buff_no_match: "&7%category%は今の職業（%job%）には効果がありません"
     buff_blocked_satiated: "&7満腹のため食事効果が付きません。空腹時に食べてください"
 
 # ===================================

--- a/src/test/java/org/tofu/tofunomics/food/FoodBuffManagerTest.java
+++ b/src/test/java/org/tofu/tofunomics/food/FoodBuffManagerTest.java
@@ -6,14 +6,17 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.jobs.JobManager;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 /**
- * FoodBuffManager のバフ付与・倍率算出・上書きルールのテスト
+ * FoodBuffManager のバフ付与・倍率算出・職業マッチ判定のテスト
  */
 public class FoodBuffManagerTest {
 
@@ -21,89 +24,121 @@ public class FoodBuffManagerTest {
     private ConfigManager configManager;
 
     @Mock
+    private JobManager jobManager;
+
+    @Mock
     private Player player;
+
+    private UUID uuid;
 
     private FoodBuffManager foodBuffManager;
 
     @Before
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        when(player.getUniqueId()).thenReturn(UUID.randomUUID());
+        uuid = UUID.randomUUID();
+        when(player.getUniqueId()).thenReturn(uuid);
+
         when(configManager.isFoodBuffEnabled()).thenReturn(true);
-        when(configManager.getFoodBuffAppliedMessage()).thenReturn("applied");
-        when(configManager.getFoodBuffReplacedMessage()).thenReturn("replaced");
-        when(configManager.getFoodBuffWeakerIgnoredMessage()).thenReturn("ignored:%current%");
+        when(configManager.getFoodBuffAppliedMessage()).thenReturn("applied:%category%");
+        when(configManager.getFoodBuffNoMatchMessage()).thenReturn("nomatch:%category%:%job%");
 
-        // パン +10% / 180秒, 肉 +30% / 480秒
-        when(configManager.getFoodBuffBonusPercent("bread")).thenReturn(10);
-        when(configManager.getFoodBuffDurationSeconds("bread")).thenReturn(180);
-        when(configManager.getFoodBuffBonusPercent("meat")).thenReturn(30);
-        when(configManager.getFoodBuffDurationSeconds("meat")).thenReturn(480);
+        // 全職業共通 +25% / 300秒
+        when(configManager.getFoodBuffBonusPercent()).thenReturn(25);
+        when(configManager.getFoodBuffDurationSeconds()).thenReturn(300);
 
-        foodBuffManager = new FoodBuffManager(configManager);
+        // カテゴリ -> 対応職業
+        when(configManager.getFoodBuffCategoryJobs("bread"))
+            .thenReturn(Arrays.asList("woodcutter", "architect"));
+        when(configManager.getFoodBuffCategoryJobs("meat"))
+            .thenReturn(Arrays.asList("miner", "blacksmith"));
+
+        // 職業表示名（no_match メッセージ用）
+        when(configManager.getJobDisplayName("miner")).thenReturn("鉱夫");
+        when(configManager.getJobDisplayName("woodcutter")).thenReturn("木こり");
+
+        // デフォルトの現在職業は木こり（パンにマッチ）
+        when(jobManager.getPlayerJob(uuid)).thenReturn("woodcutter");
+
+        foodBuffManager = new FoodBuffManager(configManager, jobManager);
     }
 
     @Test
     public void noBuffReturnsBaseMultiplier() {
-        assertEquals(1.0, foodBuffManager.getMultiplier(player), 0.0001);
+        assertEquals(1.0, foodBuffManager.getMultiplier(player, "woodcutter"), 0.0001);
     }
 
     @Test
-    public void eatingBreadGivesTenPercentBuff() {
+    public void matchingJobGetsBoost() {
+        // 木こりがパン（bread=woodcutter/architect）を食べる -> ブースト適用
         foodBuffManager.applyBuff(player, FoodCategory.BREAD);
-        assertEquals(1.10, foodBuffManager.getMultiplier(player), 0.0001);
+        assertEquals(1.25, foodBuffManager.getMultiplier(player, "woodcutter"), 0.0001);
     }
 
     @Test
-    public void strongerBuffOverwritesWeaker() {
-        foodBuffManager.applyBuff(player, FoodCategory.BREAD); // +10%
-        foodBuffManager.applyBuff(player, FoodCategory.MEAT);  // +30%（上書き）
-        assertEquals(1.30, foodBuffManager.getMultiplier(player), 0.0001);
+    public void nonMatchingJobGetsNoBoost() {
+        // パンを食べても、鉱夫の経験値にはブーストが効かない
+        foodBuffManager.applyBuff(player, FoodCategory.BREAD);
+        assertEquals(1.0, foodBuffManager.getMultiplier(player, "miner"), 0.0001);
     }
 
     @Test
-    public void weakerBuffDoesNotReplaceStronger() {
-        foodBuffManager.applyBuff(player, FoodCategory.MEAT);  // +30%
-        foodBuffManager.applyBuff(player, FoodCategory.BREAD); // +10%（無視されるべき）
-        assertEquals(1.30, foodBuffManager.getMultiplier(player), 0.0001);
+    public void lastEatenCategoryWins() {
+        // パン -> 肉 の順で食べると、最後の肉カテゴリのみ有効
+        foodBuffManager.applyBuff(player, FoodCategory.BREAD);
+        foodBuffManager.applyBuff(player, FoodCategory.MEAT);
+        assertEquals(1.25, foodBuffManager.getMultiplier(player, "miner"), 0.0001);      // 肉=鉱夫 -> 適用
+        assertEquals(1.0, foodBuffManager.getMultiplier(player, "woodcutter"), 0.0001);  // 肉≠木こり -> なし
     }
 
     @Test
-    public void weakerBuffSendsIgnoredMessage() {
-        foodBuffManager.applyBuff(player, FoodCategory.MEAT);  // +30%（現在有効: 肉）
-        foodBuffManager.applyBuff(player, FoodCategory.BREAD); // +10%（無視され通知される）
-        // 「食べたのに無反応」防止のため、現在有効なバフ名を含むメッセージが送られる
-        verify(player).sendMessage(contains("肉"));
+    public void noMatchSendsHintMessage() {
+        // 現在職業が鉱夫のときにパン（鉱夫非対応）を食べると no_match ヒントが出る
+        when(jobManager.getPlayerJob(uuid)).thenReturn("miner");
+        foodBuffManager.applyBuff(player, FoodCategory.BREAD);
+        verify(player).sendMessage(contains("鉱夫"));
+    }
+
+    @Test
+    public void matchSendsAppliedMessage() {
+        // 現在職業が木こりのときにパンを食べると applied メッセージが出る
+        foodBuffManager.applyBuff(player, FoodCategory.BREAD);
+        verify(player).sendMessage(contains("applied"));
+    }
+
+    @Test
+    public void nullJobReturnsBaseMultiplier() {
+        foodBuffManager.applyBuff(player, FoodCategory.BREAD);
+        assertEquals(1.0, foodBuffManager.getMultiplier(player, null), 0.0001);
     }
 
     @Test
     public void disabledConfigDoesNotApplyBuff() {
         when(configManager.isFoodBuffEnabled()).thenReturn(false);
         foodBuffManager.applyBuff(player, FoodCategory.MEAT);
-        assertEquals(1.0, foodBuffManager.getMultiplier(player), 0.0001);
+        assertEquals(1.0, foodBuffManager.getMultiplier(player, "miner"), 0.0001);
     }
 
     @Test
     public void zeroBonusDoesNotApplyBuff() {
-        when(configManager.getFoodBuffBonusPercent("bread")).thenReturn(0);
+        when(configManager.getFoodBuffBonusPercent()).thenReturn(0);
         foodBuffManager.applyBuff(player, FoodCategory.BREAD);
-        assertEquals(1.0, foodBuffManager.getMultiplier(player), 0.0001);
+        assertEquals(1.0, foodBuffManager.getMultiplier(player, "woodcutter"), 0.0001);
     }
 
     @Test
     public void clearRemovesBuff() {
-        foodBuffManager.applyBuff(player, FoodCategory.MEAT);
-        foodBuffManager.clear(player.getUniqueId());
-        assertEquals(1.0, foodBuffManager.getMultiplier(player), 0.0001);
+        foodBuffManager.applyBuff(player, FoodCategory.BREAD);
+        foodBuffManager.clear(uuid);
+        assertEquals(1.0, foodBuffManager.getMultiplier(player, "woodcutter"), 0.0001);
     }
 
     @Test
     public void expiredBuffReturnsBaseMultiplier() {
-        // 持続0秒（=即失効扱い）の設定では applyBuff が付与しないが、
-        // ここでは1秒設定で付与→経過で失効することを確認する
-        when(configManager.getFoodBuffDurationSeconds("bread")).thenReturn(1);
+        // 1秒設定で付与 -> 経過で失効することを確認する
+        when(configManager.getFoodBuffDurationSeconds()).thenReturn(1);
         foodBuffManager.applyBuff(player, FoodCategory.BREAD);
-        assertEquals(1.10, foodBuffManager.getMultiplier(player), 0.0001);
+        assertEquals(1.25, foodBuffManager.getMultiplier(player, "woodcutter"), 0.0001);
 
         // 1秒強待機して失効を確認（遅延失効）
         try {
@@ -111,6 +146,14 @@ public class FoodBuffManagerTest {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
-        assertEquals(1.0, foodBuffManager.getMultiplier(player), 0.0001);
+        assertEquals(1.0, foodBuffManager.getMultiplier(player, "woodcutter"), 0.0001);
+    }
+
+    @Test
+    public void unmappedCategoryGivesNoBoost() {
+        // jobs リストが空のカテゴリはどの職業にも効かない（防御的確認）
+        when(configManager.getFoodBuffCategoryJobs("bread")).thenReturn(Collections.emptyList());
+        foodBuffManager.applyBuff(player, FoodCategory.BREAD);
+        assertEquals(1.0, foodBuffManager.getMultiplier(player, "woodcutter"), 0.0001);
     }
 }


### PR DESCRIPTION
## 背景・課題

食事バフ（`food_buff`）は4カテゴリ（パン+10%〜肉+30%）で効果量が異なり、`FoodBuffManager` が**一番強い倍率だけ**を採用していた。結果、全職業のプレイヤーが「肉だけ食べればいい」状態になり、食材ごとの個性・経済的多様性が死んでいた。

## 変更内容

「**職業に合った食材を食べたときだけ、その職業の経験値ブーストが効く**」職業マッチ制へ変更。

### 職業↔食材マッピング（configで変更可能）
| カテゴリ | 対応職業 |
|---|---|
| パン bread | 木こり woodcutter / 建築家 architect |
| 野菜 vegetable | 農家 farmer / ポーション屋 alchemist |
| 魚 fish | 釣り人 fisherman / エンチャンター enchanter |
| 肉 meat | 鉱夫 miner / 鍛冶屋 blacksmith |

- **非マッチ食材**を食べた場合は効果ゼロ（倍率1.0）
- **ボーナスは全職業統一**（+25% / 300秒）で職業間の有利不利を排除
- マッチ判定の正本を `getMultiplier(player, jobName)` に集約 → 全経験値経路（採掘/伐採/農業/釣り等）へ一貫適用
- 非マッチ時はヒントメッセージ（`buff_no_match`）で「効果がない」理由を通知

## 主な変更ファイル
- `config/gameplay.yml`: food_buff を統一bonus + カテゴリ別jobsリスト構造へ
- `FoodBuffManager.java`: 全面改修（職業マッチ判定、強弱比較ロジック削除、JobManager注入）
- `ConfigManager.java`: 引数なしbonus/duration getter、`getFoodBuffCategoryJobs`、`getFoodBuffNoMatchMessage` 追加
- `JobExperienceManager.java`: `getMultiplier` 呼び出しに jobName を渡す（2箇所）
- `TofuNomics.java`: DIを2引数化

## テスト
`mvn clean test` 全344件緑（FoodBuffManagerTest 12件: マッチ/非マッチ/上書き/失効/null職業等）。

## デプロイ時の注意
config反映とjarデプロイは**同時に**行う必要あり（新jarが旧config構造で動くとバフが付かず安全側に倒れる）。`food_buff` はサーバー固有データを含まないため `config/gameplay.yml` は上書き可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)