### PR TITLE
fix: ルール未同意プレイヤーが設定OFFでも動けなくなる問題を修正

### DIFF
--- a/src/main/java/org/tofu/tofunomics/TofuNomics.java
+++ b/src/main/java/org/tofu/tofunomics/TofuNomics.java
@@ -1640,6 +1640,12 @@ public final class TofuNomics extends JavaPlugin {
             
             getLogger().info("ルール確認システムの初期化が完了しました");
             
+            // ルール同意の強制が無効な場合は既存プレイヤーへのチェックを行わない
+            if (!rulesManager.isAgreementEnforced()) {
+                getLogger().info("ルール同意の強制は無効です（rules.enabled / require_agreement）- 行動制限は行いません");
+                return;
+            }
+
             // 既存のオンラインプレイヤーに対してルール同意チェック
             getServer().getScheduler().runTaskLater(this, () -> {
                 for (org.bukkit.entity.Player player : getServer().getOnlinePlayers()) {

--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -4832,6 +4832,22 @@ public class ConfigManager {
     // ========================================
     
     /**
+     * ルール確認システムが有効かどうか
+     * @return 有効な場合 true（デフォルト: false）
+     */
+    public boolean isRulesEnabled() {
+        return config.getBoolean("rules.enabled", false);
+    }
+
+    /**
+     * ルール同意を必須にするか（未同意プレイヤーの行動制限を行うか）
+     * @return 必須の場合 true（デフォルト: false）
+     */
+    public boolean isRulesAgreementRequired() {
+        return config.getBoolean("rules.require_agreement", false);
+    }
+
+    /**
      * ルールサイトのURLを取得
      * @return ルールサイトURL（デフォルト: https://example.com/tofunomics-rules）
      */

--- a/src/main/java/org/tofu/tofunomics/players/PlayerJoinHandler.java
+++ b/src/main/java/org/tofu/tofunomics/players/PlayerJoinHandler.java
@@ -120,6 +120,11 @@ public class PlayerJoinHandler implements Listener {
             return;
         }
 
+        // ルール同意の強制が無効な場合は制限もGUI表示も行わない
+        if (!rulesManager.isAgreementEnforced()) {
+            return;
+        }
+
         // 対象ワールド外（tofunomics系以外）はルール同意システムの対象外
         if (!configManager.isEconomyEnabledInWorld(worldName)) {
             return;

--- a/src/main/java/org/tofu/tofunomics/rules/RulesManager.java
+++ b/src/main/java/org/tofu/tofunomics/rules/RulesManager.java
@@ -213,9 +213,22 @@ public class RulesManager implements Listener {
     }
     
     /**
+     * ルール同意の強制（未同意プレイヤーの行動制限）が有効かどうか
+     * rules.enabled と rules.require_agreement の両方が true の場合のみ制限を行う。
+     * 外部サイト確認方式（require_agreement: false）では制限を一切かけない。
+     */
+    public boolean isAgreementEnforced() {
+        return configManager.isRulesEnabled() && configManager.isRulesAgreementRequired();
+    }
+
+    /**
      * プレイヤーをルール未同意リストに追加（行動制限対象）
+     * 同意強制が無効な場合は登録しない
      */
     public void markAsUnagreed(UUID uuid) {
+        if (!isAgreementEnforced()) {
+            return;
+        }
         unagreedPlayers.add(uuid);
     }
     
@@ -274,11 +287,11 @@ public class RulesManager implements Listener {
 
     /**
      * 現在のワールドでルール制限を適用すべきか確認
-     * economy.enabled_worlds（ワールド制限ホワイトリスト）に従い、
+     * 同意強制が無効な場合、および economy.enabled_worlds（ワールド制限ホワイトリスト）の
      * 対象ワールド外（tofunomics系以外）ではルール同意システムを動作させない
      */
     private boolean isRulesEnabledInWorld(Player player) {
-        return configManager.isEconomyEnabledInWorld(player.getWorld().getName());
+        return isAgreementEnforced() && configManager.isEconomyEnabledInWorld(player.getWorld().getName());
     }
     
     // ========== イベントハンドラ：未同意プレイヤーの行動制限 ==========

--- a/src/test/java/org/tofu/tofunomics/rules/RulesAgreementEnforcementTest.java
+++ b/src/test/java/org/tofu/tofunomics/rules/RulesAgreementEnforcementTest.java
@@ -1,0 +1,69 @@
+package org.tofu.tofunomics.rules;
+
+import org.junit.Test;
+import org.tofu.tofunomics.TofuNomics;
+import org.tofu.tofunomics.config.ConfigManager;
+import org.tofu.tofunomics.dao.PlayerDAO;
+import org.tofu.tofunomics.jobs.JobManager;
+
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * ルール同意強制フラグの回帰テスト。
+ *
+ * 背景: rules.enabled / rules.require_agreement が false でもコード側がフラグを読んでおらず、
+ * ワールド参加した未同意プレイヤーが移動・コマンドを全てブロックされ、/rules で同意するまで
+ * 動けなくなる不具合があった。設定が無効なら未同意リストに登録されないことを保証する。
+ */
+public class RulesAgreementEnforcementTest {
+
+    private RulesManager createRulesManager(boolean enabled, boolean requireAgreement) {
+        ConfigManager configManager = mock(ConfigManager.class);
+        when(configManager.isRulesEnabled()).thenReturn(enabled);
+        when(configManager.isRulesAgreementRequired()).thenReturn(requireAgreement);
+
+        return new RulesManager(
+            mock(TofuNomics.class),
+            configManager,
+            mock(PlayerDAO.class),
+            mock(JobManager.class)
+        );
+    }
+
+    @Test
+    public void 設定が無効なら同意強制されず未同意登録もされない() {
+        RulesManager rulesManager = createRulesManager(false, false);
+        UUID uuid = UUID.randomUUID();
+
+        assertFalse("rules.enabled=false では同意強制しない", rulesManager.isAgreementEnforced());
+
+        rulesManager.markAsUnagreed(uuid);
+        assertFalse("同意強制が無効なら行動制限の対象にならない", rulesManager.isUnagreed(uuid));
+    }
+
+    @Test
+    public void 外部サイト確認方式では同意強制されない() {
+        // rules.enabled=true だが require_agreement=false（外部サイトでルール確認する運用）
+        RulesManager rulesManager = createRulesManager(true, false);
+        UUID uuid = UUID.randomUUID();
+
+        assertFalse("require_agreement=false では同意強制しない", rulesManager.isAgreementEnforced());
+
+        rulesManager.markAsUnagreed(uuid);
+        assertFalse("行動制限の対象にならない", rulesManager.isUnagreed(uuid));
+    }
+
+    @Test
+    public void 両フラグ有効なら未同意プレイヤーは制限対象になる() {
+        RulesManager rulesManager = createRulesManager(true, true);
+        UUID uuid = UUID.randomUUID();
+
+        assertTrue("両フラグ true では同意強制する", rulesManager.isAgreementEnforced());
+
+        rulesManager.markAsUnagreed(uuid);
+        assertTrue("未同意プレイヤーは行動制限の対象", rulesManager.isUnagreed(uuid));
+    }
+}


### PR DESCRIPTION
## 問題

テストユーザーがワールドに参加すると、`/rules` で同意するまで移動・ブロック破壊/設置・アイテム使用・コマンドが全てブロックされ、動けない状態になっていた。

## 原因

`rules.enabled: false` / `rules.require_agreement: false`（サーバー実機でも false）と設定されているにもかかわらず、**このフラグを読むコードが一切存在しなかった**。`ConfigManager` には `rules.url` の getter しかなく、設定値と無関係に以下が常に実行されていた。

- `PlayerJoinHandler.checkRulesAgreementOnEnter()` が未同意プレイヤーを `markAsUnagreed()` に登録
- `RulesManager` の各イベントハンドラ（Move / BlockBreak / BlockPlace / Interact / CommandPreprocess）が `/rules` 以外を全てキャンセル

外部サイト確認方式（require_agreement: false）に運用変更した際に、コード側の制限解除が漏れていた。

## 修正

- `ConfigManager` に `isRulesEnabled()` / `isRulesAgreementRequired()` を追加（デフォルトはいずれも false = 制限しない）
- `RulesManager.isAgreementEnforced()` を追加し、**両フラグが true の場合のみ**行動制限を適用
- `markAsUnagreed()` と行動制限判定 `isRulesEnabledInWorld()` の両方にガードを追加（設定リロード時の残留状態も無害化）
- 参加時チェック（`PlayerJoinHandler`）と起動時スキャン（`TofuNomics`）でもガード

## テスト

回帰テスト `RulesAgreementEnforcementTest` を追加（設定OFF / 外部サイト方式 / 強制ON の3ケース）。全398テストパス。

## 動作確認

デプロイ後、新規プレイヤーがワールド参加して `/rules` なしで自由に動けることを確認予定。config の変更は不要（サーバー側は既に false）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)