### PR TITLE
fix: 無職プレイヤーが石ピッケルで鉱石を掘れてしまう問題を修正

### DIFF
--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -123,19 +123,22 @@ public class UnifiedEventHandler implements Listener {
     
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onBlockBreak(BlockBreakEvent event) {
-        // 基本的なイベント処理チェック
-        if (!shouldProcessEvent(event)) {
-            return;
-        }
-
         Player player = event.getPlayer();
         Material blockType = event.getBlock().getType();
 
-        // 職業ブロック制限チェック（優先度HIGHで早期チェック）
+        // 職業ブロック制限チェック（採掘禁止はハードルールのため、報酬システムの
+        // ワールド/ゲームモードフィルタ shouldProcessEvent より前に必ず実行する。
+        // canPlayerBreakBlock 内で「制限無効なら許可」「管理者権限バイパス」を自己ガード済み。
+        // onBlockPlace の植え付け制限と対称の順序）
         if (!blockPermissionManager.canPlayerBreakBlock(player, blockType)) {
             event.setCancelled(true);
             String message = blockPermissionManager.getDeniedMessage(player, blockType);
             player.sendMessage(message);
+            return;
+        }
+
+        // 以降の報酬/経験値/クエスト処理は従来どおりフィルタの対象
+        if (!shouldProcessEvent(event)) {
             return;
         }
 

--- a/src/test/java/org/tofu/tofunomics/jobs/JobBlockPermissionManagerTest.java
+++ b/src/test/java/org/tofu/tofunomics/jobs/JobBlockPermissionManagerTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 /**
- * JobBlockPermissionManager の植え付け制限機能テスト
+ * JobBlockPermissionManager の植え付け制限・採掘制限機能テスト
  */
 public class JobBlockPermissionManagerTest {
 
@@ -114,5 +114,82 @@ public class JobBlockPermissionManagerTest {
         assertTrue(message.contains("農家"));
         assertTrue(message.contains("WHEAT"));
         assertTrue(message.contains("植える"));
+    }
+
+    // ========== 採掘制限テスト（無職プレイヤーが鉱石を掘れる問題の回帰防止） ==========
+
+    @Test
+    public void testNonJobPlayerCannotBreakOre() {
+        // 無職（鉱夫でない）プレイヤーは鉱石を採掘不可
+        when(configManager.isJobBlockRestrictionEnabled()).thenReturn(true);
+        when(jobManager.hasJob(player, "miner")).thenReturn(false);
+
+        assertFalse("無職は石炭鉱石を掘れない", permissionManager.canPlayerBreakBlock(player, Material.COAL_ORE));
+        assertFalse("無職は鉄鉱石を掘れない", permissionManager.canPlayerBreakBlock(player, Material.IRON_ORE));
+        assertFalse("無職はダイヤ鉱石を掘れない", permissionManager.canPlayerBreakBlock(player, Material.DIAMOND_ORE));
+    }
+
+    @Test
+    public void testDeepslateOreNormalizedForNonJob() {
+        // 深層岩鉱石も通常鉱石へ正規化され、無職では採掘不可（抜け穴封じ）
+        when(configManager.isJobBlockRestrictionEnabled()).thenReturn(true);
+        when(jobManager.hasJob(player, "miner")).thenReturn(false);
+
+        assertFalse("無職は深層岩石炭鉱石を掘れない", permissionManager.canPlayerBreakBlock(player, Material.DEEPSLATE_COAL_ORE));
+        assertFalse("無職は深層岩鉄鉱石を掘れない", permissionManager.canPlayerBreakBlock(player, Material.DEEPSLATE_IRON_ORE));
+        assertFalse("無職は深層岩ダイヤ鉱石を掘れない", permissionManager.canPlayerBreakBlock(player, Material.DEEPSLATE_DIAMOND_ORE));
+    }
+
+    @Test
+    public void testMinerCanBreakOre() {
+        // 鉱夫は鉱石を採掘可能
+        when(configManager.isJobBlockRestrictionEnabled()).thenReturn(true);
+        when(jobManager.hasJob(player, "miner")).thenReturn(true);
+
+        assertTrue(permissionManager.canPlayerBreakBlock(player, Material.COAL_ORE));
+        assertTrue(permissionManager.canPlayerBreakBlock(player, Material.DIAMOND_ORE));
+        assertTrue(permissionManager.canPlayerBreakBlock(player, Material.DEEPSLATE_COAL_ORE));
+    }
+
+    @Test
+    public void testBasicBlocksBreakableByEveryone() {
+        // 基本ブロック（石・丸石・原木等）は無職でも採掘可能
+        when(configManager.isJobBlockRestrictionEnabled()).thenReturn(true);
+        when(jobManager.hasJob(player, "miner")).thenReturn(false);
+
+        assertTrue(permissionManager.canPlayerBreakBlock(player, Material.STONE));
+        assertTrue(permissionManager.canPlayerBreakBlock(player, Material.COBBLESTONE));
+        assertTrue(permissionManager.canPlayerBreakBlock(player, Material.OAK_LOG));
+    }
+
+    @Test
+    public void testBreakAllowedWhenRestrictionDisabled() {
+        // 採掘制限が無効なら無職でも鉱石を採掘可能
+        when(configManager.isJobBlockRestrictionEnabled()).thenReturn(false);
+        when(jobManager.hasJob(player, "miner")).thenReturn(false);
+
+        assertTrue(permissionManager.canPlayerBreakBlock(player, Material.COAL_ORE));
+    }
+
+    @Test
+    public void testAdminBypassesBreakRestriction() {
+        // 管理者権限があれば無職でも鉱石を採掘可能
+        when(configManager.isJobBlockRestrictionEnabled()).thenReturn(true);
+        when(player.hasPermission("tofunomics.admin.break")).thenReturn(true);
+        when(jobManager.hasJob(player, "miner")).thenReturn(false);
+
+        assertTrue(permissionManager.canPlayerBreakBlock(player, Material.COAL_ORE));
+    }
+
+    @Test
+    public void testMiningDeniedMessage() {
+        // 拒否メッセージに必要職業名とブロック名が含まれる
+        when(jobManager.getJobDisplayName("miner")).thenReturn("鉱夫");
+
+        String message = permissionManager.getDeniedMessage(player, Material.COAL_ORE);
+
+        assertTrue(message.contains("鉱夫"));
+        assertTrue(message.contains("COAL_ORE"));
+        assertTrue(message.contains("採掘"));
     }
 }


### PR DESCRIPTION
## 概要

無職（どの職業にも就いていない）プレイヤーが石ピッケルで石炭鉱石などを採掘できてしまう問題を修正します。本番で発生を確認済み。

## 根本原因

`UnifiedEventHandler.onBlockBreak` で、職業採掘制限チェック（`canPlayerBreakBlock`）が `shouldProcessEvent` の**後ろ**に置かれていました。

`shouldProcessEvent`（→ `EventProcessor.shouldProcessEvent`）は報酬/経験値システム用のフィルタで、経済有効ワールドのホワイトリスト・除外ワールド・ゲームモード・イベントシステム有効フラグのいずれかが不成立だと `false` を返します。その場合 `onBlockBreak` が早期returnし、**採掘制限チェックに到達せず、無職でも鉱石が掘れてしまう**状態でした。

同クラスの `onBlockPlace` では、植え付け制限が `shouldProcessEvent` の**前**で実行されており、採掘系だけ順序が逆になっていたのが原因です。

## 修正内容

- `onBlockBreak` の職業採掘制限チェックを `shouldProcessEvent` の**前**（メソッド冒頭）へ移動し、`onBlockPlace` と対称の順序に統一
- 制限判定は `canPlayerBreakBlock` 内で「制限無効なら許可」「管理者権限バイパス」を先頭で自己ガードしているため、前倒ししても制限無効サーバー・管理者には影響なし
- 報酬/経験値/クエスト処理は従来どおり `shouldProcessEvent` ゲートの後ろに維持

## テスト

- `JobBlockPermissionManagerTest` に採掘制限の回帰テスト7件を追加（無職は鉱石不可／深層岩鉱石も正規化して不可／鉱夫は可／基本ブロックは誰でも可／制限無効時は可／管理者バイパス／拒否メッセージ）
- 全387テスト緑・BUILD SUCCESS
- ゲーム内で動作確認済み（無職は鉱石不可＋メッセージ表示、鉱夫は採掘可＋経験値、石・原木は誰でも可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)