### PR TITLE
feat: /jobs list で上級職業を区別表示

### DIFF
--- a/src/main/java/org/tofu/tofunomics/commands/JobsCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/JobsCommand.java
@@ -82,25 +82,42 @@ public class JobsCommand implements CommandExecutor {
             int maxLevel = configManager.getJobMaxLevel(jobName);
             double incomeMultiplier = configManager.getJobIncomeMultiplier(jobName);
             boolean employed = jobManager.hasJob(player, jobName);
+            // 上級職業の判定（GUIのJobsHubGUIと同じロジック）
+            boolean advanced = configManager.isAdvancedJob(jobName);
+            // 上級職業が未解禁か（未就職かつLv50到達経験なし）
+            boolean advancedLocked = advanced && !employed && !jobManager.hasReachedLevel50(player);
 
             if (clickable) {
                 // ホバーで詳細（説明・最大レベル・収入倍率）を表示するツールチップを構築
                 StringBuilder hover = new StringBuilder();
+                if (advanced) {
+                    hover.append("&6&l【上級職業】\n");
+                }
                 hover.append("&e").append(displayName).append(" &7(").append(jobName).append(")\n");
                 if (description != null && !description.isEmpty()) {
                     hover.append("&f").append(description).append("\n");
                 }
                 hover.append("&b最大レベル: ").append(maxLevel)
                      .append(" &7| &b収入倍率: ").append(String.format("%.1f", incomeMultiplier)).append("x");
+                if (advanced) {
+                    hover.append("\n&7※いずれかの職業でLv50到達後に就職できます");
+                }
+
+                String label = advanced
+                    ? "&6▶ ★[上級] " + displayName + " &7(" + jobName + ")  "
+                    : "&e▶ " + displayName + " &7(" + jobName + ")  ";
 
                 org.tofu.tofunomics.util.RichMessageBuilder builder =
                     org.tofu.tofunomics.util.RichMessageBuilder.create()
-                        .hoverText("&e▶ " + displayName + " &7(" + jobName + ")  ", hover.toString());
+                        .hoverText(label, hover.toString());
 
                 if (employed) {
                     PlayerJob playerJob = jobManager.getPlayerJob(player, jobName);
                     int currentLevel = playerJob != null ? playerJob.getLevel() : 0;
                     builder.text("&a[現在就職中 Lv." + currentLevel + "]");
+                } else if (advancedLocked) {
+                    // 未解禁の上級職業はクリック不可のテキスト表示
+                    builder.text("&c[未解禁] &7Lv50到達で解禁");
                 } else {
                     // クリックで就職できるボタン
                     builder.runButton("&a&l[就職する]", "/jobs join " + jobName,
@@ -108,7 +125,12 @@ public class JobsCommand implements CommandExecutor {
                 }
                 builder.sendTo(player);
             } else {
-                player.sendMessage(ChatColor.YELLOW + "▶ " + displayName + ChatColor.GRAY + " (" + jobName + ")");
+                if (advanced) {
+                    player.sendMessage(ChatColor.GOLD + "▶ ★[上級] " + displayName + ChatColor.GRAY + " (" + jobName + ")");
+                    player.sendMessage(ChatColor.GOLD + "  【上級職業】");
+                } else {
+                    player.sendMessage(ChatColor.YELLOW + "▶ " + displayName + ChatColor.GRAY + " (" + jobName + ")");
+                }
                 if (description != null && !description.isEmpty()) {
                     player.sendMessage(ChatColor.WHITE + "  " + description);
                 }
@@ -125,6 +147,8 @@ public class JobsCommand implements CommandExecutor {
                         player.sendMessage(ChatColor.GREEN + "  ★ 現在就職中 - レベル " + currentLevel +
                                          " (経験値: " + (int)currentExp + "/" + requiredExp + ")");
                     }
+                } else if (advancedLocked) {
+                    player.sendMessage(ChatColor.RED + "  ✖ 未解禁 - いずれかの職業でLv50到達後に就職できます");
                 }
                 player.sendMessage("");
             }


### PR DESCRIPTION
## 概要

`/jobs list` コマンドの一覧表示で、上級職業（alchemist / enchanter / architect）が通常職業とまったく同じフォーマットで表示されてしまう問題を修正しました。

GUI 版（`JobsHubGUI`）はすでに「【上級職業】」ラベルや未解禁状態を区別表示していましたが、コマンド版だけが区別を持たず、プレイヤーが一覧から上級職を判別できませんでした。

## 変更内容

`JobsCommand.handleJobsList()` に GUI と同じ判定ロジックを追加:

```java
boolean advanced = configManager.isAdvancedJob(jobName);
boolean advancedLocked = advanced && !employed && !jobManager.hasReachedLevel50(player);
```

- **clickable 版**: 上級職は見出しに `★[上級]` 接頭辞＋金色、ホバー先頭に「【上級職業】」を表示。未解禁時は `[就職する]` ボタンの代わりに `[未解禁] Lv50到達で解禁` をクリック不可テキストで表示。
- **プレーンテキスト版**: 上級職は金色＋`★[上級]` 接頭辞、「【上級職業】」行を追加。未解禁時は「✖ 未解禁 - いずれかの職業でLv50到達後に就職できます」を表示。

表示文言は GUI 側（ハードコード）と統一。messages.yml への新規キー追加は行っていません。

## 検証

- `mvn clean package` でコンパイル成功。
- ゲーム内確認（要実施）:
  - 非OP・Lv50未到達プレイヤーで上級職に「【上級職業】」＋「未解禁」が表示される
  - clickable ON/OFF 両方
  - Lv50到達済みプレイヤーでは未解禁ではなく就職可能表示になる
  - 上級職就職済みプレイヤーでは「現在就職中」が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)