### PR TITLE
feat: 無職プレイヤーのクラフト制限を拡張（パン・料理・木材加工品）

### DIFF
--- a/src/main/java/org/tofu/tofunomics/jobs/JobCraftPermissionManager.java
+++ b/src/main/java/org/tofu/tofunomics/jobs/JobCraftPermissionManager.java
@@ -91,17 +91,24 @@ public class JobCraftPermissionManager {
         ));
         jobCraftableItems.put("miner", minerItems);
 
-        // 木こり (woodcutter) - 斧
+        // 木こり (woodcutter) - 斧・木材加工品（板材・階段・ドア等）
         Set<Material> woodcutterItems = new HashSet<>(Arrays.asList(
             Material.WOODEN_AXE, Material.STONE_AXE, Material.IRON_AXE,
             Material.GOLDEN_AXE, Material.DIAMOND_AXE, Material.NETHERITE_AXE, Material.COPPER_AXE
         ));
+        // 木材加工品（板材含む・実用品含む）をループ生成で追加
+        woodcutterItems.addAll(collectWoodProcessedItems());
         jobCraftableItems.put("woodcutter", woodcutterItems);
 
-        // 農家 (farmer) - くわ・動物装備
+        // 農家 (farmer) - くわ・動物装備・料理・貴重食料
         Set<Material> farmerItems = new HashSet<>(Arrays.asList(
             Material.WOODEN_HOE, Material.STONE_HOE, Material.IRON_HOE,
-            Material.GOLDEN_HOE, Material.DIAMOND_HOE, Material.NETHERITE_HOE, Material.COPPER_HOE
+            Material.GOLDEN_HOE, Material.DIAMOND_HOE, Material.NETHERITE_HOE, Material.COPPER_HOE,
+            // 料理全般（クラフトレシピを持つもののみ。焼き料理は精錬のため対象外）
+            Material.BREAD, Material.COOKIE, Material.CAKE, Material.PUMPKIN_PIE,
+            Material.MUSHROOM_STEW, Material.BEETROOT_SOUP, Material.RABBIT_STEW, Material.SUSPICIOUS_STEW,
+            // 貴重食料
+            Material.GOLDEN_APPLE, Material.GOLDEN_CARROT
         ));
         // 動物装備 — 鍛冶屋と共有
         farmerItems.addAll(horseEquipment);
