### PR TITLE
fix: 職業ブロック制限が tofuNomics 以外のワールドでも発動する問題を修正

### DIFF
--- a/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
+++ b/src/main/java/org/tofu/tofunomics/config/ConfigManager.java
@@ -724,7 +724,23 @@ public class ConfigManager {
         }
         return enabledWorlds.contains(worldName);
     }
-    
+
+    /**
+     * 職業制限（採掘・植え付け・クラフト）を適用すべきワールドかどうか
+     * events.excluded_worlds を除外し、economy.enabled_worlds のホワイトリストで判定する
+     * （ホワイトリストが空の場合は全ワールドで有効：後方互換）
+     */
+    public boolean isJobRestrictionEnabledInWorld(String worldName) {
+        if (worldName == null) {
+            return false;
+        }
+        java.util.List<String> excludedWorlds = getExcludedWorlds();
+        if (excludedWorlds != null && excludedWorlds.contains(worldName)) {
+            return false;
+        }
+        return isEconomyEnabledInWorld(worldName);
+    }
+
     public java.util.List<String> getExcludedGameModes() {
         return config.getStringList("events.excluded_game_modes");
     }

--- a/src/main/java/org/tofu/tofunomics/events/CraftRestrictionEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/CraftRestrictionEventHandler.java
@@ -64,7 +64,8 @@ public class CraftRestrictionEventHandler implements Listener {
 
     /**
      * クラフト制限を適用すべきワールドかどうかを判定する。
-     * EventProcessor.isValidWorld() と同じ判定基準（除外ワールド + economy.enabled_worlds ホワイトリスト）。
+     * 判定は ConfigManager.isJobRestrictionEnabledInWorld() に集約されており、
+     * 採掘・植え付け制限（UnifiedEventHandler）と同じ基準になる。
      * 対象外ワールドでは制限を適用しない。
      */
     private boolean isCraftRestrictionEnabledWorld(Player player) {
@@ -73,15 +74,6 @@ public class CraftRestrictionEventHandler implements Listener {
             return true;
         }
 
-        String worldName = player.getWorld().getName();
-
-        // 除外ワールドはスキップ
-        java.util.List<String> excludedWorlds = plugin.getConfigManager().getExcludedWorlds();
-        if (excludedWorlds != null && excludedWorlds.contains(worldName)) {
-            return false;
-        }
-
-        // 経済機能を有効にするワールドのホワイトリスト（空の場合は全ワールドで有効：後方互換）
-        return plugin.getConfigManager().isEconomyEnabledInWorld(worldName);
+        return plugin.getConfigManager().isJobRestrictionEnabledInWorld(player.getWorld().getName());
     }
 }

