### PR TITLE
feat: /jobs guide コマンドで職業ガイドブックを入手可能に

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -146,6 +146,7 @@ public final class TofuNomics extends JavaPlugin {
     private org.tofu.tofunomics.jobs.gui.JobsGUIListener jobsGUIListener;
     private org.tofu.tofunomics.jobs.gui.JobsHubGUI jobsHubGUI;
     private org.tofu.tofunomics.jobs.gui.JobDetailGUI jobDetailGUI;
+    private org.tofu.tofunomics.jobs.JobGuideBookService jobGuideBookService;
     private org.tofu.tofunomics.jobs.gui.JobStatsGUI jobStatsGUI;
     private org.tofu.tofunomics.jobs.gui.JobConfirmGUI jobConfirmGUI;
     private org.tofu.tofunomics.market.MarketExpirationTask marketExpirationTask;
@@ -452,8 +453,9 @@ public final class TofuNomics extends JavaPlugin {
 
             // 職業GUI（ハブ・詳細・ステータス・確認）を配線する（Market と同型）
             jobsGUIListener = new org.tofu.tofunomics.jobs.gui.JobsGUIListener(this);
+            jobGuideBookService = new org.tofu.tofunomics.jobs.JobGuideBookService(configManager, jobManager);
             jobDetailGUI = new org.tofu.tofunomics.jobs.gui.JobDetailGUI(
-                this, configManager, jobManager, experienceManager, jobsGUIListener);
+                this, configManager, jobManager, experienceManager, jobsGUIListener, jobGuideBookService);
             jobStatsGUI = new org.tofu.tofunomics.jobs.gui.JobStatsGUI(
                 this, configManager, jobManager, experienceManager, jobsGUIListener);
             jobConfirmGUI = new org.tofu.tofunomics.jobs.gui.JobConfirmGUI(
@@ -853,7 +855,7 @@ public final class TofuNomics extends JavaPlugin {
             getCommand("eco").setExecutor(new EcoCommand(configManager, currencyConverter, playerDAO));
             
             // 職業系コマンド
-            getCommand("jobs").setExecutor(new JobsCommand(configManager, jobManager, experienceManager, jobsHubGUI, jobStatsManager));
+            getCommand("jobs").setExecutor(new JobsCommand(configManager, jobManager, experienceManager, jobsHubGUI, jobStatsManager, jobGuideBookService));
 
             // 畑区画コマンド
             if (farmPlotManager != null && getCommand("farmplot") != null) {

--- a/src/main/java/org/tofu/tofunomics/commands/JobsCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/JobsCommand.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.tofu.tofunomics.config.ConfigManager;
 import org.tofu.tofunomics.jobs.JobManager;
 import org.tofu.tofunomics.jobs.ExperienceManager;
+import org.tofu.tofunomics.jobs.JobGuideBookService;
 import org.tofu.tofunomics.jobs.gui.JobsHubGUI;
 import org.tofu.tofunomics.models.PlayerJob;
 import org.tofu.tofunomics.models.Job;
@@ -20,15 +21,17 @@ public class JobsCommand implements CommandExecutor {
     private final ExperienceManager experienceManager;
     private final JobsHubGUI jobsHubGUI;
     private final JobStatsManager jobStatsManager;
+    private final JobGuideBookService guideBookService;
 
     public JobsCommand(ConfigManager configManager, JobManager jobManager,
                        ExperienceManager experienceManager, JobsHubGUI jobsHubGUI,
-                       JobStatsManager jobStatsManager) {
+                       JobStatsManager jobStatsManager, JobGuideBookService guideBookService) {
         this.configManager = configManager;
         this.jobManager = jobManager;
         this.experienceManager = experienceManager;
         this.jobsHubGUI = jobsHubGUI;
         this.jobStatsManager = jobStatsManager;
+        this.guideBookService = guideBookService;
     }
 
     @Override
@@ -66,6 +69,8 @@ public class JobsCommand implements CommandExecutor {
                 return handleJobStats(player, args);
             case "info":
                 return handleJobInfo(player, args);
+            case "guide":
+                return handleJobGuide(player, args);
             case "debug":
                 return handleJobDebug(player);
             case "admin":
@@ -329,7 +334,60 @@ public class JobsCommand implements CommandExecutor {
         return true;
     }
 
+    /**
+     * /jobs guide [職業名] - 職業ガイドブックを入手する。
+     * GUI（職業詳細 スロット22）と同じく「その職業に就職中」のみ入手可能。
+     *   /jobs guide          … 就職中の全職業のガイドをまとめて入手
+     *   /jobs guide <職業名> … 指定職業（就職中のもの）のガイドを入手
+     */
+    private boolean handleJobGuide(Player player, String[] args) {
+        // 引数なし: 就職中の職業のガイドをまとめて配布
+        if (args.length == 1) {
+            int given = 0;
+            for (PlayerJob playerJob : jobManager.getPlayerJobs(player)) {
+                Job job = jobManager.getJobById(playerJob.getJobId());
+                if (job == null) {
+                    continue;
+                }
+                String jobName = job.getName();
+                if (configManager.isJobGuideBookEnabled(jobName)
+                        && !configManager.getJobGuideBookPages(jobName).isEmpty()) {
+                    if (guideBookService.giveGuideBook(player, jobName)) {
+                        given++;
+                    }
+                }
+            }
+            if (given == 0) {
+                player.sendMessage(ChatColor.YELLOW + "ガイドブックを入手するには、まず職業に就職してください。");
+                player.sendMessage(ChatColor.YELLOW + "使用法: " + ChatColor.WHITE + "/jobs guide <職業名>");
+            }
+            return true;
+        }
 
+        // /jobs guide <職業名>
+        if (args.length == 2) {
+            String jobName = args[1].toLowerCase();
+
+            if (!jobManager.isValidJobName(jobName)) {
+                player.sendMessage(ChatColor.RED + "存在しない職業です: " + jobName);
+                player.sendMessage(ChatColor.YELLOW + "利用可能な職業: " + String.join(", ", jobManager.getJobNames()));
+                return true;
+            }
+
+            if (!jobManager.hasJob(player, jobName)) {
+                player.sendMessage(ChatColor.RED + "「" + jobManager.getJobDisplayName(jobName)
+                        + "」に就職していません。ガイドブックは就職後に入手できます。");
+                player.sendMessage(ChatColor.YELLOW + "就職するには: " + ChatColor.WHITE + "/jobs join " + jobName);
+                return true;
+            }
+
+            guideBookService.giveGuideBook(player, jobName);
+            return true;
+        }
+
+        player.sendMessage(ChatColor.RED + "使用法: /jobs guide [職業名]");
+        return true;
+    }
 
     private boolean handleJobDebug(Player player) {
         player.sendMessage(ChatColor.GOLD + "=== 職業デバッグ情報 ===");
@@ -460,6 +518,7 @@ public class JobsCommand implements CommandExecutor {
         player.sendMessage(ChatColor.YELLOW + "/jobs leave <職業名> " + ChatColor.WHITE + "- 指定した職業を辞める");
         player.sendMessage(ChatColor.YELLOW + "/jobs stats [職業名|top <職業名>] " + ChatColor.WHITE + "- 職業の統計を表示（/jobstats と同じ）");
         player.sendMessage(ChatColor.YELLOW + "/jobs info <職業名> " + ChatColor.WHITE + "- 職業の詳細情報を表示");
+        player.sendMessage(ChatColor.YELLOW + "/jobs guide [職業名] " + ChatColor.WHITE + "- 職業のガイドブックを入手（就職中のみ）");
         player.sendMessage(ChatColor.YELLOW + "/jobs debug " + ChatColor.WHITE + "- 職業の詳細デバッグ情報を表示");
     }
 }

--- a/src/main/java/org/tofu/tofunomics/jobs/JobGuideBookService.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobGuideBookService.java
@@ -1,0 +1,77 @@
+package org.tofu.tofunomics.jobs;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
+import org.tofu.tofunomics.config.ConfigManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 職業ガイドブック（WRITTEN_BOOK）の生成・配布を担う共通サービス。
+ *
+ * GUI（{@link org.tofu.tofunomics.jobs.gui.JobDetailGUI}）とコマンド
+ * （{@link org.tofu.tofunomics.commands.JobsCommand}）の両方から呼ばれる。
+ * config の {@code jobs.job_settings.<job>.guide_book.*} を読み取り、
+ * 色コード（&）を変換して本を作成する。
+ */
+public class JobGuideBookService {
+
+    private final ConfigManager configManager;
+    private final JobManager jobManager;
+
+    public JobGuideBookService(ConfigManager configManager, JobManager jobManager) {
+        this.configManager = configManager;
+        this.jobManager = jobManager;
+    }
+
+    /**
+     * 指定職業のガイドブックを生成してプレイヤーに渡す。
+     * インベントリに空きがなければドロップせず警告する。
+     *
+     * @return 入手に成功した場合 true。未用意・空き不足の場合はメッセージを出して false。
+     */
+    public boolean giveGuideBook(Player player, String jobName) {
+        List<String> pageContents = configManager.getJobGuideBookPages(jobName);
+        if (pageContents.isEmpty()) {
+            player.sendMessage(ChatColor.RED + "この職業のガイドブックは用意されていません。");
+            return false;
+        }
+
+        ItemStack book = createGuideBook(jobName, pageContents);
+        java.util.Map<Integer, ItemStack> leftover = player.getInventory().addItem(book);
+        if (!leftover.isEmpty()) {
+            player.sendMessage(ChatColor.RED + "インベントリに空きがありません。整理してから再度お試しください。");
+            return false;
+        }
+
+        String displayName = jobManager.getJobDisplayName(jobName);
+        player.sendMessage(ChatColor.GREEN + "「" + ChatColor.stripColor(displayName)
+                + "」のガイドブックを入手しました。右クリックで読めます。");
+        return true;
+    }
+
+    /**
+     * config の guide_book 設定から WRITTEN_BOOK を生成する。色コード（&）は変換する。
+     */
+    private ItemStack createGuideBook(String jobName, List<String> pageContents) {
+        ItemStack book = new ItemStack(Material.WRITTEN_BOOK);
+        BookMeta meta = (BookMeta) book.getItemMeta();
+        if (meta != null) {
+            meta.setTitle(ChatColor.translateAlternateColorCodes('&',
+                    configManager.getJobGuideBookTitle(jobName)));
+            meta.setAuthor(ChatColor.translateAlternateColorCodes('&',
+                    configManager.getJobGuideBookAuthor(jobName)));
+            List<String> pages = new ArrayList<>();
+            for (String page : pageContents) {
+                pages.add(ChatColor.translateAlternateColorCodes('&', page));
+            }
+            meta.setPages(pages);
+            book.setItemMeta(meta);
+        }
+        return book;
+    }
+}

--- a/src/main/java/org/tofu/tofunomics/jobs/gui/JobDetailGUI.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/gui/JobDetailGUI.java
@@ -6,11 +6,11 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.BookMeta;
 import org.tofu.tofunomics.TofuNomics;
 import org.tofu.tofunomics.config.ConfigManager;
 import org.tofu.tofunomics.gui.GuiUtil;
 import org.tofu.tofunomics.jobs.ExperienceManager;
+import org.tofu.tofunomics.jobs.JobGuideBookService;
 import org.tofu.tofunomics.jobs.JobManager;
 import org.tofu.tofunomics.models.PlayerJob;
 
@@ -40,18 +40,20 @@ public class JobDetailGUI {
     private final JobManager jobManager;
     private final ExperienceManager experienceManager;
     private final JobsGUIListener listener;
+    private final JobGuideBookService guideBookService;
 
     private JobsHubGUI hubGUI;
     private JobConfirmGUI confirmGUI;
 
     public JobDetailGUI(TofuNomics plugin, ConfigManager configManager,
                         JobManager jobManager, ExperienceManager experienceManager,
-                        JobsGUIListener listener) {
+                        JobsGUIListener listener, JobGuideBookService guideBookService) {
         this.plugin = plugin;
         this.configManager = configManager;
         this.jobManager = jobManager;
         this.experienceManager = experienceManager;
         this.listener = listener;
+        this.guideBookService = guideBookService;
     }
 
     public void setGUIs(JobsHubGUI hubGUI, JobConfirmGUI confirmGUI) {
@@ -188,7 +190,9 @@ public class JobDetailGUI {
                 // 就職中の職業のガイドブックのみ入手可能
                 if (jobName != null && jobManager.hasJob(player, jobName)
                         && configManager.isJobGuideBookEnabled(jobName)) {
-                    giveGuideBook(player, jobName);
+                    if (guideBookService.giveGuideBook(player, jobName)) {
+                        player.closeInventory();
+                    }
                 }
                 break;
             case SLOT_BACK:
@@ -202,50 +206,5 @@ public class JobDetailGUI {
             default:
                 break;
         }
-    }
-
-    /**
-     * 指定職業のガイドブックを生成してプレイヤーに渡す。
-     * インベントリに空きがなければドロップせず警告する。
-     */
-    private void giveGuideBook(Player player, String jobName) {
-        List<String> pageContents = configManager.getJobGuideBookPages(jobName);
-        if (pageContents.isEmpty()) {
-            player.sendMessage(ChatColor.RED + "この職業のガイドブックは用意されていません。");
-            return;
-        }
-
-        ItemStack book = createGuideBook(jobName, pageContents);
-        java.util.Map<Integer, ItemStack> leftover = player.getInventory().addItem(book);
-        if (!leftover.isEmpty()) {
-            player.sendMessage(ChatColor.RED + "インベントリに空きがありません。整理してから再度お試しください。");
-            return;
-        }
-
-        String displayName = jobManager.getJobDisplayName(jobName);
-        player.closeInventory();
-        player.sendMessage(ChatColor.GREEN + "「" + ChatColor.stripColor(displayName)
-                + "」のガイドブックを入手しました。右クリックで読めます。");
-    }
-
-    /**
-     * config の guide_book 設定から WRITTEN_BOOK を生成する。色コード（&）は変換する。
-     */
-    private ItemStack createGuideBook(String jobName, List<String> pageContents) {
-        ItemStack book = new ItemStack(Material.WRITTEN_BOOK);
-        BookMeta meta = (BookMeta) book.getItemMeta();
-        if (meta != null) {
-            meta.setTitle(ChatColor.translateAlternateColorCodes('&',
-                    configManager.getJobGuideBookTitle(jobName)));
-            meta.setAuthor(ChatColor.translateAlternateColorCodes('&',
-                    configManager.getJobGuideBookAuthor(jobName)));
-            List<String> pages = new ArrayList<>();
-            for (String page : pageContents) {
-                pages.add(ChatColor.translateAlternateColorCodes('&', page));
-            }
-            meta.setPages(pages);
-            book.setItemMeta(meta);
-        }
-        return book;
     }
 }


### PR DESCRIPTION
## 概要

`/jobs guide` で職業ごとのガイドブックが入手できない不具合を修正しました。

原因は **`/jobs guide` サブコマンドが未実装**だったこと（`JobsCommand.onCommand` の switch に `guide` ケースが無く、ヘルプにフォールバックしていた）。ガイドブック自体は GUI（`/jobs` → 職業詳細 → スロット22）からは入手可能でした。

## 変更内容

- **`JobGuideBookService`（新規）**: ガイドブック生成・配布ロジックを `JobDetailGUI` の private メソッドから切り出し、GUI とコマンドで共有
- **`JobsCommand`**: `guide` サブコマンドを追加
  - `/jobs guide <職業名>` … 就職中の職業のガイドを入手
  - `/jobs guide`（引数なし） … 就職中の全職業のガイドをまとめて入手
  - 未就職・存在しない職業名は案内メッセージを表示
  - ヘルプに `/jobs guide` を追記
- **`JobDetailGUI`**: サービス利用にリファクタ（重複ロジック削除）
- **`TofuNomics`**: サービスを配線

## 入手条件

GUI（職業詳細スロット22）と同じく **「その職業に就職中」のみ入手可** という制約を踏襲。

## 動作確認

- `mvn clean package` ビルド成功・全テスト通過
- ゲーム内動作確認は別途実施予定
  - 就職中職業で `/jobs guide <職業名>` → ガイドブック入手
  - 引数なし → 就職中職業のガイドをまとめて入手
  - 未就職・無職・存在しない職業名 → 案内/エラー
  - GUI 経由の入手がリグレッションなく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)