### PR TITLE
config: 木こりの原木価格を板材と整合（原木2・板材1で価値中立）

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -701,19 +701,19 @@ npc_system:
     emerald_ore: 16
     coal_ore: 1
     copper_ore: 1.5
-    # 木材系（リリース前バランス調整: 採取系の極端な安値を是正）
-    oak_log: 0.5
-    birch_log: 0.5
-    spruce_log: 0.5
-    jungle_log: 0.7
-    acacia_log: 0.7
-    dark_oak_log: 0.7
-    mangrove_log: 0.7
-    cherry_log: 0.7
-    # 木材製品
-    oak_planks: 0.12
-    birch_planks: 0.12
-    spruce_planks: 0.12
+    # 木材系（職業間格差是正: 木こりの極端な低単価を約2倍に引き上げ。専用取引所では原木2倍ボーナスで実効2.0/2.6）
+    oak_log: 1.0
+    birch_log: 1.0
+    spruce_log: 1.0
+    jungle_log: 1.3
+    acacia_log: 1.3
+    dark_oak_log: 1.3
+    mangrove_log: 1.3
+    cherry_log: 1.3
+    # 木材製品（原木1個→板材4個。板材×4 < 原木base を維持し加工転売を防止）
+    oak_planks: 0.22
+    birch_planks: 0.22
+    spruce_planks: 0.22
     # 農作物系（バランス調整: レアリティ順の階段に再設計。小麦=最安基準）
     # 最安(3): 小麦・ビートルート・サトウキビ / 中(4): じゃがいも・にんじん・メロン
     # 上(5): かぼちゃ・カカオ豆 / 最高(6): ネザーウォート
@@ -792,24 +792,24 @@ npc_system:
     diorite: 1
     granite: 1
     # --- woodcutter: 板材・剥いだ原木・苗木・竹 ---
-    jungle_planks: 0.12
-    acacia_planks: 0.12
-    dark_oak_planks: 0.12
-    mangrove_planks: 0.12
-    cherry_planks: 0.12
-    crimson_planks: 0.18
-    warped_planks: 0.18
+    jungle_planks: 0.22
+    acacia_planks: 0.22
+    dark_oak_planks: 0.22
+    mangrove_planks: 0.22
+    cherry_planks: 0.22
+    crimson_planks: 0.3
+    warped_planks: 0.3
     bamboo_planks: 0.1
-    bamboo: 0.3
+    bamboo: 0.5
     stick: 0.05
-    stripped_oak_log: 0.5
-    stripped_birch_log: 0.5
-    stripped_spruce_log: 0.5
-    stripped_jungle_log: 0.7
-    stripped_acacia_log: 0.7
-    stripped_dark_oak_log: 0.7
-    stripped_mangrove_log: 0.7
-    stripped_cherry_log: 0.7
+    stripped_oak_log: 1.0
+    stripped_birch_log: 1.0
+    stripped_spruce_log: 1.0
+    stripped_jungle_log: 1.3
+    stripped_acacia_log: 1.3
+    stripped_dark_oak_log: 1.3
+    stripped_mangrove_log: 1.3
+    stripped_cherry_log: 1.3
     oak_sapling: 0.5
     birch_sapling: 0.5
     spruce_sapling: 0.5

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -701,19 +701,20 @@ npc_system:
     emerald_ore: 16
     coal_ore: 1
     copper_ore: 1.5
-    # 木材系（職業間格差是正: 木こりの極端な低単価を約2倍に引き上げ。専用取引所では原木2倍ボーナスで実効2.0/2.6）
-    oak_log: 1.0
-    birch_log: 1.0
-    spruce_log: 1.0
-    jungle_log: 1.3
-    acacia_log: 1.3
-    dark_oak_log: 1.3
-    mangrove_log: 1.3
-    cherry_log: 1.3
-    # 木材製品（原木1個→板材4個。板材×4 < 原木base を維持し加工転売を防止）
-    oak_planks: 0.22
-    birch_planks: 0.22
-    spruce_planks: 0.22
+    # 木材系（職業間格差是正: 原木と板材の価値を整合。原木1個=板材4個(4×1)で中立にし、クラフト転売を解消。
+    #         専用取引所の原木2倍ボーナスで実効4 = 板材4個分。サーバー実値の板材=1に合わせ原木を2へ）
+    oak_log: 2
+    birch_log: 2
+    spruce_log: 2
+    jungle_log: 2
+    acacia_log: 2
+    dark_oak_log: 2
+    mangrove_log: 2
+    cherry_log: 2
+    # 木材製品（原木1個→板材4個。整数通貨で個別売却できるよう1に統一）
+    oak_planks: 1
+    birch_planks: 1
+    spruce_planks: 1
     # 農作物系（バランス調整: レアリティ順の階段に再設計。小麦=最安基準）
     # 最安(3): 小麦・ビートルート・サトウキビ / 中(4): じゃがいも・にんじん・メロン
     # 上(5): かぼちゃ・カカオ豆 / 最高(6): ネザーウォート
