### PR TITLE
feat: 畑区画内のフェンスゲート/ドアを所有者のみ開閉可能に制限

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -807,6 +807,13 @@ public final class TofuNomics extends JavaPlugin {
                 getServer().getPluginManager().registerEvents(worldGuardTestModeListener, this);
                 getLogger().info("WorldGuardテストモードリスナーを登録しました");
             }
+
+            // 畑区画保護リスナーの登録（区画内のフェンスゲート/ドアを所有者に限定）
+            if (farmPlotManager != null) {
+                getServer().getPluginManager().registerEvents(
+                    new org.tofu.tofunomics.farming.FarmPlotProtectionListener(farmPlotManager), this);
+                getLogger().info("畑区画保護リスナーを登録しました");
+            }
             
             // ルール確認システムリスナーの登録
             if (rulesManager != null) {

--- a/src/main/java/org/tofu/tofunomics/farming/FarmPlotManager.java
+++ b/src/main/java/org/tofu/tofunomics/farming/FarmPlotManager.java
@@ -33,6 +33,10 @@ public class FarmPlotManager {
     private final Map<UUID, Location> pos1 = new HashMap<>();
     private final Map<UUID, Location> pos2 = new HashMap<>();
 
+    // 全区画のインメモリキャッシュ（フェンスゲート/ドア開閉判定で高頻度に参照されるためDBアクセスを避ける）
+    // 区画やオーナーが変わるたびに invalidateCache() で破棄する
+    private List<FarmPlot> plotCache = null;
+
     public FarmPlotManager(TofuNomics plugin, ConfigManager configManager, FarmPlotDAO farmPlotDAO) {
         this.plugin = plugin;
         this.configManager = configManager;
@@ -109,6 +113,7 @@ public class FarmPlotManager {
             pos1.remove(admin.getUniqueId());
             pos2.remove(admin.getUniqueId());
 
+            invalidateCache();
             admin.sendMessage(ChatColor.GREEN + "畑区画 '" + name + "' を作成しました（リージョン: " + regionId + "）。");
             return true;
         } catch (SQLException e) {
@@ -131,6 +136,7 @@ public class FarmPlotManager {
                 wg.removeRegion(plot.getWorldguardRegionId(), world);
             }
             farmPlotDAO.deletePlot(plot.getId());
+            invalidateCache();
             admin.sendMessage(ChatColor.GREEN + "畑区画 '" + name + "' を削除しました。");
             return true;
         } catch (SQLException e) {
@@ -203,6 +209,7 @@ public class FarmPlotManager {
             pos1.remove(admin.getUniqueId());
             pos2.remove(admin.getUniqueId());
 
+            invalidateCache();
             admin.sendMessage(ChatColor.GREEN + "畑区画 '" + name + "' の範囲を更新しました。");
             return true;
         } catch (SQLException e) {
@@ -228,6 +235,39 @@ public class FarmPlotManager {
             plugin.getLogger().severe("farm plot 取得エラー: " + e.getMessage());
             return null;
         }
+    }
+
+    /**
+     * 指定座標を含む畑区画を返す（無ければnull）。
+     * フェンスゲート/ドアの開閉判定など高頻度呼び出しを想定し、全区画をキャッシュして走査する。
+     */
+    public FarmPlot getPlotAt(Location location) {
+        if (location == null) {
+            return null;
+        }
+        List<FarmPlot> plots = plotCache;
+        if (plots == null) {
+            try {
+                plots = farmPlotDAO.getAllPlots();
+            } catch (SQLException e) {
+                plugin.getLogger().severe("farm plot キャッシュ取得エラー: " + e.getMessage());
+                return null;
+            }
+            plotCache = plots;
+        }
+        for (FarmPlot plot : plots) {
+            if (plot.contains(location)) {
+                return plot;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 区画キャッシュを破棄する。区画の作成/削除/リサイズや所有者の割り当て/解放の成功後に呼ぶ。
+     */
+    private void invalidateCache() {
+        plotCache = null;
     }
 
     // ========== 割り当て / 解放 ==========
@@ -267,6 +307,7 @@ public class FarmPlotManager {
                 return;
             }
             farmPlotDAO.updateOwner(plot.getId(), uuid);
+            invalidateCache();
 
             int cx = (plot.getX1() + plot.getX2()) / 2;
             int cy = Math.max(plot.getY1(), plot.getY2());
@@ -295,6 +336,7 @@ public class FarmPlotManager {
                 wg.removeMember(plot.getWorldguardRegionId(), world, playerUuid);
             }
             farmPlotDAO.updateOwner(plot.getId(), null);
+            invalidateCache();
 
             Player player = Bukkit.getPlayer(playerUuid);
             if (player != null && player.isOnline()) {
@@ -336,6 +378,7 @@ public class FarmPlotManager {
             }
             wg.addMember(plot.getWorldguardRegionId(), world, target.getUniqueId());
             farmPlotDAO.updateOwner(plot.getId(), uuid);
+            invalidateCache();
             admin.sendMessage(ChatColor.GREEN + target.getName() + " に区画 '" + plot.getPlotName() + "' を割り当てました。");
             target.sendMessage(ChatColor.GREEN + "農家の畑区画 '" + plot.getPlotName() + "' が割り当てられました。");
             return true;

--- a/src/main/java/org/tofu/tofunomics/farming/FarmPlotProtectionListener.java
+++ b/src/main/java/org/tofu/tofunomics/farming/FarmPlotProtectionListener.java
@@ -1,0 +1,78 @@
+package org.tofu.tofunomics.farming;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Tag;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.tofu.tofunomics.models.FarmPlot;
+
+/**
+ * 畑区画(farmplot)内のフェンスゲート/ドア/トラップドアの開閉を所有者に限定するリスナー。
+ *
+ * WorldGuardのメンバー機構はブロックの破壊・設置は保護するが、フェンスゲート/ドアの
+ * 「開閉(右クリック)」はデフォルト設定では制御されないことが多い。本リスナーで、
+ * 区画内のゲート/ドアは当該区画の所有者(owner_uuid)以外には開かせない。
+ *
+ * 仕様:
+ * - 区画内 かつ プレイヤーが当該区画の所有者でない → 開閉をキャンセル
+ * - 未割当(owner_uuid=null)区画は所有者が存在しないため、誰も開けない
+ * - 管理者バイパスなし(OPでも所有者でなければ開けない)。WGのbypass権限ですり抜けるのを防ぐため、
+ *   WorldGuardのcanInteractではなくDBのowner_uuidを直接比較する。
+ */
+public class FarmPlotProtectionListener implements Listener {
+
+    private final FarmPlotManager farmPlotManager;
+
+    public FarmPlotProtectionListener(FarmPlotManager farmPlotManager) {
+        this.farmPlotManager = farmPlotManager;
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onInteractGate(PlayerInteractEvent event) {
+        // メインハンドのみ処理(オフハンドでの二重発火を防止)
+        if (event.getHand() != EquipmentSlot.HAND) {
+            return;
+        }
+        // ブロックの右クリックのみ対象
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+        Block block = event.getClickedBlock();
+        if (block == null) {
+            return;
+        }
+        // 対象はフェンスゲート/ドア/トラップドア(鉄ドア・鉄トラップドア含む。Tagで全種網羅)
+        if (!isGateOrDoor(block)) {
+            return;
+        }
+
+        FarmPlot plot = farmPlotManager.getPlotAt(block.getLocation());
+        if (plot == null) {
+            // 区画外は通常動作
+            return;
+        }
+
+        Player player = event.getPlayer();
+        String owner = plot.getOwnerUuid();
+        if (owner != null && owner.equals(player.getUniqueId().toString())) {
+            // 区画の所有者は開閉可能
+            return;
+        }
+
+        // 非所有者・未割当区画は全員拒否
+        event.setCancelled(true);
+        player.sendMessage(ChatColor.RED + "ここは他の農家の畑区画です。所有者しか開けられません。");
+    }
+
+    private boolean isGateOrDoor(Block block) {
+        return Tag.FENCE_GATES.isTagged(block.getType())
+                || Tag.DOORS.isTagged(block.getType())
+                || Tag.TRAPDOORS.isTagged(block.getType());
+    }
+}


### PR DESCRIPTION
## 概要

farmplotで指定した区画内のフェンスゲート・ドア・トラップドアを、その区画の**所有者（アサインされたユーザー）以外は開けない**ようにします。WorldGuardのメンバー機構はブロックの破壊・設置は保護しますが、ゲート/ドアの**開閉（右クリック）**はデフォルトでは制御されず、他人が畑に侵入できてしまう問題を解決します。

## 仕様（ユーザー確認済み）

- **対象ブロック**: フェンスゲート ＋ ドア・トラップドア類（侵入経路を網羅）
- **未割当（空き）区画**: 所有者が存在しないため、誰も開けない
- **管理者バイパス**: なし。OP/管理者でも区画の所有者でなければ開けない
- ロジックは「区画内 かつ 非所有者 → 開閉をキャンセル」のみ

## 変更内容

- `FarmPlotProtectionListener`（新規）: `PlayerInteractEvent`（HIGH, ignoreCancelled）で、区画内のゲート/ドア右クリックを所有者判定。`getHand()==HAND`・`RIGHT_CLICK_BLOCK` でガード
- 所有者判定はDBの `owner_uuid` を直接比較（WGの `canInteract` は使わない＝OPが `worldguard.region.bypass` ですり抜けるのを防止）
- 対象判定は `Tag.FENCE_GATES` / `Tag.DOORS` / `Tag.TRAPDOORS`（木材全種＋鉄ドア/鉄トラップドアを列挙不要で網羅）
- `FarmPlotManager` に `getPlotAt(Location)` と区画のインメモリキャッシュを追加。create/delete/resize/assign/release の成功時に `invalidateCache()` でキャッシュ無効化
- `TofuNomics#registerEventListeners()` にリスナー登録を追記

## テスト

- `mvn clean package` 成功
- `mvn test`: 365 tests, 0 failures
- ゲーム内動作確認は別途実施予定（所有者は開閉可 / 非所有者・OP・未割当区画は不可 / 区画外は従来どおり / assign-release後の即時切替）

🤖 Generated with [Claude Code](https://claude.com/claude-code)