### PR TITLE
feat: /tntest に setlevel サブコマンドを追加

### DIFF
--- a/src/main/java/org/tofu/tofunomics/commands/TestKitCommand.java
+++ b/src/main/java/org/tofu/tofunomics/commands/TestKitCommand.java
@@ -82,6 +82,9 @@ public class TestKitCommand implements CommandExecutor, TabCompleter {
             case "job":
                 handleJob(player, args);
                 break;
+            case "setlevel":
+                handleSetLevel(player, args);
+                break;
             case "lv50":
                 handleLv50(player, args);
                 break;
@@ -153,6 +156,51 @@ public class TestKitCommand implements CommandExecutor, TabCompleter {
             target.sendMessage("§7管理者により職業が " + jobName + " Lv" + appliedLevel + " に設定されました");
         }
         logAction(sender, target, "job " + jobName + " Lv" + appliedLevel);
+    }
+
+    // ===== setlevel: 現在就いている職業のレベルだけを変更（リセットなし） =====
+    private void handleSetLevel(Player sender, String[] args) {
+        // /tntest setlevel <level> [player]
+        if (args.length < 2) {
+            sender.sendMessage("§c使用法: /tntest setlevel <レベル> [プレイヤー]");
+            sender.sendMessage("§7現職を保持したままレベルのみ変更します（職業データ・履歴・畑区画は維持）");
+            return;
+        }
+        Integer level = parseLevel(sender, args[1]);
+        if (level == null) {
+            return;
+        }
+        Player target = resolveTarget(sender, args.length >= 3 ? args[2] : null);
+        if (target == null) {
+            return;
+        }
+
+        PlayerJob playerJob = jobManager.getCurrentJob(target.getUniqueId());
+        if (playerJob == null) {
+            sender.sendMessage("§c" + target.getName() + " は職業に就いていません（先に /tntest job で就職させてください）");
+            return;
+        }
+        org.tofu.tofunomics.models.Job job = jobManager.getJobById(playerJob.getJobId());
+        if (job == null) {
+            sender.sendMessage("§c現在の職業情報を取得できませんでした");
+            return;
+        }
+        String jobName = job.getName();
+        if (!experienceManager.setLevel(playerJob, jobName, level)) {
+            sender.sendMessage("§cレベル設定に失敗しました");
+            return;
+        }
+
+        int maxLevel = configManager.getJobMaxLevel(jobName);
+        int appliedLevel = Math.min(level, maxLevel);
+        sender.sendMessage("§a" + target.getName() + " の §e" + jobName + "§a を Lv" + appliedLevel + " に変更しました");
+        if (appliedLevel != level) {
+            sender.sendMessage("§7（最大レベル " + maxLevel + " にクランプされました）");
+        }
+        if (!sender.equals(target)) {
+            target.sendMessage("§7管理者により " + jobName + " が Lv" + appliedLevel + " に変更されました");
+        }
+        logAction(sender, target, "setlevel " + jobName + " Lv" + appliedLevel);
     }
 
     // ===== lv50: 上級職解禁の前提「いずれかの職でLv50到達」を即達成 =====
@@ -490,7 +538,8 @@ public class TestKitCommand implements CommandExecutor, TabCompleter {
 
     private void sendUsage(CommandSender sender) {
         sender.sendMessage("§6===== /tntest 管理者テスト支援コマンド =====");
-        sender.sendMessage("§e/tntest job <職業> <Lv> [対象] §7- 指定職業に就かせLvを即設定（上級職もOK）");
+        sender.sendMessage("§e/tntest job <職業> <Lv> [対象] §7- 指定職業に就かせLvを即設定（リセットあり・上級職OK）");
+        sender.sendMessage("§e/tntest setlevel <Lv> [対象] §7- 現職のレベルのみ変更（リセットなし）");
         sender.sendMessage("§e/tntest lv50 [対象] §7- 上級職解禁状態（いずれかの職でLv50）にする");
         sender.sendMessage("§e/tntest reward <職業> <Lv> [対象] §7- レベルアップ報酬を手動付与");
         sender.sendMessage("§e/tntest money <cash|bank> <額> [対象] §7- 現金付与/預金設定");
@@ -507,7 +556,7 @@ public class TestKitCommand implements CommandExecutor, TabCompleter {
         List<String> result = new ArrayList<>();
         if (args.length == 1) {
             return filter(Arrays.asList(
-                "job", "lv50", "reward", "money", "reset", "kit", "time", "stockreset", "help"), args[0]);
+                "job", "setlevel", "lv50", "reward", "money", "reset", "kit", "time", "stockreset", "help"), args[0]);
         }
 
         String sub = args[0].toLowerCase();
@@ -534,7 +583,7 @@ public class TestKitCommand implements CommandExecutor, TabCompleter {
         if (args.length == 4 && (sub.equals("job") || sub.equals("reward") || sub.equals("money"))) {
             return filter(onlinePlayerNames(), args[3]);
         }
-        if (args.length == 3 && sub.equals("kit")) {
+        if (args.length == 3 && (sub.equals("kit") || sub.equals("setlevel"))) {
             return filter(onlinePlayerNames(), args[2]);
         }
         return result;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -99,7 +99,7 @@ commands:
     permission: tofunomics.market.use
   tntest:
     description: 管理者テスト支援コマンド（テスト前提条件のセットアップ）
-    usage: /tntest <job|lv50|reward|money|reset|kit|time|stockreset|help> [args]
+    usage: /tntest <job|setlevel|lv50|reward|money|reset|kit|time|stockreset|help> [args]
     aliases: [tnt]
     permission: tofunomics.admin
 


### PR DESCRIPTION
## 概要
`/tntest job` は内部で `resetAllJobs`（職業データ・履歴・農家畑区画を作り直し）を行うため、「現職のレベルだけを1つ上げる」といった用途には不向きだった。リセットを伴わず**現在就いている職業のレベルのみ**を変更する `setlevel` サブコマンドを追加する。

## 追加コマンド
```
/tntest setlevel <Lv> [対象]
```
- `getCurrentJob` で現職を取得し、`ExperienceManager.setLevel` でレベル（経験値）のみ更新
- 職業データ・職業履歴・農家畑区画は**維持**
- 無職の場合はエラー表示

## 使い分け
| コマンド | 用途 | リセット |
|---|---|---|
| `job <職業> <Lv>` | 職業を新規セット（上級職解禁・転職テスト） | あり |
| `setlevel <Lv>` | 現職のレベルだけ変更（レベル別挙動テスト） | なし |

## テスト
- `mvn clean compile` 成功
- 既存の自動テストに影響なし（コマンド層の追加のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)