@@ -792,24 +793,24 @@ npc_system:
     diorite: 1
     granite: 1
     # --- woodcutter: 板材・剥いだ原木・苗木・竹 ---
-    jungle_planks: 0.22
-    acacia_planks: 0.22
-    dark_oak_planks: 0.22
-    mangrove_planks: 0.22
-    cherry_planks: 0.22
-    crimson_planks: 0.3
-    warped_planks: 0.3
+    jungle_planks: 1
+    acacia_planks: 1
+    dark_oak_planks: 1
+    mangrove_planks: 1
+    cherry_planks: 1
+    crimson_planks: 1
+    warped_planks: 1
     bamboo_planks: 0.1
-    bamboo: 0.5
+    bamboo: 1
     stick: 0.05
-    stripped_oak_log: 1.0
-    stripped_birch_log: 1.0
-    stripped_spruce_log: 1.0
-    stripped_jungle_log: 1.3
-    stripped_acacia_log: 1.3
-    stripped_dark_oak_log: 1.3
-    stripped_mangrove_log: 1.3
-    stripped_cherry_log: 1.3
+    stripped_oak_log: 2
+    stripped_birch_log: 2
+    stripped_spruce_log: 2
+    stripped_jungle_log: 2
+    stripped_acacia_log: 2
+    stripped_dark_oak_log: 2
+    stripped_mangrove_log: 2
+    stripped_cherry_log: 2
     oak_sapling: 0.5
     birch_sapling: 0.5
     spruce_sapling: 0.5


### PR DESCRIPTION
## 背景・調査での修正

当初「原木0.5は低すぎ」と診断したが、**サーバー実値を確認したところ板材=1**（リポジトリの0.12から乖離）と判明。Minecraftでは原木1個→板材4個なので、木こりは原木を板材にクラフトして売ると**実効4G/原木**となり、農家主力（wheat 3・carrot 4）と既に同等だった。つまり「原木が無駄に安い」だけで、実収入は低くなかった。

そこで方針を**原木と板材の価値整合**（クラフト転売の解消）に変更。

## 変更（item_prices）

| 項目 | 変更前(repo) | サーバー実値 | 変更後 |
|---|---|---|---|
| 原木 oak/birch/spruce（stripped含む） | 0.5 | 0.5 | **2** |
| 原木 広葉樹5種（stripped含む） | 0.7 | 0.7 | **2** |
| 板材8種 | 0.12 | 1 | **1** |
| crimson/warped_planks | 0.18 | 1 | **1** |
| bamboo | 0.3 | 1 | **1** |

- 原木2 × 専用取引所2倍ボーナス = **実効4 = 板材4個分**で価値中立。原木/板材どちらを売っても同じ＝クラフト転売の動機を解消。
- 板材・bambooはサーバー実値(1)に合わせ、リポジトリのドリフトも是正（整数通貨で個別売却可能に）。
- stripped原木も `_LOG` 判定で2倍ボーナス対象のため同額(2)。
- bamboo_planks・stick・苗木は据え置き。

## 反映状況

- **サーバー実ファイルに反映済み**（板材/bambooは既に1のため原木16キーのみ pinpoint 変更、YAML検証・NPC座標保持を確認）。バックアップ: `config.yml.backup.20260626-204121`。
- リロード後のゲーム内確認推奨: 木こりで原木を売ると専用取引所で2×2=実効4、板材を売っても4で**クラフトしてもしなくても同じ**になること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)