### PR TITLE
feat: 畑区画リサイズ機能 /farmplot resize を追加

### DIFF
--- a/src/main/java/org/tofu/tofunomics/commands/FarmPlotCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/FarmPlotCommand.java
@@ -70,6 +70,13 @@ public class FarmPlotCommand implements CommandExecutor, TabCompleter {
                 }
                 farmPlotManager.deletePlot(player, args[1]);
                 return true;
+            case "resize":
+                if (args.length < 2) {
+                    player.sendMessage(ChatColor.RED + "使用法: /farmplot resize <名前>");
+                    return true;
+                }
+                farmPlotManager.resizePlot(player, args[1]);
+                return true;
             case "list":
                 handleList(player);
                 return true;
@@ -168,6 +175,7 @@ public class FarmPlotCommand implements CommandExecutor, TabCompleter {
         player.sendMessage(ChatColor.YELLOW + "/farmplot pos1|pos2" + ChatColor.GRAY + " - 立っている位置を角に設定");
         player.sendMessage(ChatColor.YELLOW + "/farmplot create <名前>" + ChatColor.GRAY + " - 選択範囲で区画を作成");
         player.sendMessage(ChatColor.YELLOW + "/farmplot delete <名前>" + ChatColor.GRAY + " - 区画を削除");
+        player.sendMessage(ChatColor.YELLOW + "/farmplot resize <名前>" + ChatColor.GRAY + " - 選択範囲で区画の範囲を更新（所有者保持）");
         player.sendMessage(ChatColor.YELLOW + "/farmplot list" + ChatColor.GRAY + " - 区画一覧");
         player.sendMessage(ChatColor.YELLOW + "/farmplot info <名前>" + ChatColor.GRAY + " - 区画詳細");
         player.sendMessage(ChatColor.YELLOW + "/farmplot assign <プレイヤー> [区画名]" + ChatColor.GRAY + " - 手動割り当て");
@@ -180,7 +188,7 @@ public class FarmPlotCommand implements CommandExecutor, TabCompleter {
             return new ArrayList<>();
         }
         if (args.length == 1) {
-            List<String> subs = Arrays.asList("pos1", "pos2", "create", "delete", "list", "info", "assign", "release");
+            List<String> subs = Arrays.asList("pos1", "pos2", "create", "delete", "resize", "list", "info", "assign", "release");
             List<String> result = new ArrayList<>();
             for (String s : subs) {
                 if (s.startsWith(args[0].toLowerCase())) {
@@ -191,7 +199,7 @@ public class FarmPlotCommand implements CommandExecutor, TabCompleter {
         }
         if (args.length == 2) {
             String sub = args[0].toLowerCase();
-            if (sub.equals("delete") || sub.equals("info")) {
+            if (sub.equals("delete") || sub.equals("info") || sub.equals("resize")) {
                 List<String> names = new ArrayList<>();
                 for (FarmPlot p : farmPlotManager.listPlots()) {
                     if (p.getPlotName().toLowerCase().startsWith(args[1].toLowerCase())) {

--- a/src/main/java/org/tofu/tofunomics/dao/FarmPlotDAO.java
+++ b/src/main/java/org/tofu/tofunomics/dao/FarmPlotDAO.java
@@ -134,6 +134,24 @@ public class FarmPlotDAO {
         }
     }
 
+    /**
+     * 区画の座標範囲を更新する（owner_uuid・worldguard_region_id・world_nameは変更しない）
+     */
+    public boolean updateCoordinates(int id, int x1, int y1, int z1, int x2, int y2, int z2) throws SQLException {
+        String query = "UPDATE farm_plots SET x1 = ?, y1 = ?, z1 = ?, x2 = ?, y2 = ?, z2 = ?, " +
+                "updated_at = CURRENT_TIMESTAMP WHERE id = ?";
+        try (PreparedStatement st = connection.prepareStatement(query)) {
+            st.setInt(1, x1);
+            st.setInt(2, y1);
+            st.setInt(3, z1);
+            st.setInt(4, x2);
+            st.setInt(5, y2);
+            st.setInt(6, z2);
+            st.setInt(7, id);
+            return st.executeUpdate() > 0;
+        }
+    }
+
     public boolean deletePlot(int id) throws SQLException {
         String query = "DELETE FROM farm_plots WHERE id = ?";
         try (PreparedStatement st = connection.prepareStatement(query)) {

--- a/src/main/java/org/tofu/tofunomics/farming/FarmPlotManager.java
+++ b/src/main/java/org/tofu/tofunomics/farming/FarmPlotManager.java
@@ -140,6 +140,78 @@ public class FarmPlotManager {
         }
     }
 
+    /**
+     * 選択範囲で既存区画の座標範囲を更新する。
+     * 所有者(owner_uuid)・WGメンバー登録・リージョンID・各種フラグは保持し、範囲のみ変更する。
+     */
+    public boolean resizePlot(Player admin, String name) {
+        WorldGuardIntegration wg = wg();
+        if (wg == null || !wg.isEnabled()) {
+            admin.sendMessage(ChatColor.RED + "WorldGuardが無効なため区画をリサイズできません。");
+            return false;
+        }
+        if (!hasSelection(admin)) {
+            admin.sendMessage(ChatColor.RED + "範囲が未選択です。/farmplot pos1 と /farmplot pos2 で角を指定してください。");
+            return false;
+        }
+        Location p1 = pos1.get(admin.getUniqueId());
+        Location p2 = pos2.get(admin.getUniqueId());
+        if (p1.getWorld() == null || p2.getWorld() == null
+                || !p1.getWorld().getName().equals(p2.getWorld().getName())) {
+            admin.sendMessage(ChatColor.RED + "pos1とpos2は同じワールドで指定してください。");
+            return false;
+        }
+
+        try {
+            FarmPlot plot = farmPlotDAO.getPlotByName(name);
+            if (plot == null) {
+                admin.sendMessage(ChatColor.RED + "区画 '" + name + "' は存在しません。");
+                return false;
+            }
+            World world = p1.getWorld();
+            // 別ワールドへのリサイズは禁止（リージョンはワールド固有）
+            if (!world.getName().equals(plot.getWorldName())) {
+                admin.sendMessage(ChatColor.RED + "区画 '" + name + "' は別ワールド("
+                        + plot.getWorldName() + ")にあります。同じワールドで範囲を選択してください。");
+                return false;
+            }
+
+            String regionId = plot.getWorldguardRegionId();
+
+            // 旧座標を控える（DB更新失敗時のロールバック用）
+            Location oldP1 = new Location(world, plot.getX1(), plot.getY1(), plot.getZ1());
+            Location oldP2 = new Location(world, plot.getX2(), plot.getY2(), plot.getZ2());
+
+            // WGリージョンを新範囲で再構築（メンバー/オーナー/フラグを保持）
+            if (!wg.redefineRegion(regionId, world, p1, p2)) {
+                admin.sendMessage(ChatColor.RED + "WorldGuardリージョンの再構築に失敗しました。");
+                return false;
+            }
+
+            // DBの座標を更新
+            boolean dbUpdated = farmPlotDAO.updateCoordinates(plot.getId(),
+                    p1.getBlockX(), p1.getBlockY(), p1.getBlockZ(),
+                    p2.getBlockX(), p2.getBlockY(), p2.getBlockZ());
+            if (!dbUpdated) {
+                // DB更新失敗時はWGリージョンを旧範囲に戻してロールバック
+                wg.redefineRegion(regionId, world, oldP1, oldP2);
+                admin.sendMessage(ChatColor.RED + "区画のDB更新に失敗しました。リージョンを元の範囲に戻しました。");
+                return false;
+            }
+
+            // 選択をクリア
+            pos1.remove(admin.getUniqueId());
+            pos2.remove(admin.getUniqueId());
+
+            admin.sendMessage(ChatColor.GREEN + "畑区画 '" + name + "' の範囲を更新しました。");
+            return true;
+        } catch (SQLException e) {
+            admin.sendMessage(ChatColor.RED + "区画リサイズ中にエラーが発生しました。");
+            plugin.getLogger().severe("farm plot リサイズエラー: " + e.getMessage());
+            return false;
+        }
+    }
+
     public List<FarmPlot> listPlots() {
         try {
             return farmPlotDAO.getAllPlots();

--- a/src/main/java/org/tofu/tofunomics/integration/WorldGuardIntegration.java
+++ b/src/main/java/org/tofu/tofunomics/integration/WorldGuardIntegration.java
@@ -263,6 +263,74 @@ public class WorldGuardIntegration {
     }
 
     /**
+     * 既存領域を新しい座標範囲で再定義する。
+     * WorldGuardのCuboid領域はbounds（min/max）の直接変更APIを持たないため、
+     * 同IDで新しい領域を作成し、旧領域のメンバー/オーナー/フラグ/親/優先度を引き継ぐ。
+     * （区画リサイズ用。所有者・WGメンバー登録を保持したまま範囲のみ変更する）
+     *
+     * @param regionId 領域ID
+     * @param world ワールド
+     * @param pos1 新しい範囲の角1
+     * @param pos2 新しい範囲の角2
+     * @return 成功した場合true
+     */
+    public boolean redefineRegion(String regionId, World world, Location pos1, Location pos2) {
+        if (!enabled) {
+            logger.warning("WorldGuardが無効なため領域を再定義できません");
+            return false;
+        }
+
+        try {
+            RegionManager regionManager = regionContainer.get(BukkitAdapter.adapt(world));
+            if (regionManager == null) {
+                return false;
+            }
+
+            ProtectedRegion oldRegion = regionManager.getRegion(regionId);
+            if (oldRegion == null) {
+                logger.warning("再定義対象の領域 " + regionId + " が見つかりません");
+                return false;
+            }
+
+            BlockVector3 min = BlockVector3.at(
+                Math.min(pos1.getBlockX(), pos2.getBlockX()),
+                Math.min(pos1.getBlockY(), pos2.getBlockY()),
+                Math.min(pos1.getBlockZ(), pos2.getBlockZ())
+            );
+            BlockVector3 max = BlockVector3.at(
+                Math.max(pos1.getBlockX(), pos2.getBlockX()),
+                Math.max(pos1.getBlockY(), pos2.getBlockY()),
+                Math.max(pos1.getBlockZ(), pos2.getBlockZ())
+            );
+
+            // 同IDで新しいCuboid領域を作成し、旧領域の属性（メンバー/オーナー/フラグ/親/優先度）を引き継ぐ
+            // copyFromはbounds以外をコピーするため、まさにリサイズ用途に適する
+            ProtectedCuboidRegion newRegion = new ProtectedCuboidRegion(regionId, min, max);
+            newRegion.copyFrom(oldRegion);
+
+            // 同IDでaddRegionすると既存領域を置き換える
+            regionManager.addRegion(newRegion);
+
+            // 変更を保存
+            try {
+                regionManager.save();
+                logger.info("WorldGuard領域 " + regionId + " を新しい範囲で再定義しました");
+            } catch (Exception saveException) {
+                logger.severe("領域再定義の保存に失敗しました: " + saveException.getMessage());
+                // 保存失敗時は旧領域を再登録してロールバック
+                regionManager.addRegion(oldRegion);
+                return false;
+            }
+
+            return true;
+
+        } catch (Exception e) {
+            logger.severe("WorldGuard領域の再定義に失敗しました: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
      * プレイヤーが指定された場所で操作可能かをチェック
      * WorldGuardの保護設定を考慮してチェックする
      * 


### PR DESCRIPTION
## 概要
既存の畑区画を作り直さずに範囲だけを変更できる管理者向けコマンド `/farmplot resize <名前>` を追加します。

## 背景・目的
これまで畑区画の範囲を変えるには `delete` → `create` が必要で、その際に所有者(owner_uuid)・WorldGuardメンバー登録・リージョンIDが失われていました。本機能により、**所有者やメンバー登録を保持したまま範囲だけを変更**できるようになります。

## 変更内容
- **`FarmPlotCommand`**: `resize` サブコマンド追加（`tofunomics.farmplot.admin` 権限ガード内、引数検証・使用法表示・タブ補完対応）
- **`FarmPlotManager#resizePlot`**: WG有効性 / 選択範囲 / ワールド一致 / 区画存在を検証。WGリージョン再定義 → DB座標更新の順で実行し、DB更新失敗時はWGリージョンを旧範囲にロールバック
- **`WorldGuardIntegration#redefineRegion`**: 同IDで `ProtectedCuboidRegion` を再作成し `copyFrom()` でメンバー/オーナー/フラグ/優先度を引き継ぎ。save失敗時は旧領域を再登録
- **`FarmPlotDAO#updateCoordinates`**: 座標と `updated_at` のみ更新（owner_uuid 等は不変更）

## 使い方
1. `/farmplot pos1` → `/farmplot pos2` で新しい範囲の角を指定
2. `/farmplot resize <区画名>` で範囲を更新
3. `/farmplot info <区画名>` で新座標・所有者保持を確認

## テスト
- `mvn clean compile` 成功を確認
- 実機での動作確認は今後実施予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)