### PR TITLE
feat: 作業台を持って右クリックで作業台GUIを開く機能

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -215,6 +215,9 @@ public final class TofuNomics extends JavaPlugin {
         // 時計アイテムシステムの初期化
         initializeClockItemSystem();
 
+        // 作業台アイテム右クリックシステムの初期化
+        initializeWorkbenchItemSystem();
+
         // プレイヤー間マーケットシステムの初期化
         initializeMarketSystem();
 
@@ -1600,6 +1603,24 @@ public final class TofuNomics extends JavaPlugin {
      */
     public org.tofu.tofunomics.items.ClockItemManager getClockItemManager() {
         return clockItemManager;
+    }
+
+    /**
+     * 作業台アイテム右クリックシステムの初期化
+     * 保護区域内で作業台を持って右クリックするとGUIを開く
+     */
+    private void initializeWorkbenchItemSystem() {
+        try {
+            getLogger().info("作業台アイテム右クリックシステムを初期化しています...");
+
+            org.tofu.tofunomics.items.WorkbenchItemListener workbenchItemListener =
+                new org.tofu.tofunomics.items.WorkbenchItemListener(this, configManager, worldGuardIntegration);
+            getServer().getPluginManager().registerEvents(workbenchItemListener, this);
+
+            getLogger().info("作業台アイテム右クリックシステムが初期化されました");
+        } catch (Exception e) {
+            getLogger().severe("作業台アイテム右クリックシステムの初期化に失敗しました: " + e.getMessage());
+        }
     }
     
     /**

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -2039,6 +2039,14 @@ public class ConfigManager {
     public boolean isClockItemEnabled() {
         return (Boolean) getCachedValue("clock_item.enabled", true);
     }
+
+    /**
+     * 作業台アイテム右クリック機能が有効かどうか
+     * （保護区域内で作業台を持って右クリックするとGUIを開く）
+     */
+    public boolean isWorkbenchItemEnabled() {
+        return (Boolean) getCachedValue("workbench_item.enabled", true);
+    }
     
     /**
      * 時計の購入価格

--- a/src/main/java/org/tofu/tofunomics/items/WorkbenchItemListener.java
+++ b/src/main/java/org/tofu/tofunomics/items/WorkbenchItemListener.java
@@ -1,0 +1,77 @@
+package org.tofu.tofunomics.items;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.integration.WorldGuardIntegration;
+
+/**
+ * 作業台アイテムを持って右クリックすると、設置せずに作業台GUIを開くリスナー
+ *
+ * WorldGuard保護区域内（建築不可の街など）でのみ機能し、
+ * 区域外では従来通りブロックとして設置できる。
+ */
+public class WorkbenchItemListener implements Listener {
+
+    private final TofuNomics plugin;
+    private final ConfigManager configManager;
+    private final WorldGuardIntegration worldGuardIntegration;
+
+    public WorkbenchItemListener(TofuNomics plugin, ConfigManager configManager, WorldGuardIntegration worldGuardIntegration) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.worldGuardIntegration = worldGuardIntegration;
+    }
+
+    @EventHandler
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        // config で無効化されている場合は何もしない
+        if (!configManager.isWorkbenchItemEnabled()) {
+            return;
+        }
+
+        // メインハンドのみ処理（オフハンドとの二重発火を防止）
+        if (event.getHand() != EquipmentSlot.HAND) {
+            return;
+        }
+
+        // 手に持っているアイテムが作業台でなければ対象外
+        ItemStack item = event.getItem();
+        if (item == null || item.getType() != Material.CRAFTING_TABLE) {
+            return;
+        }
+
+        // 右クリック以外は対象外
+        Action action = event.getAction();
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+
+        // インタラクト可能ブロック（チェスト・かまど・既設の作業台・ドア等）を
+        // 右クリックした場合は、そのブロック本来の操作を優先する
+        if (action == Action.RIGHT_CLICK_BLOCK) {
+            Block clickedBlock = event.getClickedBlock();
+            if (clickedBlock != null && clickedBlock.getType().isInteractable()) {
+                return;
+            }
+        }
+
+        // WorldGuard保護区域内でのみ機能させる（区域外は従来通り設置）
+        Player player = event.getPlayer();
+        if (worldGuardIntegration == null || !worldGuardIntegration.isInProtectedRegion(player.getLocation())) {
+            return;
+        }
+
+        // 設置をキャンセルして作業台GUIを開く
+        event.setCancelled(true);
+        player.openWorkbench(null, true);
+    }
+}

--- a/src/main/resources/config/gameplay.yml
+++ b/src/main/resources/config/gameplay.yml
@@ -343,6 +343,12 @@ trade_system:
     chest_already_exists: "&cこの場所には既に取引チェストが設置されています。"
 
 # 時計アイテムシステム設定
+# 作業台アイテム右クリック機能
+# 保護区域（WorldGuardリージョン）内で作業台を手に持って右クリックすると、
+# 設置せずに作業台GUIを直接開く。区域外では従来通りブロックとして設置できる。
+workbench_item:
+  enabled: true
+
 clock_item:
   # 時計アイテムシステムの有効化
   enabled: true


### PR DESCRIPTION
## 概要

保護区域（WorldGuardリージョン）内で作業台アイテムを手に持って右クリックすると、設置せずに作業台GUIを直接開けるようにしました。街など建築不可の区域でもクラフトが利用できます。

## 背景

作業台を使うにはブロックを地面に設置する必要がありますが、街などの WorldGuard 保護区域内では建築（ブロック設置）が禁止されているため、そこでは作業台を使えませんでした。

## 仕様

- 対象範囲は **いずれかの WorldGuard リージョン内（保護区域内すべて）**
- 保護区域外では従来通り作業台を設置できる（機能しない）
- チェスト・かまど等インタラクト可能ブロックへの右クリックは本来の操作を優先（横取り回避）
- オフハンドとの二重発火を防止
- `config/gameplay.yml` の `workbench_item.enabled` で有効/無効を切替可能（既定 true）

## 変更ファイル

- 新規 `items/WorkbenchItemListener.java` — 右クリック検知リスナー
- `TofuNomics.java` — `initializeWorkbenchItemSystem()` を追加し onEnable で登録
- `config/ConfigManager.java` — `isWorkbenchItemEnabled()` ゲッター追加
- `config/gameplay.yml` — `workbench_item.enabled` 設定追加

## テスト

- `mvn clean package` ビルド成功
- 既存ユニットテスト 387件すべてパス

## 動作確認（ゲーム内）

- [ ] 保護区域内で作業台を持ち空中/地面を右クリック → 設置されずGUIが開く
- [ ] 保護区域内でチェスト等を右クリック → チェストが正常に開く
- [ ] 保護区域外で作業台を右クリック → 従来通り設置される
- [ ] `workbench_item.enabled: false` で機能無効化

🤖 Generated with [Claude Code](https://claude.com/claude-code)