--- a/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
+++ b/src/main/java/org/tofu/tofunomics/events/UnifiedEventHandler.java
@@ -127,10 +127,12 @@ public class UnifiedEventHandler implements Listener {
         Material blockType = event.getBlock().getType();
 
         // 職業ブロック制限チェック（採掘禁止はハードルールのため、報酬システムの
-        // ワールド/ゲームモードフィルタ shouldProcessEvent より前に必ず実行する。
+        // ゲームモードフィルタ shouldProcessEvent より前に必ず実行する。
+        // ただしワールド判定だけは先に行い、TofuNomics 対象外ワールド
+        // （ロビー・ミニゲーム等）には干渉しない。
         // canPlayerBreakBlock 内で「制限無効なら許可」「管理者権限バイパス」を自己ガード済み。
         // onBlockPlace の植え付け制限と対称の順序）
-        if (!blockPermissionManager.canPlayerBreakBlock(player, blockType)) {
+        if (isJobRestrictionWorld(player) && !blockPermissionManager.canPlayerBreakBlock(player, blockType)) {
             event.setCancelled(true);
             String message = blockPermissionManager.getDeniedMessage(player, blockType);
             player.sendMessage(message);
@@ -172,18 +174,22 @@ public class UnifiedEventHandler implements Listener {
         Player player = event.getPlayer();
         Material blockType = event.getBlock().getType();
         
-        // 鉱石ブロックの設置を禁止（管理者権限がない場合）
-        if (isOreBlock(blockType) && !player.hasPermission("tofunomics.place.ore")) {
-            event.setCancelled(true);
-            player.sendMessage(ChatColor.RED + "鉱石ブロックは設置できません。");
-            return;
-        }
+        // TofuNomics 対象ワールドでのみ設置系の制限を適用する
+        // （ロビー・ミニゲーム等の他ワールドには干渉しない）
+        if (isJobRestrictionWorld(player)) {
+            // 鉱石ブロックの設置を禁止（管理者権限がない場合）
+            if (isOreBlock(blockType) && !player.hasPermission("tofunomics.place.ore")) {
+                event.setCancelled(true);
+                player.sendMessage(ChatColor.RED + "鉱石ブロックは設置できません。");
+                return;
+            }
 
-        // 職業別 植え付け制限チェック（農家以外の作物植え付けを拒否）
-        if (!blockPermissionManager.canPlayerPlantBlock(player, blockType)) {
-            event.setCancelled(true);
-            player.sendMessage(blockPermissionManager.getPlantingDeniedMessage(player, blockType));
-            return;
+            // 職業別 植え付け制限チェック（農家以外の作物植え付けを拒否）
+            if (!blockPermissionManager.canPlayerPlantBlock(player, blockType)) {
+                event.setCancelled(true);
+                player.sendMessage(blockPermissionManager.getPlantingDeniedMessage(player, blockType));
+                return;
+            }
         }
 
         if (!shouldProcessEvent(event)) return;
@@ -236,10 +242,26 @@ public class UnifiedEventHandler implements Listener {
         if (!validSurface) return;
 
         Player player = event.getPlayer();
+        // TofuNomics 対象ワールド以外では制限しない
+        if (!isJobRestrictionWorld(player)) return;
+
         if (!blockPermissionManager.canPlayerPlantBlock(player, cropBlock)) {
             event.setCancelled(true);
             player.sendMessage(blockPermissionManager.getPlantingDeniedMessage(player, cropBlock));
         }
+    }
+
+    /**
+     * 職業制限（採掘・植え付け・鉱石設置）を適用すべきワールドかどうかを判定する。
+     * CraftRestrictionEventHandler と同じ基準（events.excluded_worlds 除外 +
+     * economy.enabled_worlds ホワイトリスト）。
+     */
+    private boolean isJobRestrictionWorld(Player player) {
+        if (configManager == null) {
+            // 設定が取得できない場合は安全側（制限なし）に倒す
+            return false;
+        }
+        return configManager.isJobRestrictionEnabledInWorld(player.getWorld().getName());
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/src/test/java/org/tofu/tofunomics/config/JobRestrictionWorldScopeTest.java
+++ b/src/test/java/org/tofu/tofunomics/config/JobRestrictionWorldScopeTest.java
@@ -1,0 +1,73 @@
+package org.tofu.tofunomics.config;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 職業制限（採掘・植え付け・クラフト）のワールド適用範囲テスト。
+ *
+ * 背景: 無職プレイヤーのブロック破壊制限が tofuNomics 以外のワールド
+ * （ロビー・ミニゲーム等）でも発動していたため、ConfigManager に判定を集約した。
+ *
+ * ConfigManager のコンストラクタは Bukkit のファイルIOに依存するため、
+ * ここではワールド判定に必要なアクセサのみを差し替えて実ロジックを検証する。
+ */
+public class JobRestrictionWorldScopeTest {
+
+    private ConfigManager configManager;
+
+    @Before
+    public void setUp() {
+        configManager = mock(ConfigManager.class);
+        when(configManager.isJobRestrictionEnabledInWorld(anyString())).thenCallRealMethod();
+        when(configManager.isJobRestrictionEnabledInWorld(isNull(String.class))).thenCallRealMethod();
+        when(configManager.isEconomyEnabledInWorld(anyString())).thenCallRealMethod();
+    }
+
+    private void setWorlds(List<String> excluded, List<String> enabled) {
+        when(configManager.getExcludedWorlds()).thenReturn(excluded);
+        when(configManager.getEconomyEnabledWorlds()).thenReturn(enabled);
+    }
+
+    @Test
+    public void ホワイトリストが空なら全ワールドで有効() {
+        setWorlds(Collections.<String>emptyList(), Collections.<String>emptyList());
+
+        assertTrue(configManager.isJobRestrictionEnabledInWorld("tofuNomics"));
+        assertTrue(configManager.isJobRestrictionEnabledInWorld("world"));
+    }
+
+    @Test
+    public void ホワイトリスト内のワールドのみ制限が有効() {
+        setWorlds(Collections.<String>emptyList(), Collections.singletonList("tofuNomics"));
+
+        assertTrue("対象ワールドでは制限を適用",
+            configManager.isJobRestrictionEnabledInWorld("tofuNomics"));
+        assertFalse("他ワールドには干渉しない",
+            configManager.isJobRestrictionEnabledInWorld("world"));
+        assertFalse("ロビーには干渉しない",
+            configManager.isJobRestrictionEnabledInWorld("lobby"));
+    }
+
+    @Test
+    public void 除外ワールドはホワイトリストに含まれていても無効() {
+        setWorlds(Collections.singletonList("tofuNomics"),
+                  Arrays.asList("tofuNomics", "world"));
+
+        assertFalse(configManager.isJobRestrictionEnabledInWorld("tofuNomics"));
+    }
+
+    @Test
+    public void ワールド名がnullなら無効() {
+        setWorlds(Collections.<String>emptyList(), Collections.singletonList("tofuNomics"));
+
+        assertFalse(configManager.isJobRestrictionEnabledInWorld(null));
+    }
+}


### PR DESCRIPTION
## 背景

無職プレイヤーのブロック破壊制限が、tofuNomics ワールド以外（ロビー・ミニゲーム系ワールド等）でも発動していた。

`UnifiedEventHandler` の採掘制限・植え付け制限・鉱石設置禁止は、報酬系フィルタ `shouldProcessEvent()`（内部で `EventProcessor.isValidWorld()` によるワールド判定を行う）**より前**に実行されており、独自のワールド判定を持っていなかったのが原因。

## 変更内容

- `ConfigManager.isJobRestrictionEnabledInWorld(worldName)` を追加し、職業制限のワールド判定を一本化
  - 判定基準は既存のクラフト制限と同じ（`events.excluded_worlds` 除外 + `economy.enabled_worlds` ホワイトリスト、空なら全ワールド有効）
- `UnifiedEventHandler` の以下3ハンドラーを同ヘルパーでガード
  - `onBlockBreak`（採掘制限）
  - `onBlockPlace`（鉱石設置禁止 + 植え付け制限）
  - `onPlayerInteractPlanting`（種の右クリック植え付け制限）
- `CraftRestrictionEventHandler` の重複したワールド判定ロジックを同ヘルパー呼び出しに置き換え

サーバー設定の変更は不要（`economy.enabled_worlds` は既に `[tofuNomics]`）。

## テスト

- `JobRestrictionWorldScopeTest` を新規追加（ホワイトリスト空 / 対象内外 / 除外ワールド / null）
- `mvn clean test` → 402件すべて通過（`JobBlockPermissionManagerTest`, `ConfigSplitMergeTest` に回帰なし）

## ゲーム内での確認事項（デプロイ後）

非OP・無職のアカウントで確認（OPは `tofunomics.admin.*` でバイパスされる）:

- [ ] tofuNomics: 鉱石採掘・種まきがこれまで通り制限される
- [ ] world / lobby 等: 採掘・種まき・鉱石設置が制限なしで行える

🤖 Generated with [Claude Code](https://claude.com/claude-code)