### PR TITLE
feat: NPC購入アイテムの取引所転売を防止（アービトラージ封じ）

### DIFF
--- a/src/main/java/org/tofu/tofunomics/npc/FoodNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/FoodNPCManager.java
@@ -10,6 +10,7 @@ import org.tofu.tofunomics.TofuNomics;
 import org.tofu.tofunomics.config.ConfigManager;
 import org.tofu.tofunomics.economy.CurrencyConverter;
 import org.tofu.tofunomics.dao.PlayerDAO;
+import org.tofu.tofunomics.util.NPCPurchaseMarker;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -438,7 +439,13 @@ public class FoodNPCManager {
         }
         
         // アイテム付与
+        // 取引所で売却可能なアイテム（item_pricesに価格があるもの）のみNPC購入マーカーを付与し、
+        // 食料NPC購入価格 < 取引所売却価格 を悪用した転売（アービトラージ）を防止する。
+        // 非売却品（bread等）はマークせず、通常の手持ちアイテムと同一スタックになるようにする。
         ItemStack item = new ItemStack(itemType, amount);
+        if (configManager.getItemBasePrice(itemType.name()) > 0) {
+            item = NPCPurchaseMarker.mark(plugin, item);
+        }
         player.getInventory().addItem(item);
         
         // 在庫減少

--- a/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
+++ b/src/main/java/org/tofu/tofunomics/npc/TradingNPCManager.java
@@ -11,6 +11,7 @@ import org.tofu.tofunomics.economy.CurrencyConverter;
 import org.tofu.tofunomics.jobs.JobManager;
 import org.tofu.tofunomics.trade.TradePriceManager;
 import org.tofu.tofunomics.dao.PlayerDAO;
+import org.tofu.tofunomics.util.NPCPurchaseMarker;
 
 import java.util.*;
 