@@ -126,6 +133,53 @@ public class JobCraftPermissionManager {
         jobCraftableItems.put("enchanter", enchanterItems);
 
         // 建築家 (builder) - 専売なし（建材・装飾は誰でもクラフト可）
+    }
+
+    // 木材種プレフィックス（この接頭辞を持つMaterialのみ木材加工品として扱う）
+    private static final Set<String> WOOD_TYPE_PREFIXES = new HashSet<>(Arrays.asList(
+        "OAK", "SPRUCE", "BIRCH", "JUNGLE", "ACACIA", "DARK_OAK",
+        "MANGROVE", "CHERRY", "PALE_OAK", "BAMBOO", "CRIMSON", "WARPED"
+    ));
+
+    // 木材加工品のサフィックス（実用品も含む・広め）。板材専売のため _PLANKS を含める。
+    // ※板材を専売対象から外す場合はこのリストから "_PLANKS" を削るだけでよい。
+    private static final List<String> WOOD_PROCESSED_SUFFIXES = Arrays.asList(
+        "_PLANKS", "_STAIRS", "_SLAB", "_FENCE", "_FENCE_GATE", "_DOOR", "_TRAPDOOR",
+        "_PRESSURE_PLATE", "_BUTTON", "_SIGN", "_HANGING_SIGN", "_BOAT", "_CHEST_BOAT"
+    );
+
+    /**
+     * 木材加工品（板材・階段・フェンス・ドア等）を Material enum から動的収集する。
+     *
+     * 「木材種プレフィックス」と「加工品サフィックス」の AND 条件で判定するため、
+     * 石・鉄・ブラックストーン等の非木材（STONE_STAIRS, IRON_DOOR 等）は誤って含まれない。
+     * Material.values() 走査により、新バージョンで追加された木材種も自動追従する。
+     */
+    private Set<Material> collectWoodProcessedItems() {
+        Set<Material> result = EnumSet.noneOf(Material.class);
+        for (Material m : Material.values()) {
+            String n = m.name();
+            boolean prefixOk = WOOD_TYPE_PREFIXES.stream().anyMatch(p -> n.startsWith(p + "_"));
+            if (!prefixOk) {
+                continue;
+            }
+            for (String suf : WOOD_PROCESSED_SUFFIXES) {
+                if (n.endsWith(suf)) {
+                    result.add(m);
+                    break;
+                }
+            }
+        }
+        // 竹の特殊加工品（サフィックス規則から漏れるもの）
+        for (String extra : new String[]{
+                "BAMBOO_MOSAIC", "BAMBOO_MOSAIC_STAIRS", "BAMBOO_MOSAIC_SLAB",
+                "BAMBOO_RAFT", "BAMBOO_CHEST_RAFT"}) {
+            Material m = Material.getMaterial(extra); // 存在しなければ null
+            if (m != null) {
+                result.add(m);
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/resources/config/messages.yml
+++ b/src/main/resources/config/messages.yml
@@ -56,7 +56,13 @@ messages:
     no_job: "&c現在就職していません。"
     job_not_found: "&c指定された職業は存在しません。"
     already_have_job: "&c既に職業に就いています。"
-  
+
+  # クラフト制限メッセージ
+  craft:
+    no_job_required: "&c職業に就いていないため、このアイテムをクラフトできません。まず /job join で就職してください。"
+    wrong_job_required: "&c{item}をクラフトするには{required_job}である必要があります。（現在: {current_job}）"
+    item_not_craftable: "&cこのアイテムはクラフトできません。"
+
   # スコアボード関連メッセージ
   scoreboard:
     enabled: "&aスコアボードを有効にしました。"

--- a/src/test/java/org/tofu/tofunomics/jobs/JobCraftPermissionManagerTest.java
+++ b/src/test/java/org/tofu/tofunomics/jobs/JobCraftPermissionManagerTest.java
@@ -1,0 +1,139 @@
+package org.tofu.tofunomics.jobs;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.tofu.tofunomics.config.ConfigManager;
+
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * JobCraftPermissionManager の職業別クラフト制限機能テスト
+ *
+ * 検証観点:
+ * - 農家専売（パン・料理・貴重食料）: 農家は可、無職・他職業は不可
+ * - 木こり専売（板材・木材加工品）: 木こりは可、無職は不可
+ * - 誤爆防止: 石・鉄の階段/ドア/感圧板は非制限（全員可）
+ * - 非制限品: 作業台・棒・チェスト、精錬品（焼き肉）は全員可
+ */
+public class JobCraftPermissionManagerTest {
+
+    @Mock
+    private JavaPlugin plugin;
+
+    @Mock
+    private JobManager jobManager;
+
+    @Mock
+    private ConfigManager configManager;
+
+    @Mock
+    private Player player;
+
+    private JobCraftPermissionManager permissionManager;
+
+    private final UUID playerUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        // plugin.getLogger() は警告ログ用（正常系では呼ばれないが保険でstub）
+        lenient().when(plugin.getLogger()).thenReturn(Logger.getLogger("test"));
+        lenient().when(player.getUniqueId()).thenReturn(playerUuid);
+
+        permissionManager = new JobCraftPermissionManager(plugin, jobManager, configManager);
+    }
+
+    /** プレイヤーの職業を設定するヘルパー（null = 無職） */
+    private void setPlayerJob(String job) {
+        when(jobManager.getPlayerJob(playerUuid)).thenReturn(job);
+    }
+
+    // ===== farmer 専売（料理・貴重食料） =====
+
+    @Test
+    public void testFarmerCanCraftFood() {
+        setPlayerJob("farmer");
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.BREAD));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.COOKIE));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.CAKE));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.PUMPKIN_PIE));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.GOLDEN_APPLE));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.GOLDEN_CARROT));
+    }
+
+    @Test
+    public void testUnemployedCannotCraftBread() {
+        setPlayerJob(null); // 無職
+        assertFalse(permissionManager.canPlayerCraftItem(player, Material.BREAD));
+        assertFalse(permissionManager.canPlayerCraftItem(player, Material.GOLDEN_APPLE));
+        assertFalse(permissionManager.canPlayerCraftItem(player, Material.GOLDEN_CARROT));
+    }
+
+    @Test
+    public void testMinerCannotCraftBread() {
+        setPlayerJob("miner"); // 他職業
+        assertFalse(permissionManager.canPlayerCraftItem(player, Material.BREAD));
+        assertFalse(permissionManager.canPlayerCraftItem(player, Material.CAKE));
+    }
+
+    // ===== woodcutter 専売（板材・木材加工品） =====
+
+    @Test
+    public void testWoodcutterCanCraftWoodProducts() {
+        setPlayerJob("woodcutter");
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.OAK_PLANKS));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.OAK_STAIRS));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.OAK_DOOR));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.SPRUCE_FENCE));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.OAK_BOAT));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.BAMBOO_RAFT));
+    }
+
+    @Test
+    public void testUnemployedCannotCraftWoodProducts() {
+        setPlayerJob(null); // 無職
+        assertFalse(permissionManager.canPlayerCraftItem(player, Material.OAK_PLANKS));
+        assertFalse(permissionManager.canPlayerCraftItem(player, Material.OAK_STAIRS));
+        assertFalse(permissionManager.canPlayerCraftItem(player, Material.OAK_DOOR));
+    }
+
+    // ===== 誤爆防止（非木材の階段/ドア/感圧板は全員可） =====
+
+    @Test
+    public void testStoneAndIronProductsNotRestricted() {
+        setPlayerJob(null); // 無職でも作れることを確認
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.STONE_STAIRS));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.IRON_DOOR));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.IRON_TRAPDOOR));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.POLISHED_BLACKSTONE_PRESSURE_PLATE));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.STONE_BUTTON));
+    }
+
+    // ===== 基礎クラフト・精錬品は非制限 =====
+
+    @Test
+    public void testBasicCraftItemsNotRestricted() {
+        setPlayerJob(null); // 無職
+        // 作業台・棒・チェストは成果物としては専売にしていない（全員クラフト可）
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.CRAFTING_TABLE));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.STICK));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.CHEST));
+    }
+
+    @Test
+    public void testSmeltedFoodNotRestricted() {
+        setPlayerJob(null); // 無職
+        // 焼き料理は精錬でありCraftItemEventを通らない → 専売リストに含めていない
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.COOKED_BEEF));
+        assertTrue(permissionManager.canPlayerCraftItem(player, Material.BAKED_POTATO));
+    }
+}


