### PR TITLE
fix: 職業辞職→再就職時に経験値が引き継がれない問題を修正

### DIFF
--- a/src/main/java/org/tofu/tofunomics/dao/JobHistoryDAO.java
+++ b/src/main/java/org/tofu/tofunomics/dao/JobHistoryDAO.java
@@ -27,13 +27,14 @@ public class JobHistoryDAO {
      * @return 成功時true
      */
     public boolean insertJobHistory(JobHistory jobHistory) {
-        String query = "INSERT INTO job_history (uuid, job_id, max_level, left_at) VALUES (?, ?, ?, ?)";
-        
+        String query = "INSERT INTO job_history (uuid, job_id, max_level, experience, left_at) VALUES (?, ?, ?, ?, ?)";
+
         try (PreparedStatement statement = connection.prepareStatement(query)) {
             statement.setString(1, jobHistory.getUuid());
             statement.setInt(2, jobHistory.getJobId());
             statement.setInt(3, jobHistory.getMaxLevel());
-            statement.setTimestamp(4, jobHistory.getLeftAt());
+            statement.setDouble(4, jobHistory.getExperience());
+            statement.setTimestamp(5, jobHistory.getLeftAt());
             
             return statement.executeUpdate() > 0;
         } catch (SQLException e) {
@@ -48,12 +49,12 @@ public class JobHistoryDAO {
      * @return 職業履歴のリスト
      */
     public List<JobHistory> getJobHistoriesByUUID(String uuid) {
-        String query = "SELECT id, uuid, job_id, max_level, left_at FROM job_history WHERE uuid = ? ORDER BY left_at DESC";
+        String query = "SELECT id, uuid, job_id, max_level, experience, left_at FROM job_history WHERE uuid = ? ORDER BY left_at DESC";
         List<JobHistory> histories = new ArrayList<>();
-        
+
         try (PreparedStatement statement = connection.prepareStatement(query)) {
             statement.setString(1, uuid);
-            
+
             try (ResultSet resultSet = statement.executeQuery()) {
                 while (resultSet.next()) {
                     JobHistory history = new JobHistory();
@@ -61,6 +62,7 @@ public class JobHistoryDAO {
                     history.setUuid(resultSet.getString("uuid"));
                     history.setJobId(resultSet.getInt("job_id"));
                     history.setMaxLevel(resultSet.getInt("max_level"));
+                    history.setExperience(resultSet.getDouble("experience"));
                     history.setLeftAt(resultSet.getTimestamp("left_at"));
                     histories.add(history);
                 }
@@ -127,13 +129,13 @@ public class JobHistoryDAO {
      * @return 最新の職業履歴（履歴がない場合はnull）
      */
     public JobHistory getLatestJobHistory(String uuid, int jobId) {
-        String query = "SELECT id, uuid, job_id, max_level, left_at FROM job_history " +
-                      "WHERE uuid = ? AND job_id = ? ORDER BY max_level DESC LIMIT 1";
-        
+        String query = "SELECT id, uuid, job_id, max_level, experience, left_at FROM job_history " +
+                      "WHERE uuid = ? AND job_id = ? ORDER BY max_level DESC, experience DESC LIMIT 1";
+
         try (PreparedStatement statement = connection.prepareStatement(query)) {
             statement.setString(1, uuid);
             statement.setInt(2, jobId);
-            
+
             try (ResultSet resultSet = statement.executeQuery()) {
                 if (resultSet.next()) {
                     JobHistory history = new JobHistory();
@@ -141,6 +143,7 @@ public class JobHistoryDAO {
                     history.setUuid(resultSet.getString("uuid"));
                     history.setJobId(resultSet.getInt("job_id"));
                     history.setMaxLevel(resultSet.getInt("max_level"));
+                    history.setExperience(resultSet.getDouble("experience"));
                     history.setLeftAt(resultSet.getTimestamp("left_at"));
                     return history;
                 }

--- a/src/main/java/org/tofu/tofunomics/database/DatabaseManager.java
+++ b/src/main/java/org/tofu/tofunomics/database/DatabaseManager.java
@@ -137,6 +137,7 @@ public class DatabaseManager {
             "    uuid TEXT NOT NULL," +
             "    job_id INTEGER NOT NULL," +
             "    max_level INTEGER NOT NULL," +
+            "    experience REAL NOT NULL DEFAULT 0.0," +
             "    left_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP," +
             "    FOREIGN KEY (uuid) REFERENCES players(uuid) ON DELETE CASCADE," +
             "    FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE" +
@@ -458,6 +459,15 @@ public class DatabaseManager {
                 logger.info("housing_rentals テーブルに end_tick カラムを追加しています...");
                 statement.executeUpdate("ALTER TABLE housing_rentals ADD COLUMN end_tick INTEGER DEFAULT 0");
                 logger.info("housing_rentals テーブルに end_tick カラムを追加しました");
+            }
+
+            // job_history テーブルの experience カラムが存在するかチェック
+            try {
+                statement.executeQuery("SELECT experience FROM job_history LIMIT 1");
+            } catch (SQLException e) {
+                logger.info("job_history テーブルに experience カラムを追加しています...");
+                statement.executeUpdate("ALTER TABLE job_history ADD COLUMN experience REAL NOT NULL DEFAULT 0.0");
+                logger.info("job_history テーブルに experience カラムを追加しました");
             }
 
             // 期限切れ検索高速化用インデックス（存在しなければ作成）

--- a/src/main/java/org/tofu/tofunomics/jobs/JobManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobManager.java
@@ -107,16 +107,17 @@ public class JobManager {
         playerJob.setUuid(uuid);
         playerJob.setJobId(job.getId());
         
-        // job_historyから過去の記録を取得してレベルを復元
+        // job_historyから過去の記録を取得してレベルと経験値を復元
         JobHistory history = jobHistoryDAO.getLatestJobHistory(uuid, job.getId());
         if (history != null) {
-            // 過去の記録がある場合はレベルを復元
+            // 過去の記録がある場合はレベルと経験値を復元
             playerJob.setLevel(history.getMaxLevel());
+            playerJob.setExperience(history.getExperience());
         } else {
-            // 初回就職の場合はレベル1
+            // 初回就職の場合はレベル1・経験値0
             playerJob.setLevel(1);
+            playerJob.setExperience(0.0);
         }
-        playerJob.setExperience(0.0); // 経験値は常に0
         
         if (!playerJobDAO.insertPlayerJob(playerJob)) {
             return JobJoinResult.DATABASE_ERROR;
@@ -195,7 +196,7 @@ public class JobManager {
         }
         
         // 退職前に職業履歴を保存
-        JobHistory jobHistory = new JobHistory(uuid, job.getId(), playerJob.getLevel());
+        JobHistory jobHistory = new JobHistory(uuid, job.getId(), playerJob.getLevel(), playerJob.getExperience());
         if (!jobHistoryDAO.insertJobHistory(jobHistory)) {
             TofuNomics.getInstance().getLogger().warning("職業履歴の保存に失敗しました: " + uuid + ", job=" + jobName);
         }
@@ -242,7 +243,7 @@ public class JobManager {
         // レベルチェックをスキップして辞職処理を実行
         
         // 退職前に職業履歴を保存
-        JobHistory jobHistory = new JobHistory(uuid, job.getId(), playerJob.getLevel());
+        JobHistory jobHistory = new JobHistory(uuid, job.getId(), playerJob.getLevel(), playerJob.getExperience());
         if (!jobHistoryDAO.insertJobHistory(jobHistory)) {
             TofuNomics.getInstance().getLogger().warning("職業履歴の保存に失敗しました: " + uuid + ", job=" + jobName);
         }

--- a/src/main/java/org/tofu/tofunomics/models/JobHistory.java
+++ b/src/main/java/org/tofu/tofunomics/models/JobHistory.java
@@ -12,14 +12,20 @@ public class JobHistory {
     private String uuid;
     private int jobId;
     private int maxLevel;
+    private double experience;
     private Timestamp leftAt;
-    
+
     public JobHistory() {}
-    
+
     public JobHistory(String uuid, int jobId, int maxLevel) {
+        this(uuid, jobId, maxLevel, 0.0);
+    }
+
+    public JobHistory(String uuid, int jobId, int maxLevel, double experience) {
         this.uuid = uuid;
         this.jobId = jobId;
         this.maxLevel = maxLevel;
+        this.experience = experience;
         this.leftAt = new Timestamp(System.currentTimeMillis());
     }
     
@@ -39,7 +45,11 @@ public class JobHistory {
     public int getMaxLevel() {
         return maxLevel;
     }
-    
+
+    public double getExperience() {
+        return experience;
+    }
+
     public Timestamp getLeftAt() {
         return leftAt;
     }
@@ -60,7 +70,11 @@ public class JobHistory {
     public void setMaxLevel(int maxLevel) {
         this.maxLevel = maxLevel;
     }
-    
+
+    public void setExperience(double experience) {
+        this.experience = experience;
+    }
+
     public void setLeftAt(Timestamp leftAt) {
         this.leftAt = leftAt;
     }
@@ -72,6 +86,7 @@ public class JobHistory {
                 ", uuid='" + uuid + '\'' +
                 ", jobId=" + jobId +
                 ", maxLevel=" + maxLevel +
+                ", experience=" + experience +
                 ", leftAt=" + leftAt +
                 '}';
     }

--- a/src/test/java/org/tofu/tofunomics/jobs/JobManagerTest.java
+++ b/src/test/java/org/tofu/tofunomics/jobs/JobManagerTest.java
@@ -3,6 +3,7 @@ package org.tofu.tofunomics.jobs;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
@@ -14,6 +15,7 @@ import org.tofu.tofunomics.dao.PlayerJobDAO;
 import org.tofu.tofunomics.dao.JobChangeDAO;
 import org.tofu.tofunomics.dao.JobHistoryDAO;
 import org.tofu.tofunomics.models.Job;
+import org.tofu.tofunomics.models.JobHistory;
 import org.tofu.tofunomics.models.PlayerJob;
 import org.tofu.tofunomics.jobs.JobManager.JobJoinResult;
 import org.tofu.tofunomics.jobs.JobManager.JobLeaveResult;
@@ -312,6 +314,60 @@ public class JobManagerTest {
 
         assertEquals("職業離脱が成功するべき", JobLeaveResult.SUCCESS, result);
         verify(playerJobDAO).deletePlayerJob(playerUuidString, 1);
+    }
+
+    @Test
+    public void testLeaveJobSavesExperienceToHistory() {
+        // 辞職時に現在の経験値が job_history に保存されることを検証
+        String jobName = "farmer";
+        Job job = new Job(jobName, "農家", 100, 15.0);
+        job.setId(1);
+
+        PlayerJob playerJob = new PlayerJob();
+        playerJob.setJobId(1);
+        playerJob.setLevel(50);
+        playerJob.setExperience(123456.0); // 付与済みの経験値
+
+        when(configManager.isDailyJobChangeLimitEnabled()).thenReturn(false);
+        when(jobDAO.getJobByNameSafe(jobName)).thenReturn(job);
+        when(playerJobDAO.getPlayerJob(playerUuidString, 1)).thenReturn(playerJob);
+        when(jobHistoryDAO.insertJobHistory(any())).thenReturn(true);
+        when(playerJobDAO.deletePlayerJob(playerUuidString, 1)).thenReturn(true);
+
+        JobLeaveResult result = jobManager.leaveJob(player, jobName);
+
+        assertEquals("職業離脱が成功するべき", JobLeaveResult.SUCCESS, result);
+
+        ArgumentCaptor<JobHistory> captor = ArgumentCaptor.forClass(JobHistory.class);
+        verify(jobHistoryDAO).insertJobHistory(captor.capture());
+        assertEquals("辞職時のレベルが履歴に保存されるべき", 50, captor.getValue().getMaxLevel());
+        assertEquals("辞職時の経験値が履歴に保存されるべき", 123456.0, captor.getValue().getExperience(), 0.001);
+    }
+
+    @Test
+    public void testJoinJobRestoresLevelAndExperienceFromHistory() {
+        // 再就職時に job_history からレベルと経験値の両方が復元されることを検証
+        String jobName = "farmer";
+        Job job = new Job(jobName, "農家", 100, 15.0);
+        job.setId(1);
+
+        JobHistory history = new JobHistory(playerUuidString, 1, 50, 123456.0);
+
+        when(jobDAO.getJobByNameSafe(jobName)).thenReturn(job);
+        when(configManager.isDailyJobChangeLimitEnabled()).thenReturn(false);
+        when(configManager.getMaxJobsPerPlayer()).thenReturn(3);
+        when(playerJobDAO.getPlayerJobsByUUID(playerUuidString)).thenReturn(new ArrayList<>());
+        when(jobHistoryDAO.getLatestJobHistory(playerUuidString, 1)).thenReturn(history);
+        when(playerJobDAO.insertPlayerJob(any(PlayerJob.class))).thenReturn(true);
+
+        JobJoinResult result = jobManager.joinJob(player, jobName);
+
+        assertEquals("再就職が成功するべき", JobJoinResult.SUCCESS, result);
+
+        ArgumentCaptor<PlayerJob> captor = ArgumentCaptor.forClass(PlayerJob.class);
+        verify(playerJobDAO).insertPlayerJob(captor.capture());
+        assertEquals("過去の最高レベルが復元されるべき", 50, captor.getValue().getLevel());
+        assertEquals("過去の経験値が復元されるべき", 123456.0, captor.getValue().getExperience(), 0.001);
     }
 
     @Test


### PR DESCRIPTION
## 概要

`/tntest` で職業レベルを50まで上げ経験値を付与した後、職業を辞職して同じ職業に再就職すると**経験値が0にリセットされる**問題を修正しました。

## 原因

- **辞職** (`JobManager.leaveJob` / `forceLeaveJob`): `player_jobs` を `DELETE` し、`job_history` には `max_level`（レベル）だけ記録。`job_history` に `experience` カラムが無く経験値は保存されていなかった。
- **再就職** (`JobManager.joinJob`): レベルは復元するが `setExperience(0.0)` で経験値を必ず0にしていた。

結果「レベルは復元されるが経験値は失われる」状態になっていた。

## 変更内容

- `job_history` テーブルに `experience` カラムを追加（新規DB用 `CREATE TABLE` 定義 ＋ 既存DB向け `performMigrations()` マイグレーション）
- `JobHistory` モデルに経験値フィールド・getter/setter・4引数コンストラクタを追加
- `JobHistoryDAO` の INSERT / SELECT に経験値を追加（`getLatestJobHistory` は `max_level DESC, experience DESC` で最も進んだ履歴を返す）
- 辞職時に経験値を履歴へ保存、再就職時にレベルと経験値の両方を復元
- 引き継ぎを検証するユニットテストを2件追加

## 補足

- マイグレーション前に辞職済みのプレイヤーの履歴は `experience=0`（DEFAULT）となるため、その分の再就職は従来どおり経験値0のまま。マイグレーション後の辞職分から正しく引き継がれます。

## テスト

- `mvn clean test`: 全379テストパス（新規2件含む）

## 動作確認手順（要サーバー再起動）

1. `/tntest job <職業> 50` → `/tntest exp <値>` で経験値付与
2. `/jobs` で経験値を確認
3. `/jobs leave <職業>` → `/jobs join <職業>`
4. 経験値が復元され、スコアボード進捗%も整合することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)