### PR TITLE
feat: 釣り人が海洋モブを倒した時に経験値を付与

### DIFF
--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -316,8 +316,8 @@ public class UnifiedEventHandler implements Listener {
             return;
         }
         
-        // エンティティ討伐による基本的な報酬処理（将来実装）
-        // handleEntityDeathRewards(event, player);
+        // 釣り人: 海洋系モブ討伐による経験値付与
+        experienceManager.onFishermanEntityKill(player, event.getEntity());
         
         // キャッシュに記録
         eventCache.markAsProcessed(player, "entity_death");

--- a/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
+++ b/src/main/java/org/tofu/tofunomics/experience/JobExperienceManager.java
@@ -89,6 +89,8 @@ public class JobExperienceManager implements Listener {
     // BlockBreakEventでは発火しないため farmingExperience とは分離し、onPlayerInteractHarvestで付与する。
     private final Map<Material, Double> interactHarvestExperience;
     private final Map<PlayerFishEvent.State, Double> fishingExperience;
+    // 釣り人が海洋系モブを討伐した際に得る経験値テーブル（キーは討伐されたモブのEntityType）
+    private final Map<EntityType, Double> aquaticKillExperience;
     private final Map<Material, Double> craftingExperience;
     private final Map<Material, Double> brewingExperience;
     private final Map<Integer, Double> enchantingExperience;
@@ -125,6 +127,7 @@ public class JobExperienceManager implements Listener {
         this.farmingExperience = new HashMap<>();
         this.interactHarvestExperience = new HashMap<>();
         this.fishingExperience = new HashMap<>();
+        this.aquaticKillExperience = new HashMap<>();
         this.craftingExperience = new HashMap<>();
         this.brewingExperience = new HashMap<>();
         this.enchantingExperience = new HashMap<>();
@@ -266,6 +269,22 @@ public class JobExperienceManager implements Listener {
         fishingExperience.put(PlayerFishEvent.State.CAUGHT_FISH, 5.0);
         fishingExperience.put(PlayerFishEvent.State.CAUGHT_ENTITY, 8.0);
         fishingExperience.put(PlayerFishEvent.State.IN_GROUND, 1.0);
+
+        // 海洋モブ討伐経験値テーブル（釣り人）— 釣り経験値量と統一
+        // 魚系 = 釣りCAUGHT_FISH(5.0) と同額
+        aquaticKillExperience.put(EntityType.COD, 5.0);
+        aquaticKillExperience.put(EntityType.SALMON, 5.0);
+        aquaticKillExperience.put(EntityType.PUFFERFISH, 5.0);
+        aquaticKillExperience.put(EntityType.TROPICAL_FISH, 5.0);
+        // 海洋モブ = 釣りCAUGHT_ENTITY(8.0) と同額
+        aquaticKillExperience.put(EntityType.SQUID, 8.0);
+        aquaticKillExperience.put(EntityType.GLOW_SQUID, 8.0);
+        aquaticKillExperience.put(EntityType.DOLPHIN, 8.0);
+        aquaticKillExperience.put(EntityType.TURTLE, 8.0);
+        aquaticKillExperience.put(EntityType.AXOLOTL, 8.0);
+        aquaticKillExperience.put(EntityType.DROWNED, 8.0);
+        aquaticKillExperience.put(EntityType.GUARDIAN, 8.0);
+        aquaticKillExperience.put(EntityType.ELDER_GUARDIAN, 8.0);
         
         // 製作経験値テーブル（鍛冶屋）
         // インゴット精錬
@@ -703,7 +722,25 @@ public class JobExperienceManager implements Listener {
             }
         }
     }
-    
+
+    /**
+     * 釣り人が海洋系モブ（魚・イカ・ガーディアン等）を討伐した際の経験値付与。
+     * UnifiedEventHandler.onEntityDeath から委譲される
+     * （本クラスはListener未登録のため@EventHandlerは付けない）。
+     */
+    public void onFishermanEntityKill(Player player, org.bukkit.entity.Entity entity) {
+        if (player == null || entity == null) return;
+        Double baseExp = aquaticKillExperience.get(entity.getType());
+        if (baseExp == null) return; // 対象外エンティティ
+        if (!jobManager.hasJob(player, "fisherman")) return;
+
+        double multipliedExp = applyJobMultiplier(player, "fisherman", baseExp);
+        // 海洋モブ種別ごとに初回討伐ボーナス（釣りのFISHERMAN_FIRST_KEYとは別系統）
+        multipliedExp = applyFirstAcquisitionBonus(player, "fisherman",
+            "KILL_" + entity.getType().name(), multipliedExp);
+        giveJobExperience(player, "fisherman", multipliedExp);
+    }
+
     @EventHandler
     public void onCraftItem(CraftItemEvent event) {
         if (!(event.getWhoClicked() instanceof Player)) return;


### PR DESCRIPTION
## 概要
釣り人(fisherman)の経験値トリガーを、釣り(`PlayerFishEvent`)に加えて**海洋系モブの討伐**にも拡張しました。経験値量は釣りと統一しています。

## 経験値量（釣りと統一）
| 区分 | EntityType | 経験値 |
|---|---|---|
| 魚モブ | COD, SALMON, PUFFERFISH, TROPICAL_FISH | 5.0（釣りCAUGHT_FISHと同額） |
| 海洋モブ | SQUID, GLOW_SQUID, DOLPHIN, TURTLE, AXOLOTL, DROWNED, GUARDIAN, ELDER_GUARDIAN | 8.0（釣りCAUGHT_ENTITYと同額） |

## 変更内容
- `JobExperienceManager`: 海洋モブ経験値テーブル `aquaticKillExperience` と公開メソッド `onFishermanEntityKill(Player, Entity)` を追加。既存の `applyJobMultiplier` / `applyFirstAcquisitionBonus` / `giveJobExperience` を再利用。
- `UnifiedEventHandler.onEntityDeath`: コメントアウトされていた未使用の汎用処理を、釣り人専用の委譲呼び出しに置換。

## 設計ポイント
- `JobExperienceManager` はListener未登録のため、既存パターン通り `UnifiedEventHandler` から委譲（二重発火なし）
- `onEntityDeath` の `getKiller()` 判定・100ms重複防止を流用し、釣り人を持つプレイヤーのみ付与
- 初回討伐ボーナスは種別ごと（`"KILL_" + EntityType名`）で釣りの初回ボーナスとは別系統

## スコープ外
- guide_book更新なし / config化なし（既存テーブルがハードコードのため踏襲）

## 検証
- `mvn clean package` / `mvn test` 成功
- ゲーム内確認推奨: 釣り人で各海洋モブを倒し経験値メッセージ・BossBar反映、釣り人以外では入らないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)