### PR DESCRIPTION
## 概要

無職プレイヤーがパン(BREAD)等を自由にクラフトでき、職業経済の意義が薄れていた問題を修正します。各職業の成果物を職業専売にすることで「就職して専門アイテムを作り、他プレイヤーに売る」経済サイクルを機能させます。

## 変更内容

`JobCraftPermissionManager` の職業専売リスト（ブラックリスト型）に以下を追加:

### 農家(farmer)専売
- 料理: パン・クッキー・ケーキ・パンプキンパイ・キノコシチュー・ビートルートスープ・ウサギシチュー・怪しいシチュー
- 貴重食料: 金リンゴ・金にんじん
- ※焼き肉/焼き魚等は**かまど精錬(smelting)であり`CraftItemEvent`を通らないため制限不可**（仕様）

### 木こり(woodcutter)専売
- 板材・木材加工品（階段/ハーフ/フェンス/門/ドア/トラップドア/感圧板/ボタン/看板/吊り看板/ボート/竹イカダ等）
- `Material.values()`走査＋**木材種プレフィックスとのAND条件**で、石・鉄・ブラックストーン等の非木材（`STONE_STAIRS`, `IRON_DOOR`等）を誤って専売化しないよう防止

### メッセージ
- クラフト拒否メッセージ(`messages.craft.*`)を`messages.yml`に静的定義（従来は実行時注入のみ）

### テスト
- `JobCraftPermissionManagerTest` を新規追加（全8ケース）。誤爆防止・基礎クラフト非制限・精錬品非制限の回帰テストを含む

## 板材専売と新規プレイヤーの救済経路（確認済み）

板材(PLANKS)も木こり専売に含めていますが、無職プレイヤーには以下の救済経路があり、ゲーム開始不能にはなりません（コード確認済み）:

1. 無職でも `basic_blocks` のオーク等6種の原木を採掘可能
2. 木材加工NPC(`ProcessingNPCManager`)は職業制限なしで無職も利用可（木こり無料 / 無職・他職業は原木1個=1の有料。原木1個→板材4個）
3. 加工板材は`addItem`で直接付与され`CraftItemEvent`を通らないため、クラフト制限に引っかからない。PDCマーカーも付かず通常板材として利用可

→ 「原木採掘 → NPC売却で現金入手 → 加工NPCで板材化」で板材を入手できる。

軽微な留意点: mangrove/cherry/竹/ネザー系の原木は`basic_blocks`未登録で無職は掘れない可能性あり（オーク等6種で救済成立）。板材を専売から外したい場合は`WOOD_PROCESSED_SUFFIXES`から`_PLANKS`を削るだけで切り替え可能。

## テスト結果

全395テストパス（新規8テスト含む）。

## 動作確認（デプロイ後に実施予定）

- 無職: パン・金リンゴ・オーク階段・板材がクラフト不可＋拒否メッセージ / 作業台・棒・チェストは可 / 加工NPC経由で板材入手可
- 農家: パン・料理・金リンゴ・金にんじんが可
- 木こり: 板材・木材加工品が可
- 石の階段・鉄のドア等は全員可（誤爆なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)