### PR TITLE
fix: スコアボードの次レベル%が負になる問題を修正、MAX判定を職業別上限に統一

### DIFF
--- a/src/main/java/org/tofu/tofunomics/models/PlayerJob.java
+++ b/src/main/java/org/tofu/tofunomics/models/PlayerJob.java
@@ -85,6 +85,20 @@ public class PlayerJob {
         return Math.pow(level - 1, 2.2) * 100;
     }
 
+    /**
+     * 現在レベル内での次レベルまでの進捗率を 0.0〜100.0 にクランプして返す。
+     * requiredExp <= prevLevelExp の縮退ケース(0除算)では 100.0 を返す。
+     */
+    public static double calculateLevelProgressPercent(int level, double experience) {
+        double prevLevelExp = calculateExperienceRequired(level);
+        double requiredExp = calculateExperienceRequired(level + 1);
+        if (requiredExp <= prevLevelExp) {
+            return 100.0;
+        }
+        double progress = ((experience - prevLevelExp) / (requiredExp - prevLevelExp)) * 100.0;
+        return Math.max(0.0, Math.min(100.0, progress));
+    }
+
     public Timestamp getJoinedAt() {
         return joinedAt;
     }

--- a/src/main/java/org/tofu/tofunomics/scoreboard/JobLevelBossBarManager.java
+++ b/src/main/java/org/tofu/tofunomics/scoreboard/JobLevelBossBarManager.java
@@ -110,19 +110,20 @@ public class JobLevelBossBarManager implements Listener {
                     ? configManager.getJobDisplayName(jobData.getName())
                     : "職業";
 
-            // 進捗率（0.0〜1.0）を計算（旧 ScoreboardManager.updateExperienceBar と同一ロジック）
-            double currentExp = currentJob.getExperience();
-            double prevLevelExp = PlayerJob.calculateExperienceRequired(currentJob.getLevel());
-            double requiredExp = PlayerJob.calculateExperienceRequired(currentJob.getLevel() + 1);
+            // 進捗率（0.0〜1.0）を計算（ScoreboardManager と共通ヘルパーを使用）
+            // レベル上限は職業別設定(既定75)を使用。jobData が null の場合のみ 100 固定にフォールバック。
+            // config キーには内部職業名(jobData.getName())を渡すこと(表示名 jobName 変数は不可)。
+            int jobMaxLevel = (jobData != null) ? configManager.getJobMaxLevel(jobData.getName())
+                                                : configManager.getMaxJobLevel();
 
             float progress;
-            boolean maxLevel = currentJob.getLevel() >= configManager.getMaxJobLevel() || requiredExp <= prevLevelExp;
+            boolean maxLevel = currentJob.getLevel() >= jobMaxLevel;
             if (maxLevel) {
                 progress = 1.0f;
             } else {
-                progress = (float) ((currentExp - prevLevelExp) / (requiredExp - prevLevelExp));
+                progress = (float) (PlayerJob.calculateLevelProgressPercent(
+                        currentJob.getLevel(), currentJob.getExperience()) / 100.0);
             }
-            progress = Math.max(0.0f, Math.min(1.0f, progress));
 
             int percent = (int) Math.floor(progress * 100);
             String title = configManager.getJobBossBarTitleFormat()

--- a/src/main/java/org/tofu/tofunomics/scoreboard/ScoreboardManager.java
+++ b/src/main/java/org/tofu/tofunomics/scoreboard/ScoreboardManager.java
@@ -198,14 +198,14 @@ public class ScoreboardManager implements Listener {
                     levelInfo = "Lv." + currentJob.getLevel() + " " + jobTitle;
                     
                     // 次レベルまでの経験値計算
-                    double requiredExp = PlayerJob.calculateExperienceRequired(currentJob.getLevel() + 1);
-                    double currentExp = currentJob.getExperience();
-                    double prevLevelExp = PlayerJob.calculateExperienceRequired(currentJob.getLevel());
-                    
-                    if (currentJob.getLevel() >= configManager.getMaxJobLevel()) {
+                    // レベル上限は職業別設定(既定75)を使用する。getMaxJobLevel()(=100固定)
+                    // ではないことに注意(JobLevelBossBarManager と共通)。
+                    if (currentJob.getLevel() >= configManager.getJobMaxLevel(jobInfo)) {
                         experienceInfo = "MAX";
                     } else {
-                        double progress = ((currentExp - prevLevelExp) / (requiredExp - prevLevelExp)) * 100;
+                        // [0,100]クランプ＋0除算ガード付きの共通ヘルパーで計算(負値・100超え・NaN防止)
+                        double progress = PlayerJob.calculateLevelProgressPercent(
+                                currentJob.getLevel(), currentJob.getExperience());
                         experienceInfo = String.format("%.1f%%", progress);
                     }
                 }

--- a/src/test/java/org/tofu/tofunomics/models/PlayerJobTest.java
+++ b/src/test/java/org/tofu/tofunomics/models/PlayerJobTest.java
@@ -247,6 +247,53 @@ public class PlayerJobTest {
     }
 
     @Test
+    public void testCalculateLevelProgressPercentNormal() {
+        // レベル5で、現在レベルと次レベルの中間の経験値 → 約50%
+        int level = 5;
+        double prev = PlayerJob.calculateExperienceRequired(level);
+        double next = PlayerJob.calculateExperienceRequired(level + 1);
+        double midExp = prev + (next - prev) / 2.0;
+
+        double progress = PlayerJob.calculateLevelProgressPercent(level, midExp);
+        assertEquals("中間の経験値では進捗率が約50%になるべき", 50.0, progress, DELTA);
+    }
+
+    @Test
+    public void testCalculateLevelProgressPercentClampsNegative() {
+        // 本バグ再現: 経験値が現在レベルの必要値を下回る（レベルだけ先行した不整合状態）
+        // → 負値ではなく0.0にクランプされるべき
+        int level = 50;
+        double belowExp = PlayerJob.calculateExperienceRequired(level) - 1000.0;
+
+        double progress = PlayerJob.calculateLevelProgressPercent(level, belowExp);
+        assertEquals("経験値がレベルに満たない場合は0.0にクランプされるべき(負にならない)",
+                     0.0, progress, DELTA);
+    }
+
+    @Test
+    public void testCalculateLevelProgressPercentClampsOverflow() {
+        // 経験値が次レベル必要値を超える場合 → 100.0にクランプされるべき
+        int level = 10;
+        double overExp = PlayerJob.calculateExperienceRequired(level + 1) + 10000.0;
+
+        double progress = PlayerJob.calculateLevelProgressPercent(level, overExp);
+        assertEquals("経験値が次レベルを超える場合は100.0にクランプされるべき",
+                     100.0, progress, DELTA);
+    }
+
+    @Test
+    public void testCalculateLevelProgressPercentDegenerate() {
+        // レベル0以下は prevLevelExp == requiredExp == 0 で0除算となる縮退ケース
+        // → ガードにより100.0を返すべき(NaN/Infinityにならない)
+        double progress = PlayerJob.calculateLevelProgressPercent(0, 0.0);
+        assertEquals("レベル0の縮退ケースでは100.0を返すべき", 100.0, progress, DELTA);
+
+        // レベル1で経験値0は縮退ではなく進捗の起点 → 0.0が正しい
+        double level1Start = PlayerJob.calculateLevelProgressPercent(1, 0.0);
+        assertEquals("レベル1で経験値0は進捗0.0であるべき", 0.0, level1Start, DELTA);
+    }
+
+    @Test
     public void testExperienceFormula() {
         // 各レベルでの必要経験値の増加を確認
         double level1Exp = PlayerJob.calculateExperienceRequired(1);


### PR DESCRIPTION
## 概要
`/tntest setlevel 50` 等で職業を高レベルにした際、スコアボードの「次レベルまで%」がマイナス表示される問題を修正します。

## 原因
1. **クランプ抜け（直接原因）**: `ScoreboardManager` の進捗率計算に下限/上限ガードが無く、`currentExp < prevLevelExp`（レベルと経験値の不整合状態）で負値、`requiredExp == prevLevelExp` で0除算（NaN/Infinity）になっていた。対になる `JobLevelBossBarManager` は既にクランプ済みだが、スコアボード側だけ保護が抜けていた。
2. **MAX判定の不整合（根本バグ）**: 表示系2クラスの MAX 判定がハードコード `getMaxJobLevel()`（=100）を使用。実際のレベル上限は職業別 `getJobMaxLevel()`（config既定75）であり、上限到達時も「MAX」にならず0%固定になっていた。

## 変更内容
- `PlayerJob.calculateLevelProgressPercent()` を追加し、進捗率計算（[0,100]クランプ＋0除算ガード）を共通化
- `ScoreboardManager` / `JobLevelBossBarManager` の重複ロジックをヘルパー使用に一本化
- 両クラスの MAX 判定を職業別上限 `getJobMaxLevel(内部職業名)` に統一
- `PlayerJobTest` に進捗率計算テスト（正常・負値クランプ・超過クランプ・0除算ガード）を追加

## テスト
- `mvn clean test` → 376件全パス（BUILD SUCCESS）

## 実機検証（デプロイ後に確認）
- `/tntest setlevel 50`（上限75未満）→ スコアボードが負でない%（≒0.0%）
- `/tntest setlevel 75`（=職業上限）→ スコアボード・ボスバー両方が「MAX」表示
- スコアボードとボスバーの表示が一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)