@@ -620,7 +621,9 @@ public class TradingNPCManager {
         
         for (ItemStack item : items) {
             if (item == null || item.getType() == Material.AIR) continue;
-            
+            // NPC購入マーカー付きアイテムは転売不可（GUI側でも除外するが精算側でも防御）
+            if (NPCPurchaseMarker.isMarked(plugin, item)) continue;
+
             Material material = item.getType();
             double basePrice = tradingPost.getItemPrice(material);
             

--- a/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
+++ b/src/main/java/org/tofu/tofunomics/npc/gui/TradingGUI.java
@@ -20,6 +20,7 @@ import org.tofu.tofunomics.trade.TradePriceManager;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import org.tofu.tofunomics.util.NPCPurchaseMarker;
 
 public class TradingGUI implements Listener {
     
@@ -469,7 +470,8 @@ public class TradingGUI implements Listener {
     private int countPlayerItems(Player player, Material material) {
         int count = 0;
         for (ItemStack item : player.getInventory().getContents()) {
-            if (item != null && matchesSellable(item.getType(), material)) {
+            if (item != null && matchesSellable(item.getType(), material)
+                    && !NPCPurchaseMarker.isMarked(plugin, item)) {
                 count += item.getAmount();
             }
         }
@@ -869,7 +871,8 @@ public class TradingGUI implements Listener {
         int remaining = sellAmount;
         
         for (ItemStack item : player.getInventory().getContents()) {
-            if (item != null && matchesSellable(item.getType(), material) && !isCurrencyItem(item) && remaining > 0) {
+            if (item != null && matchesSellable(item.getType(), material) && !isCurrencyItem(item)
+                    && !NPCPurchaseMarker.isMarked(plugin, item) && remaining > 0) {
                 int available = item.getAmount();
                 int takeAmount = Math.min(available, remaining);
                 
@@ -910,7 +913,8 @@ public class TradingGUI implements Listener {
             
             for (int i = 0; i < player.getInventory().getSize(); i++) {
                 ItemStack item = player.getInventory().getItem(i);
-                if (item != null && item.getType() == sellMaterial && remainingToRemove > 0) {
+                if (item != null && item.getType() == sellMaterial && remainingToRemove > 0
+                        && !NPCPurchaseMarker.isMarked(plugin, item)) {
                     int removeAmount = Math.min(item.getAmount(), remainingToRemove);
                     
                     // バックアップ
@@ -1033,7 +1037,8 @@ public class TradingGUI implements Listener {
         List<ItemStack> allItems = new ArrayList<>();
         
         for (ItemStack item : player.getInventory().getContents()) {
-            if (item != null && item.getAmount() > 0 && tradingPost.getItemPrice(item.getType()) > 0) {
+            if (item != null && item.getAmount() > 0 && tradingPost.getItemPrice(item.getType()) > 0
+                    && !NPCPurchaseMarker.isMarked(plugin, item)) {
                 allItems.add(item.clone());
             }
         }
@@ -1052,7 +1057,8 @@ public class TradingGUI implements Listener {
             
             for (int i = 0; i < player.getInventory().getSize(); i++) {
                 ItemStack item = player.getInventory().getItem(i);
-                if (item != null && item.getType() == sellMaterial && remainingToRemove > 0) {
+                if (item != null && item.getType() == sellMaterial && remainingToRemove > 0
+                        && !NPCPurchaseMarker.isMarked(plugin, item)) {
                     int removeAmount = Math.min(item.getAmount(), remainingToRemove);
                     
                     // バックアップ

--- a/src/main/java/org/tofu/tofunomics/util/NPCPurchaseMarker.java
+++ b/src/main/java/org/tofu/tofunomics/util/NPCPurchaseMarker.java
@@ -1,0 +1,59 @@
+package org.tofu.tofunomics.util;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.tofu.tofunomics.TofuNomics;
+
+/**
+ * NPC（食料NPC等）から購入したアイテムを識別するためのマーカー。
+ *
+ * PersistentDataContainer（ItemMetaの一部）に不可視のフラグを付与する。
+ * これにより「NPCから購入したアイテム」と「プレイヤーが自分で採取したアイテム」を
+ * 区別でき、取引所での転売（食料NPC購入価格 &lt; 取引所売却価格 を悪用した
+ * アービトラージ）を防止する。
+ *
+ * マーカー付きアイテムはItemMetaが無印アイテムと異なるため、インベントリ上で
+ * 別スタックとして扱われ混ざらない（Minecraftの仕様）。これがマーカー方式の前提。
+ */
+public final class NPCPurchaseMarker {
+
+    private static final String KEY = "npc_purchase";
+
+    private NPCPurchaseMarker() {
+    }
+
+    private static NamespacedKey key(TofuNomics plugin) {
+        return new NamespacedKey(plugin, KEY);
+    }
+
+    /**
+     * アイテムにNPC購入マーカーを付与する。
+     *
+     * @return マーカー付与後のItemStack（引数と同一インスタンス）
+     */
+    public static ItemStack mark(TofuNomics plugin, ItemStack item) {
+        if (item == null) {
+            return item;
+        }
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.getPersistentDataContainer().set(key(plugin), PersistentDataType.BYTE, (byte) 1);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    /**
+     * アイテムがNPC購入マーカーを持つか判定する。
+     */
+    public static boolean isMarked(TofuNomics plugin, ItemStack item) {
+        if (item == null || !item.hasItemMeta()) {
+            return false;
+        }
+        ItemMeta meta = item.getItemMeta();
+        return meta != null
+            && meta.getPersistentDataContainer().has(key(plugin), PersistentDataType.BYTE);
+    }
+}

--- a/src/test/java/org/tofu/tofunomics/util/NPCPurchaseMarkerTest.java
+++ b/src/test/java/org/tofu/tofunomics/util/NPCPurchaseMarkerTest.java
@@ -1,0 +1,102 @@
+package org.tofu.tofunomics.util;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.tofu.tofunomics.TofuNomics;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * NPCPurchaseMarker のロジック分岐・null安全性を検証する。
+ *
+ * PersistentDataContainer の実際の永続化・スタック分離挙動はBukkitの保証であり、
+ * テスト環境（実Bukkitサーバーなし）では検証できないため、ここでは
+ * 「マーカー付与/判定が正しい分岐で呼ばれるか」をMockitoで検証する。
+ */
+public class NPCPurchaseMarkerTest {
+
+    @Mock
+    private TofuNomics plugin;
+    @Mock
+    private ItemStack item;
+    @Mock
+    private ItemMeta meta;
+    @Mock
+    private PersistentDataContainer pdc;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        // NamespacedKey(plugin, key) は plugin.getName() を namespace に使う
+        when(plugin.getName()).thenReturn("tofunomics");
+    }
+
+    @Test
+    public void mark_metaがある場合はPDCにフラグを付与しsetItemMetaする() {
+        when(item.getItemMeta()).thenReturn(meta);
+        when(meta.getPersistentDataContainer()).thenReturn(pdc);
+
+        ItemStack result = NPCPurchaseMarker.mark(plugin, item);
+
+        assertSame(item, result);
+        verify(pdc).set(any(NamespacedKey.class), eq(PersistentDataType.BYTE), eq((byte) 1));
+        verify(item).setItemMeta(meta);
+    }
+
+    @Test
+    public void mark_nullアイテムはNPEにならずnullを返す() {
+        assertNull(NPCPurchaseMarker.mark(plugin, null));
+    }
+
+    @Test
+    public void mark_metaがnullならsetItemMetaせずそのまま返す() {
+        when(item.getItemMeta()).thenReturn(null);
+
+        ItemStack result = NPCPurchaseMarker.mark(plugin, item);
+
+        assertSame(item, result);
+        verify(item, never()).setItemMeta(any());
+    }
+
+    @Test
+    public void isMarked_マーカー付きはtrue() {
+        when(item.hasItemMeta()).thenReturn(true);
+        when(item.getItemMeta()).thenReturn(meta);
+        when(meta.getPersistentDataContainer()).thenReturn(pdc);
+        when(pdc.has(any(NamespacedKey.class), eq(PersistentDataType.BYTE))).thenReturn(true);
+
+        assertTrue(NPCPurchaseMarker.isMarked(plugin, item));
+    }
+
+    @Test
+    public void isMarked_マーカー無しはfalse() {
+        when(item.hasItemMeta()).thenReturn(true);
+        when(item.getItemMeta()).thenReturn(meta);
+        when(meta.getPersistentDataContainer()).thenReturn(pdc);
+        when(pdc.has(any(NamespacedKey.class), eq(PersistentDataType.BYTE))).thenReturn(false);
+
+        assertFalse(NPCPurchaseMarker.isMarked(plugin, item));
+    }
+
+    @Test
+    public void isMarked_metaを持たないアイテムはfalse() {
+        when(item.hasItemMeta()).thenReturn(false);
+
+        assertFalse(NPCPurchaseMarker.isMarked(plugin, item));
+    }
+
+    @Test
+    public void isMarked_nullアイテムはfalse() {
+        assertFalse(NPCPurchaseMarker.isMarked(plugin, null));
+    }
+}


### PR DESCRIPTION
## 背景

経済バランス調査で、**食料NPCの購入価格 < 取引所の売却価格**になっているアイテムがあり、労働ゼロで「買って売る」だけの不労所得（アービトラージ）が成立していた。

| アイテム | 食料NPC購入 | 取引所売却 | 漁師倍率込み | 差益 |
|---|---|---|---|---|
| carrot | 2 | 4 | 4 | +2 |
| potato | 0.2 | 4 | 4 | +3.8 |
| beetroot | 2 | 3 | 3 | +1 |
| cooked_cod | 6 | 7 | 8.4 | +1〜2.4 |
| cooked_salmon | 7 | 8 | 9.6 | +1〜2.6 |

即時採取収入(JobIncomeManager)が無効な現状、収入はNPC売却に集中しており、この穴の影響が大きい。

## 対応（マーカー方式）

価格は据え置き、食料NPC購入アイテムに**不可視マーカー（PersistentDataContainer）**を付け、取引所での売却対象から除外する。採取物の売却・緊急食料の安さを両立し、将来の価格変更にも強い。前例: `ItemManager` の通貨金塊メタ識別。

- `util/NPCPurchaseMarker`（新規）: PDCマーカーの付与/判定。
- `FoodNPCManager`: 購入時にマーカー付与（**売却対象=item_pricesに価格があるもののみ**マークし、bread等のスタック分離副作用を回避）。
- `TradingNPCManager.processItemSale`: 精算側の防御ガード。
- `TradingGUI`: 収集2箇所・**削除ループ2箇所**・プレビュー件数でマーカー除外。
  - ⚠️ 削除ループはマテリアル一致のみで削るため、収集だけ除外しても「無印を売ったつもりでマーカー品が削られる」穴が残る。削除側でも除外して対処。

マーカー付き(NPC購入)と無印(採取)はItemMetaが異なり**別スタックになり混ざらない**のが本方式の前提。

## 非対象
- マーケット（プレイヤー間取引）: 手数料5%＋マーカーが残るため転売不可。ブロック不要。
- 改修前に購入済みの手持ち: 無印のまま売却可（過去分のみ・影響軽微）。

## テスト
- `NPCPurchaseMarkerTest`（7件）追加。全372テストパス（`mvn clean package`）。
- ゲーム内確認推奨: ①NPC購入carrotが売れない ②採取carrotは売れる ③混在時に採取分だけ売れNPC分は残る ④cooked_salmon(漁師)も同様。

## デプロイ
- コード変更のためjarリビルド＆デプロイが必要。config変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)