### PR TITLE
fix: 鉱夫が岩系ブロック(安山岩/閃緑岩/花崗岩)を掘っても経験値が入らない問題を修正

### DIFF
--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -473,11 +473,13 @@ public class UnifiedEventHandler implements Listener {
         // 鉱石類は設置禁止のため追跡不要（isOreBlockで判定）
         
         // STONE, COBBLESTONE（無限経験値防止）
-        // 深層岩石材（DEEPSLATE/COBBLED_DEEPSLATE/TUFF）はSTONEへ正規化され採掘経験値の対象になるため、
-        // 設置→採掘による無限経験値を防ぐべく追跡する
+        // 深層岩石材（DEEPSLATE/COBBLED_DEEPSLATE/TUFF）および岩系（ANDESITE/DIORITE/GRANITE）は
+        // STONEへ正規化され採掘経験値の対象になるため、設置→採掘による無限経験値を防ぐべく追跡する
         if (blockType == Material.STONE || blockType == Material.COBBLESTONE ||
             blockType == Material.DEEPSLATE || blockType == Material.COBBLED_DEEPSLATE ||
-            blockType == Material.TUFF) {
+            blockType == Material.TUFF ||
+            blockType == Material.ANDESITE || blockType == Material.DIORITE ||
+            blockType == Material.GRANITE) {
             return true;
         }
 

--- a/src/main/java/org/tofu/tofunomics/util/BlockNormalizer.java
+++ b/src/main/java/org/tofu/tofunomics/util/BlockNormalizer.java
@@ -121,6 +121,10 @@ public final class BlockNormalizer {
             case DEEPSLATE:
             case COBBLED_DEEPSLATE:
             case TUFF:                   return Material.STONE;
+            // 岩系（自然生成の石バリエーション → 石。採掘経験値の対象にする）
+            case ANDESITE:
+            case DIORITE:
+            case GRANITE:                return Material.STONE;
             default:                     return material;
         }
     }

--- a/src/test/java/org/tofu/tofunomics/events/UnifiedEventHandlerTrackingTest.java
+++ b/src/test/java/org/tofu/tofunomics/events/UnifiedEventHandlerTrackingTest.java
@@ -41,5 +41,8 @@ public class UnifiedEventHandlerTrackingTest {
         assertTrue("石は追跡対象", UnifiedEventHandler.shouldTrackPlacedBlock(Material.STONE));
         assertTrue("丸石は追跡対象", UnifiedEventHandler.shouldTrackPlacedBlock(Material.COBBLESTONE));
         assertTrue("原木は追跡対象", UnifiedEventHandler.shouldTrackPlacedBlock(Material.OAK_LOG));
+        assertTrue("安山岩は追跡対象", UnifiedEventHandler.shouldTrackPlacedBlock(Material.ANDESITE));
+        assertTrue("閃緑岩は追跡対象", UnifiedEventHandler.shouldTrackPlacedBlock(Material.DIORITE));
+        assertTrue("花崗岩は追跡対象", UnifiedEventHandler.shouldTrackPlacedBlock(Material.GRANITE));
     }
 }

--- a/src/test/java/org/tofu/tofunomics/util/BlockNormalizerTest.java
+++ b/src/test/java/org/tofu/tofunomics/util/BlockNormalizerTest.java
@@ -34,6 +34,13 @@ public class BlockNormalizerTest {
     }
 
     @Test
+    public void 岩系ブロックは石へ正規化される() {
+        assertEquals(Material.STONE, BlockNormalizer.normalizeForJob(Material.ANDESITE));
+        assertEquals(Material.STONE, BlockNormalizer.normalizeForJob(Material.DIORITE));
+        assertEquals(Material.STONE, BlockNormalizer.normalizeForJob(Material.GRANITE));
+    }
+
+    @Test
     public void 通常版ブロックはそのまま返る() {
         assertEquals(Material.IRON_ORE, BlockNormalizer.normalizeForJob(Material.IRON_ORE));
         assertEquals(Material.COPPER_ORE, BlockNormalizer.normalizeForJob(Material.COPPER_ORE));


### PR DESCRIPTION
## 概要

鉱夫が安山岩(ANDESITE)・閃緑岩(DIORITE)・花崗岩(GRANITE)を採掘しても職業経験値が入らない問題を修正します。「岩系も掘れば経験値が入る仕様のはず」という認識に対し、実装が食い違っていました。

## 根本原因

- 鉱夫の採掘経験値は `JobExperienceManager.miningExperience` にハードコードされており、岩系のうち経験値対象は実質 `STONE`(1.0) のみ。
- ANDESITE / DIORITE / GRANITE は経験値テーブルに未登録で、正規化 `BlockNormalizer.normalizeForJob()` でも深層岩石材(DEEPSLATE等)しかSTONEに寄せておらず、これら岩系は素通り → 経験値ゼロ。
- 採掘権限上は「基本ブロック（全職業採掘可）」に含まれるため、**「掘れるのに経験値だけ入らない」**症状になっていた。

## 修正内容

- `BlockNormalizer.normalizeForJob()`: ANDESITE/DIORITE/GRANITE を `STONE` に正規化（既存の深層岩石材→STONE と同じパターン）。これで既存の `STONE:1.0` を流用し経験値1.0を付与。
- `UnifiedEventHandler.shouldTrackPlacedBlock()`: 岩系を設置追跡対象に追加し、設置→採掘による無限経験値稼ぎを防止。

## テスト

- `BlockNormalizerTest`: 岩系→STONE 正規化ケースを追加。
- `UnifiedEventHandlerTrackingTest`: 岩系が追跡対象になるケースを追加。
- 全380テスト通過・ビルド成功を確認済み。

## 動作確認（要ゲーム内確認）

- 鉱夫で自然生成の安山岩/閃緑岩/花崗岩を採掘 → 経験値1.0（STONE同量）が入る。
- 設置した岩を掘っても経験値が入らない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)